### PR TITLE
Produce java source jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,24 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Produce source jar files so that users loading the library in IDEs can easily access source corresponding to the library.

This is also one of the mandatory requirements when releasing jars into Maven Central.