### PR TITLE
Convert primitives before passing to host language

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,14 +331,14 @@ jobs:
         run: rustup target install aarch64-apple-darwin
       - name: Fetch upstream LLVM/clang snapshot
         run: |
-          wget -O clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz
-          if [ "$(shasum -a 256 clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz | awk '{ print $1 }')" != "cf5af0f32d78dcf4413ef6966abbfd5b1445fe80bba57f2ff8a08f77e672b9b3" ]; then
+          wget -O clang+llvm-14.0.1-x86_64-apple-darwin.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.1/clang+llvm-14.0.1-x86_64-apple-darwin.tar.xz
+          if [ "$(shasum -a 256 clang+llvm-14.0.1-x86_64-apple-darwin.tar.xz | awk '{ print $1 }')" != "43149390e95b1cdbf1d4ef2e9d214bbb6d35858ceb2df27245868e06bc4fc44c" ]; then
             echo "Bad hash"
             exit 1
           fi
       - name: Unpack upstream LLVM+clang and use it by default
         run: |
-          tar xvvf clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz
+          tar xvvf clang+llvm-14.0.1-x86_64-apple-darwin.tar.xz
       - name: Checkout source code
         uses: actions/checkout@v2
         with:
@@ -360,7 +360,7 @@ jobs:
       - name: Rebuild C bindings with upstream clang, and check the sample app builds + links
         run: |
           cd ldk-c-bindings
-          export PATH=`pwd`/clang+llvm-14.0.0-x86_64-apple-darwin/bin:$PATH
+          export PATH=`pwd`/clang+llvm-14.0.1-x86_64-apple-darwin/bin:$PATH
           CC=clang ./genbindings.sh ../rust-lightning true
           cd ..
       - name: Fetch OpenJDK 16
@@ -390,7 +390,7 @@ jobs:
           export LDK_GARBAGECOLLECTED_GIT_OVERRIDE="$(git describe --tag HEAD)"
           export JAVA_HOME=`pwd`/jdk-16.0.1.jdk/Contents/Home
           export PATH=$JAVA_HOME/bin:$PATH
-          export PATH=`pwd`/clang+llvm-14.0.0-x86_64-apple-darwin/bin:$PATH
+          export PATH=`pwd`/clang+llvm-14.0.1-x86_64-apple-darwin/bin:$PATH
           ./genbindings.sh ./ldk-c-bindings/ "-I$JAVA_HOME/include/ -I$JAVA_HOME/include/darwin -isysroot$(xcrun --show-sdk-path)" false false
           if [ "${{ matrix.platform }}" = "macos-11" ]; then
             export CC="clang --target=aarch64-apple-darwin"

--- a/gen_type_mapping.py
+++ b/gen_type_mapping.py
@@ -260,11 +260,19 @@ class TypeMappingGenerator:
                 return ConvInfo(ty_info = ty_info, arg_name = ty_info.var_name,
                     arg_conv = None, arg_conv_name = "arg", arg_conv_cleanup = None,
                     ret_conv = None, ret_conv_name = None, to_hu_conv = "TODO 8", to_hu_conv_name = None, from_hu_conv = None)
-        elif ty_info.is_native_primitive:
+        elif ty_info.is_native_primitive and ty_info.c_ty != "void":
             assert not is_nullable
             return ConvInfo(ty_info = ty_info, arg_name = ty_info.var_name,
-                arg_conv = None, arg_conv_name = ty_info.var_name, arg_conv_cleanup = None,
-                ret_conv = None, ret_conv_name = None, to_hu_conv = None, to_hu_conv_name = None, from_hu_conv = None)
+                arg_conv = None, arg_conv_name =  ty_info.var_name, arg_conv_cleanup = None,
+                ret_conv = (ty_info.c_ty + " " + ty_info.var_name + "_conv = ", ";"), ret_conv_name = ty_info.var_name + "_conv",
+                to_hu_conv = None, to_hu_conv_name = None, from_hu_conv = None)
+        elif ty_info.c_ty == "void":
+            assert ty_info.is_native_primitive
+            assert not is_nullable
+            return ConvInfo(ty_info = ty_info, arg_name = ty_info.var_name,
+                arg_conv = None, arg_conv_name =  ty_info.var_name, arg_conv_cleanup = None,
+                ret_conv = None, ret_conv_name = ty_info.var_name,
+                to_hu_conv = None, to_hu_conv_name = None, from_hu_conv = None)
         else:
             if ty_info.var_name == "":
                 ty_info.var_name = "ret"

--- a/src/main/jni/bindings.c
+++ b/src/main/jni/bindings.c
@@ -937,10 +937,12 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKBech32Error_1ref_1from_1
 			return (*env)->NewObject(env, LDKBech32Error_InvalidLength_class, LDKBech32Error_InvalidLength_meth);
 		}
 		case LDKBech32Error_InvalidChar: {
-			return (*env)->NewObject(env, LDKBech32Error_InvalidChar_class, LDKBech32Error_InvalidChar_meth, obj->invalid_char);
+			int32_t invalid_char_conv = obj->invalid_char;
+			return (*env)->NewObject(env, LDKBech32Error_InvalidChar_class, LDKBech32Error_InvalidChar_meth, invalid_char_conv);
 		}
 		case LDKBech32Error_InvalidData: {
-			return (*env)->NewObject(env, LDKBech32Error_InvalidData_class, LDKBech32Error_InvalidData_meth, obj->invalid_data);
+			int8_t invalid_data_conv = obj->invalid_data;
+			return (*env)->NewObject(env, LDKBech32Error_InvalidData_class, LDKBech32Error_InvalidData_meth, invalid_data_conv);
 		}
 		case LDKBech32Error_InvalidPadding: {
 			return (*env)->NewObject(env, LDKBech32Error_InvalidPadding_class, LDKBech32Error_InvalidPadding_meth);
@@ -967,8 +969,8 @@ struct LDKCVec_u8Z TxOut_get_script_pubkey (struct LDKTxOut* thing) {	return CVe
 
 uint64_t TxOut_get_value (struct LDKTxOut* thing) {	return thing->value;}JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxOut_1get_1value(JNIEnv *env, jclass clz, int64_t thing) {
 	LDKTxOut* thing_conv = (LDKTxOut*)(thing & ~1);
-	int64_t ret_val = TxOut_get_value(thing_conv);
-	return ret_val;
+	int64_t ret_conv = TxOut_get_value(thing_conv);
+	return ret_conv;
 }
 
 static inline void CResult_NoneNoneZ_get_ok(LDKCResult_NoneNoneZ *NONNULL_PTR owner){
@@ -1187,7 +1189,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKCOption_1u32Z_1ref_1from
 	LDKCOption_u32Z *obj = (LDKCOption_u32Z*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKCOption_u32Z_Some: {
-			return (*env)->NewObject(env, LDKCOption_u32Z_Some_class, LDKCOption_u32Z_Some_meth, obj->some);
+			int32_t some_conv = obj->some;
+			return (*env)->NewObject(env, LDKCOption_u32Z_Some_class, LDKCOption_u32Z_Some_meth, some_conv);
 		}
 		case LDKCOption_u32Z_None: {
 			return (*env)->NewObject(env, LDKCOption_u32Z_None_class, LDKCOption_u32Z_None_meth);
@@ -1727,7 +1730,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKCOption_1u64Z_1ref_1from
 	LDKCOption_u64Z *obj = (LDKCOption_u64Z*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKCOption_u64Z_Some: {
-			return (*env)->NewObject(env, LDKCOption_u64Z_Some_class, LDKCOption_u64Z_Some_meth, obj->some);
+			int64_t some_conv = obj->some;
+			return (*env)->NewObject(env, LDKCOption_u64Z_Some_class, LDKCOption_u64Z_Some_meth, some_conv);
 		}
 		case LDKCOption_u64Z_None: {
 			return (*env)->NewObject(env, LDKCOption_u64Z_None_class, LDKCOption_u64Z_None_meth);
@@ -1919,8 +1923,8 @@ static inline uintptr_t C2Tuple_usizeTransactionZ_get_a(LDKC2Tuple_usizeTransact
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1usizeTransactionZ_1get_1a(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKC2Tuple_usizeTransactionZ* owner_conv = (LDKC2Tuple_usizeTransactionZ*)(owner & ~1);
-	int64_t ret_val = C2Tuple_usizeTransactionZ_get_a(owner_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_usizeTransactionZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKTransaction C2Tuple_usizeTransactionZ_get_b(LDKC2Tuple_usizeTransactionZ *NONNULL_PTR owner){
@@ -2025,7 +2029,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKMonitorEvent_1ref_1from_
 			CHECK((((uintptr_t)&funding_txo_var) & 1) == 0); // We rely on a free low bit, pointer alignment guarantees this.
 			CHECK_INNER_FIELD_ACCESS_OR_NULL(funding_txo_var);
 			funding_txo_ref = (uintptr_t)funding_txo_var.inner & ~1;
-			return (*env)->NewObject(env, LDKMonitorEvent_UpdateCompleted_class, LDKMonitorEvent_UpdateCompleted_meth, funding_txo_ref, obj->update_completed.monitor_update_id);
+			int64_t monitor_update_id_conv = obj->update_completed.monitor_update_id;
+			return (*env)->NewObject(env, LDKMonitorEvent_UpdateCompleted_class, LDKMonitorEvent_UpdateCompleted_meth, funding_txo_ref, monitor_update_id_conv);
 		}
 		case LDKMonitorEvent_UpdateFailed: {
 			LDKOutPoint update_failed_var = obj->update_failed;
@@ -2264,12 +2269,15 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKNetworkUpdate_1ref_1from
 			return (*env)->NewObject(env, LDKNetworkUpdate_ChannelUpdateMessage_class, LDKNetworkUpdate_ChannelUpdateMessage_meth, msg_ref);
 		}
 		case LDKNetworkUpdate_ChannelClosed: {
-			return (*env)->NewObject(env, LDKNetworkUpdate_ChannelClosed_class, LDKNetworkUpdate_ChannelClosed_meth, obj->channel_closed.short_channel_id, obj->channel_closed.is_permanent);
+			int64_t short_channel_id_conv = obj->channel_closed.short_channel_id;
+			jboolean is_permanent_conv = obj->channel_closed.is_permanent;
+			return (*env)->NewObject(env, LDKNetworkUpdate_ChannelClosed_class, LDKNetworkUpdate_ChannelClosed_meth, short_channel_id_conv, is_permanent_conv);
 		}
 		case LDKNetworkUpdate_NodeFailure: {
 			int8_tArray node_id_arr = (*env)->NewByteArray(env, 33);
 			(*env)->SetByteArrayRegion(env, node_id_arr, 0, 33, obj->node_failure.node_id.compressed_form);
-			return (*env)->NewObject(env, LDKNetworkUpdate_NodeFailure_class, LDKNetworkUpdate_NodeFailure_meth, node_id_arr, obj->node_failure.is_permanent);
+			jboolean is_permanent_conv = obj->node_failure.is_permanent;
+			return (*env)->NewObject(env, LDKNetworkUpdate_NodeFailure_class, LDKNetworkUpdate_NodeFailure_meth, node_id_arr, is_permanent_conv);
 		}
 		default: abort();
 	}
@@ -2493,16 +2501,19 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 		case LDKEvent_FundingGenerationReady: {
 			int8_tArray temporary_channel_id_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, temporary_channel_id_arr, 0, 32, obj->funding_generation_ready.temporary_channel_id.data);
+			int64_t channel_value_satoshis_conv = obj->funding_generation_ready.channel_value_satoshis;
 			LDKCVec_u8Z output_script_var = obj->funding_generation_ready.output_script;
 			int8_tArray output_script_arr = (*env)->NewByteArray(env, output_script_var.datalen);
 			(*env)->SetByteArrayRegion(env, output_script_arr, 0, output_script_var.datalen, output_script_var.data);
-			return (*env)->NewObject(env, LDKEvent_FundingGenerationReady_class, LDKEvent_FundingGenerationReady_meth, temporary_channel_id_arr, obj->funding_generation_ready.channel_value_satoshis, output_script_arr, obj->funding_generation_ready.user_channel_id);
+			int64_t user_channel_id_conv = obj->funding_generation_ready.user_channel_id;
+			return (*env)->NewObject(env, LDKEvent_FundingGenerationReady_class, LDKEvent_FundingGenerationReady_meth, temporary_channel_id_arr, channel_value_satoshis_conv, output_script_arr, user_channel_id_conv);
 		}
 		case LDKEvent_PaymentReceived: {
 			int8_tArray payment_hash_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, payment_hash_arr, 0, 32, obj->payment_received.payment_hash.data);
+			int64_t amt_conv = obj->payment_received.amt;
 			int64_t purpose_ref = ((uintptr_t)&obj->payment_received.purpose) | 1;
-			return (*env)->NewObject(env, LDKEvent_PaymentReceived_class, LDKEvent_PaymentReceived_meth, payment_hash_arr, obj->payment_received.amt, purpose_ref);
+			return (*env)->NewObject(env, LDKEvent_PaymentReceived_class, LDKEvent_PaymentReceived_meth, payment_hash_arr, amt_conv, purpose_ref);
 		}
 		case LDKEvent_PaymentSent: {
 			int8_tArray payment_id_arr = (*env)->NewByteArray(env, 32);
@@ -2519,7 +2530,9 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 			(*env)->SetByteArrayRegion(env, payment_id_arr, 0, 32, obj->payment_path_failed.payment_id.data);
 			int8_tArray payment_hash_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, payment_hash_arr, 0, 32, obj->payment_path_failed.payment_hash.data);
+			jboolean rejected_by_dest_conv = obj->payment_path_failed.rejected_by_dest;
 			int64_t network_update_ref = ((uintptr_t)&obj->payment_path_failed.network_update) | 1;
+			jboolean all_paths_failed_conv = obj->payment_path_failed.all_paths_failed;
 			LDKCVec_RouteHopZ path_var = obj->payment_path_failed.path;
 			int64_tArray path_arr = NULL;
 			path_arr = (*env)->NewLongArray(env, path_var.datalen);
@@ -2543,7 +2556,7 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 			CHECK_INNER_FIELD_ACCESS_OR_NULL(retry_var);
 				retry_ref = (uintptr_t)retry_var.inner & ~1;
 			}
-			return (*env)->NewObject(env, LDKEvent_PaymentPathFailed_class, LDKEvent_PaymentPathFailed_meth, payment_id_arr, payment_hash_arr, obj->payment_path_failed.rejected_by_dest, network_update_ref, obj->payment_path_failed.all_paths_failed, path_arr, short_channel_id_ref, retry_ref);
+			return (*env)->NewObject(env, LDKEvent_PaymentPathFailed_class, LDKEvent_PaymentPathFailed_meth, payment_id_arr, payment_hash_arr, rejected_by_dest_conv, network_update_ref, all_paths_failed_conv, path_arr, short_channel_id_ref, retry_ref);
 		}
 		case LDKEvent_PaymentFailed: {
 			int8_tArray payment_id_arr = (*env)->NewByteArray(env, 32);
@@ -2553,7 +2566,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 			return (*env)->NewObject(env, LDKEvent_PaymentFailed_class, LDKEvent_PaymentFailed_meth, payment_id_arr, payment_hash_arr);
 		}
 		case LDKEvent_PendingHTLCsForwardable: {
-			return (*env)->NewObject(env, LDKEvent_PendingHTLCsForwardable_class, LDKEvent_PendingHTLCsForwardable_meth, obj->pending_htl_cs_forwardable.time_forwardable);
+			int64_t time_forwardable_conv = obj->pending_htl_cs_forwardable.time_forwardable;
+			return (*env)->NewObject(env, LDKEvent_PendingHTLCsForwardable_class, LDKEvent_PendingHTLCsForwardable_meth, time_forwardable_conv);
 		}
 		case LDKEvent_SpendableOutputs: {
 			LDKCVec_SpendableOutputDescriptorZ outputs_var = obj->spendable_outputs.outputs;
@@ -2569,13 +2583,15 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 		}
 		case LDKEvent_PaymentForwarded: {
 			int64_t fee_earned_msat_ref = ((uintptr_t)&obj->payment_forwarded.fee_earned_msat) | 1;
-			return (*env)->NewObject(env, LDKEvent_PaymentForwarded_class, LDKEvent_PaymentForwarded_meth, fee_earned_msat_ref, obj->payment_forwarded.claim_from_onchain_tx);
+			jboolean claim_from_onchain_tx_conv = obj->payment_forwarded.claim_from_onchain_tx;
+			return (*env)->NewObject(env, LDKEvent_PaymentForwarded_class, LDKEvent_PaymentForwarded_meth, fee_earned_msat_ref, claim_from_onchain_tx_conv);
 		}
 		case LDKEvent_ChannelClosed: {
 			int8_tArray channel_id_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, channel_id_arr, 0, 32, obj->channel_closed.channel_id.data);
+			int64_t user_channel_id_conv = obj->channel_closed.user_channel_id;
 			int64_t reason_ref = ((uintptr_t)&obj->channel_closed.reason) | 1;
-			return (*env)->NewObject(env, LDKEvent_ChannelClosed_class, LDKEvent_ChannelClosed_meth, channel_id_arr, obj->channel_closed.user_channel_id, reason_ref);
+			return (*env)->NewObject(env, LDKEvent_ChannelClosed_class, LDKEvent_ChannelClosed_meth, channel_id_arr, user_channel_id_conv, reason_ref);
 		}
 		case LDKEvent_DiscardFunding: {
 			int8_tArray channel_id_arr = (*env)->NewByteArray(env, 32);
@@ -2611,13 +2627,15 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 			(*env)->SetByteArrayRegion(env, temporary_channel_id_arr, 0, 32, obj->open_channel_request.temporary_channel_id.data);
 			int8_tArray counterparty_node_id_arr = (*env)->NewByteArray(env, 33);
 			(*env)->SetByteArrayRegion(env, counterparty_node_id_arr, 0, 33, obj->open_channel_request.counterparty_node_id.compressed_form);
+			int64_t funding_satoshis_conv = obj->open_channel_request.funding_satoshis;
+			int64_t push_msat_conv = obj->open_channel_request.push_msat;
 			LDKChannelTypeFeatures channel_type_var = obj->open_channel_request.channel_type;
 			int64_t channel_type_ref = 0;
 			CHECK((((uintptr_t)channel_type_var.inner) & 1) == 0); // We rely on a free low bit, malloc guarantees this.
 			CHECK((((uintptr_t)&channel_type_var) & 1) == 0); // We rely on a free low bit, pointer alignment guarantees this.
 			CHECK_INNER_FIELD_ACCESS_OR_NULL(channel_type_var);
 			channel_type_ref = (uintptr_t)channel_type_var.inner & ~1;
-			return (*env)->NewObject(env, LDKEvent_OpenChannelRequest_class, LDKEvent_OpenChannelRequest_meth, temporary_channel_id_arr, counterparty_node_id_arr, obj->open_channel_request.funding_satoshis, obj->open_channel_request.push_msat, channel_type_ref);
+			return (*env)->NewObject(env, LDKEvent_OpenChannelRequest_class, LDKEvent_OpenChannelRequest_meth, temporary_channel_id_arr, counterparty_node_id_arr, funding_satoshis_conv, push_msat_conv, channel_type_ref);
 		}
 		default: abort();
 	}
@@ -3740,9 +3758,10 @@ LDKPublicKey get_per_commitment_point_LDKBaseSign_jcall(const void* this_arg, ui
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t idx_conv = idx;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int8_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_per_commitment_point_meth, idx);
+	int8_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_per_commitment_point_meth, idx_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_per_commitment_point in LDKBaseSign from rust threw an exception.");
@@ -3764,9 +3783,10 @@ LDKThirtyTwoBytes release_commitment_secret_LDKBaseSign_jcall(const void* this_a
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t idx_conv = idx;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int8_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->release_commitment_secret_meth, idx);
+	int8_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->release_commitment_secret_meth, idx_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to release_commitment_secret in LDKBaseSign from rust threw an exception.");
@@ -3904,11 +3924,12 @@ LDKCResult_NoneNoneZ validate_counterparty_revocation_LDKBaseSign_jcall(const vo
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t idx_conv = idx;
 	int8_tArray secret_arr = (*env)->NewByteArray(env, 32);
 	(*env)->SetByteArrayRegion(env, secret_arr, 0, 32, *secret);
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->validate_counterparty_revocation_meth, idx, secret_arr);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->validate_counterparty_revocation_meth, idx_conv, secret_arr);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to validate_counterparty_revocation in LDKBaseSign from rust threw an exception.");
@@ -3970,11 +3991,13 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_output_LDKBaseSign_jcall(const vo
 	int8_tArray justice_tx_arr = (*env)->NewByteArray(env, justice_tx_var.datalen);
 	(*env)->SetByteArrayRegion(env, justice_tx_arr, 0, justice_tx_var.datalen, justice_tx_var.data);
 	Transaction_free(justice_tx_var);
+	int64_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_key_arr = (*env)->NewByteArray(env, 32);
 	(*env)->SetByteArrayRegion(env, per_commitment_key_arr, 0, 32, *per_commitment_key);
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_justice_revoked_output_meth, justice_tx_arr, input, amount, per_commitment_key_arr);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_justice_revoked_output_meth, justice_tx_arr, input_conv, amount_conv, per_commitment_key_arr);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to sign_justice_revoked_output in LDKBaseSign from rust threw an exception.");
@@ -4001,6 +4024,8 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_htlc_LDKBaseSign_jcall(const void
 	int8_tArray justice_tx_arr = (*env)->NewByteArray(env, justice_tx_var.datalen);
 	(*env)->SetByteArrayRegion(env, justice_tx_arr, 0, justice_tx_var.datalen, justice_tx_var.data);
 	Transaction_free(justice_tx_var);
+	int64_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_key_arr = (*env)->NewByteArray(env, 32);
 	(*env)->SetByteArrayRegion(env, per_commitment_key_arr, 0, 32, *per_commitment_key);
 	LDKHTLCOutputInCommitment htlc_var = *htlc;
@@ -4015,7 +4040,7 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_htlc_LDKBaseSign_jcall(const void
 	}
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_justice_revoked_htlc_meth, justice_tx_arr, input, amount, per_commitment_key_arr, htlc_ref);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_justice_revoked_htlc_meth, justice_tx_arr, input_conv, amount_conv, per_commitment_key_arr, htlc_ref);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to sign_justice_revoked_htlc in LDKBaseSign from rust threw an exception.");
@@ -4042,6 +4067,8 @@ LDKCResult_SignatureNoneZ sign_counterparty_htlc_transaction_LDKBaseSign_jcall(c
 	int8_tArray htlc_tx_arr = (*env)->NewByteArray(env, htlc_tx_var.datalen);
 	(*env)->SetByteArrayRegion(env, htlc_tx_arr, 0, htlc_tx_var.datalen, htlc_tx_var.data);
 	Transaction_free(htlc_tx_var);
+	int64_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_point_arr = (*env)->NewByteArray(env, 33);
 	(*env)->SetByteArrayRegion(env, per_commitment_point_arr, 0, 33, per_commitment_point.compressed_form);
 	LDKHTLCOutputInCommitment htlc_var = *htlc;
@@ -4056,7 +4083,7 @@ LDKCResult_SignatureNoneZ sign_counterparty_htlc_transaction_LDKBaseSign_jcall(c
 	}
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_counterparty_htlc_transaction_meth, htlc_tx_arr, input, amount, per_commitment_point_arr, htlc_ref);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_counterparty_htlc_transaction_meth, htlc_tx_arr, input_conv, amount_conv, per_commitment_point_arr, htlc_ref);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to sign_counterparty_htlc_transaction in LDKBaseSign from rust threw an exception.");
@@ -4795,7 +4822,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKCOption_1u16Z_1ref_1from
 	LDKCOption_u16Z *obj = (LDKCOption_u16Z*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKCOption_u16Z_Some: {
-			return (*env)->NewObject(env, LDKCOption_u16Z_Some_class, LDKCOption_u16Z_Some_meth, obj->some);
+			int16_t some_conv = obj->some;
+			return (*env)->NewObject(env, LDKCOption_u16Z_Some_class, LDKCOption_u16Z_Some_meth, some_conv);
 		}
 		case LDKCOption_u16Z_None: {
 			return (*env)->NewObject(env, LDKCOption_u16Z_None_class, LDKCOption_u16Z_None_meth);
@@ -4858,7 +4886,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKAPIError_1ref_1from_1ptr
 		case LDKAPIError_FeeRateTooHigh: {
 			LDKStr err_str = obj->fee_rate_too_high.err;
 			jstring err_conv = str_ref_to_java(env, err_str.chars, err_str.len);
-			return (*env)->NewObject(env, LDKAPIError_FeeRateTooHigh_class, LDKAPIError_FeeRateTooHigh_meth, err_conv, obj->fee_rate_too_high.feerate);
+			int32_t feerate_conv = obj->fee_rate_too_high.feerate;
+			return (*env)->NewObject(env, LDKAPIError_FeeRateTooHigh_class, LDKAPIError_FeeRateTooHigh_meth, err_conv, feerate_conv);
 		}
 		case LDKAPIError_RouteError: {
 			LDKStr err_str = obj->route_error.err;
@@ -5156,12 +5185,14 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKNetAddress_1ref_1from_1p
 		case LDKNetAddress_IPv4: {
 			int8_tArray addr_arr = (*env)->NewByteArray(env, 4);
 			(*env)->SetByteArrayRegion(env, addr_arr, 0, 4, obj->i_pv4.addr.data);
-			return (*env)->NewObject(env, LDKNetAddress_IPv4_class, LDKNetAddress_IPv4_meth, addr_arr, obj->i_pv4.port);
+			int16_t port_conv = obj->i_pv4.port;
+			return (*env)->NewObject(env, LDKNetAddress_IPv4_class, LDKNetAddress_IPv4_meth, addr_arr, port_conv);
 		}
 		case LDKNetAddress_IPv6: {
 			int8_tArray addr_arr = (*env)->NewByteArray(env, 16);
 			(*env)->SetByteArrayRegion(env, addr_arr, 0, 16, obj->i_pv6.addr.data);
-			return (*env)->NewObject(env, LDKNetAddress_IPv6_class, LDKNetAddress_IPv6_meth, addr_arr, obj->i_pv6.port);
+			int16_t port_conv = obj->i_pv6.port;
+			return (*env)->NewObject(env, LDKNetAddress_IPv6_class, LDKNetAddress_IPv6_meth, addr_arr, port_conv);
 		}
 		case LDKNetAddress_OnionV2: {
 			int8_tArray onion_v2_arr = (*env)->NewByteArray(env, 12);
@@ -5171,7 +5202,10 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKNetAddress_1ref_1from_1p
 		case LDKNetAddress_OnionV3: {
 			int8_tArray ed25519_pubkey_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, ed25519_pubkey_arr, 0, 32, obj->onion_v3.ed25519_pubkey.data);
-			return (*env)->NewObject(env, LDKNetAddress_OnionV3_class, LDKNetAddress_OnionV3_meth, ed25519_pubkey_arr, obj->onion_v3.checksum, obj->onion_v3.version, obj->onion_v3.port);
+			int16_t checksum_conv = obj->onion_v3.checksum;
+			int8_t version_conv = obj->onion_v3.version;
+			int16_t port_conv = obj->onion_v3.port;
+			return (*env)->NewObject(env, LDKNetAddress_OnionV3_class, LDKNetAddress_OnionV3_meth, ed25519_pubkey_arr, checksum_conv, version_conv, port_conv);
 		}
 		default: abort();
 	}
@@ -5900,9 +5934,11 @@ LDKSign get_channel_signer_LDKKeysInterface_jcall(const void* this_arg, bool inb
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	jboolean inbound_conv = inbound;
+	int64_t channel_value_satoshis_conv = channel_value_satoshis;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->get_channel_signer_meth, inbound, channel_value_satoshis);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->get_channel_signer_meth, inbound_conv, channel_value_satoshis_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_channel_signer in LDKKeysInterface from rust threw an exception.");
@@ -6258,8 +6294,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_FeeEstimator_1get_1est_1sat
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKFeeEstimator* this_arg_conv = (LDKFeeEstimator*)this_arg_ptr;
 	LDKConfirmationTarget confirmation_target_conv = LDKConfirmationTarget_from_java(env, confirmation_target);
-	int32_t ret_val = (this_arg_conv->get_est_sat_per_1000_weight)(this_arg_conv->this_arg, confirmation_target_conv);
-	return ret_val;
+	int32_t ret_conv = (this_arg_conv->get_est_sat_per_1000_weight)(this_arg_conv->this_arg, confirmation_target_conv);
+	return ret_conv;
 }
 
 typedef struct LDKLogger_JCalls {
@@ -6595,8 +6631,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_Type_1type_1id(JNIEnv *env,
 	void* this_arg_ptr = (void*)(((uintptr_t)this_arg) & ~1);
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKType* this_arg_conv = (LDKType*)this_arg_ptr;
-	int16_t ret_val = (this_arg_conv->type_id)(this_arg_conv->this_arg);
-	return ret_val;
+	int16_t ret_conv = (this_arg_conv->type_id)(this_arg_conv->this_arg);
+	return ret_conv;
 }
 
 JNIEXPORT jstring JNICALL Java_org_ldk_impl_bindings_Type_1debug_1str(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -7452,8 +7488,8 @@ static inline uint32_t C2Tuple_u32ScriptZ_get_a(LDKC2Tuple_u32ScriptZ *NONNULL_P
 }
 JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32ScriptZ_1get_1a(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKC2Tuple_u32ScriptZ* owner_conv = (LDKC2Tuple_u32ScriptZ*)(owner & ~1);
-	int32_t ret_val = C2Tuple_u32ScriptZ_get_a(owner_conv);
-	return ret_val;
+	int32_t ret_conv = C2Tuple_u32ScriptZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKCVec_u8Z C2Tuple_u32ScriptZ_get_b(LDKC2Tuple_u32ScriptZ *NONNULL_PTR owner){
@@ -7523,8 +7559,8 @@ static inline uint32_t C2Tuple_u32TxOutZ_get_a(LDKC2Tuple_u32TxOutZ *NONNULL_PTR
 }
 JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32TxOutZ_1get_1a(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKC2Tuple_u32TxOutZ* owner_conv = (LDKC2Tuple_u32TxOutZ*)(owner & ~1);
-	int32_t ret_val = C2Tuple_u32TxOutZ_get_a(owner_conv);
-	return ret_val;
+	int32_t ret_conv = C2Tuple_u32TxOutZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKTxOut C2Tuple_u32TxOutZ_get_b(LDKC2Tuple_u32TxOutZ *NONNULL_PTR owner){
@@ -7614,16 +7650,23 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKBalance_1ref_1from_1ptr(
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKBalance_ClaimableOnChannelClose: {
-			return (*env)->NewObject(env, LDKBalance_ClaimableOnChannelClose_class, LDKBalance_ClaimableOnChannelClose_meth, obj->claimable_on_channel_close.claimable_amount_satoshis);
+			int64_t claimable_amount_satoshis_conv = obj->claimable_on_channel_close.claimable_amount_satoshis;
+			return (*env)->NewObject(env, LDKBalance_ClaimableOnChannelClose_class, LDKBalance_ClaimableOnChannelClose_meth, claimable_amount_satoshis_conv);
 		}
 		case LDKBalance_ClaimableAwaitingConfirmations: {
-			return (*env)->NewObject(env, LDKBalance_ClaimableAwaitingConfirmations_class, LDKBalance_ClaimableAwaitingConfirmations_meth, obj->claimable_awaiting_confirmations.claimable_amount_satoshis, obj->claimable_awaiting_confirmations.confirmation_height);
+			int64_t claimable_amount_satoshis_conv = obj->claimable_awaiting_confirmations.claimable_amount_satoshis;
+			int32_t confirmation_height_conv = obj->claimable_awaiting_confirmations.confirmation_height;
+			return (*env)->NewObject(env, LDKBalance_ClaimableAwaitingConfirmations_class, LDKBalance_ClaimableAwaitingConfirmations_meth, claimable_amount_satoshis_conv, confirmation_height_conv);
 		}
 		case LDKBalance_ContentiousClaimable: {
-			return (*env)->NewObject(env, LDKBalance_ContentiousClaimable_class, LDKBalance_ContentiousClaimable_meth, obj->contentious_claimable.claimable_amount_satoshis, obj->contentious_claimable.timeout_height);
+			int64_t claimable_amount_satoshis_conv = obj->contentious_claimable.claimable_amount_satoshis;
+			int32_t timeout_height_conv = obj->contentious_claimable.timeout_height;
+			return (*env)->NewObject(env, LDKBalance_ContentiousClaimable_class, LDKBalance_ContentiousClaimable_meth, claimable_amount_satoshis_conv, timeout_height_conv);
 		}
 		case LDKBalance_MaybeClaimableHTLCAwaitingTimeout: {
-			return (*env)->NewObject(env, LDKBalance_MaybeClaimableHTLCAwaitingTimeout_class, LDKBalance_MaybeClaimableHTLCAwaitingTimeout_meth, obj->maybe_claimable_htlc_awaiting_timeout.claimable_amount_satoshis, obj->maybe_claimable_htlc_awaiting_timeout.claimable_height);
+			int64_t claimable_amount_satoshis_conv = obj->maybe_claimable_htlc_awaiting_timeout.claimable_amount_satoshis;
+			int32_t claimable_height_conv = obj->maybe_claimable_htlc_awaiting_timeout.claimable_height;
+			return (*env)->NewObject(env, LDKBalance_MaybeClaimableHTLCAwaitingTimeout_class, LDKBalance_MaybeClaimableHTLCAwaitingTimeout_meth, claimable_amount_satoshis_conv, claimable_height_conv);
 		}
 		default: abort();
 	}
@@ -7724,8 +7767,8 @@ CHECK(owner->result_ok);
 }
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1get_1ok(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKCResult_boolLightningErrorZ* owner_conv = (LDKCResult_boolLightningErrorZ*)(owner & ~1);
-	jboolean ret_val = CResult_boolLightningErrorZ_get_ok(owner_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolLightningErrorZ_get_ok(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKLightningError CResult_boolLightningErrorZ_get_err(LDKCResult_boolLightningErrorZ *NONNULL_PTR owner){
@@ -7904,8 +7947,8 @@ CHECK(owner->result_ok);
 }
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1get_1ok(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKCResult_boolPeerHandleErrorZ* owner_conv = (LDKCResult_boolPeerHandleErrorZ*)(owner & ~1);
-	jboolean ret_val = CResult_boolPeerHandleErrorZ_get_ok(owner_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolPeerHandleErrorZ_get_ok(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKPeerHandleError CResult_boolPeerHandleErrorZ_get_err(LDKCResult_boolPeerHandleErrorZ *NONNULL_PTR owner){
@@ -8026,9 +8069,10 @@ LDKCResult_TxOutAccessErrorZ get_utxo_LDKAccess_jcall(const void* this_arg, cons
 	}
 	int8_tArray genesis_hash_arr = (*env)->NewByteArray(env, 32);
 	(*env)->SetByteArrayRegion(env, genesis_hash_arr, 0, 32, *genesis_hash);
+	int64_t short_channel_id_conv = short_channel_id;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->get_utxo_meth, genesis_hash_arr, short_channel_id);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->get_utxo_meth, genesis_hash_arr, short_channel_id_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_utxo in LDKAccess from rust threw an exception.");
@@ -10199,9 +10243,10 @@ void block_connected_LDKListen_jcall(const void* this_arg, LDKu8slice block, uin
 	LDKu8slice block_var = block;
 	int8_tArray block_arr = (*env)->NewByteArray(env, block_var.datalen);
 	(*env)->SetByteArrayRegion(env, block_arr, 0, block_var.datalen, block_var.data);
+	int32_t height_conv = height;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->block_connected_meth, block_arr, height);
+	(*env)->CallVoidMethod(env, obj, j_calls->block_connected_meth, block_arr, height_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to block_connected in LDKListen from rust threw an exception.");
@@ -10221,9 +10266,10 @@ void block_disconnected_LDKListen_jcall(const void* this_arg, const uint8_t (* h
 	}
 	int8_tArray header_arr = (*env)->NewByteArray(env, 80);
 	(*env)->SetByteArrayRegion(env, header_arr, 0, 80, *header);
+	int32_t height_conv = height;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->block_disconnected_meth, header_arr, height);
+	(*env)->CallVoidMethod(env, obj, j_calls->block_disconnected_meth, header_arr, height_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to block_disconnected in LDKListen from rust threw an exception.");
@@ -10331,9 +10377,10 @@ void transactions_confirmed_LDKConfirm_jcall(const void* this_arg, const uint8_t
 	}
 	(*env)->ReleasePrimitiveArrayCritical(env, txdata_arr, txdata_arr_ptr, 0);
 	FREE(txdata_var.data);
+	int32_t height_conv = height;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->transactions_confirmed_meth, header_arr, txdata_arr, height);
+	(*env)->CallVoidMethod(env, obj, j_calls->transactions_confirmed_meth, header_arr, txdata_arr, height_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to transactions_confirmed in LDKConfirm from rust threw an exception.");
@@ -10375,9 +10422,10 @@ void best_block_updated_LDKConfirm_jcall(const void* this_arg, const uint8_t (* 
 	}
 	int8_tArray header_arr = (*env)->NewByteArray(env, 80);
 	(*env)->SetByteArrayRegion(env, header_arr, 0, 80, *header);
+	int32_t height_conv = height;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->best_block_updated_meth, header_arr, height);
+	(*env)->CallVoidMethod(env, obj, j_calls->best_block_updated_meth, header_arr, height_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to best_block_updated in LDKConfirm from rust threw an exception.");
@@ -11305,9 +11353,10 @@ void peer_disconnected_LDKChannelMessageHandler_jcall(const void* this_arg, LDKP
 	}
 	int8_tArray their_node_id_arr = (*env)->NewByteArray(env, 33);
 	(*env)->SetByteArrayRegion(env, their_node_id_arr, 0, 33, their_node_id.compressed_form);
+	jboolean no_connection_possible_conv = no_connection_possible;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->peer_disconnected_meth, their_node_id_arr, no_connection_possible);
+	(*env)->CallVoidMethod(env, obj, j_calls->peer_disconnected_meth, their_node_id_arr, no_connection_possible_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to peer_disconnected in LDKChannelMessageHandler from rust threw an exception.");
@@ -11973,9 +12022,11 @@ LDKCVec_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZZ get_next_channel
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t starting_point_conv = starting_point;
+	int8_t batch_amount_conv = batch_amount;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int64_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_next_channel_announcements_meth, starting_point, batch_amount);
+	int64_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_next_channel_announcements_meth, starting_point_conv, batch_amount_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_next_channel_announcements in LDKRoutingMessageHandler from rust threw an exception.");
@@ -12012,9 +12063,10 @@ LDKCVec_NodeAnnouncementZ get_next_node_announcements_LDKRoutingMessageHandler_j
 	}
 	int8_tArray starting_point_arr = (*env)->NewByteArray(env, 33);
 	(*env)->SetByteArrayRegion(env, starting_point_arr, 0, 33, starting_point.compressed_form);
+	int8_t batch_amount_conv = batch_amount;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int64_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_next_node_announcements_meth, starting_point_arr, batch_amount);
+	int64_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_next_node_announcements_meth, starting_point_arr, batch_amount_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_next_node_announcements in LDKRoutingMessageHandler from rust threw an exception.");
@@ -12477,12 +12529,13 @@ LDKCResult_COption_TypeZDecodeErrorZ read_LDKCustomMessageReader_jcall(const voi
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int16_t message_type_conv = message_type;
 	LDKu8slice buffer_var = buffer;
 	int8_tArray buffer_arr = (*env)->NewByteArray(env, buffer_var.datalen);
 	(*env)->SetByteArrayRegion(env, buffer_arr, 0, buffer_var.datalen, buffer_var.data);
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->read_meth, message_type, buffer_arr);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->read_meth, message_type_conv, buffer_arr);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to read in LDKCustomMessageReader from rust threw an exception.");
@@ -12739,9 +12792,10 @@ uintptr_t send_data_LDKSocketDescriptor_jcall(void* this_arg, LDKu8slice data, b
 	LDKu8slice data_var = data;
 	int8_tArray data_arr = (*env)->NewByteArray(env, data_var.datalen);
 	(*env)->SetByteArrayRegion(env, data_arr, 0, data_var.datalen, data_var.data);
+	jboolean resume_read_conv = resume_read;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int64_t ret = (*env)->CallLongMethod(env, obj, j_calls->send_data_meth, data_arr, resume_read);
+	int64_t ret = (*env)->CallLongMethod(env, obj, j_calls->send_data_meth, data_arr, resume_read_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to send_data in LDKSocketDescriptor from rust threw an exception.");
@@ -12858,9 +12912,9 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1send_1dat
 	LDKu8slice data_ref;
 	data_ref.datalen = (*env)->GetArrayLength(env, data);
 	data_ref.data = (*env)->GetByteArrayElements (env, data, NULL);
-	int64_t ret_val = (this_arg_conv->send_data)(this_arg_conv->this_arg, data_ref, resume_read);
+	int64_t ret_conv = (this_arg_conv->send_data)(this_arg_conv->this_arg, data_ref, resume_read);
 	(*env)->ReleaseByteArrayElements(env, data, (int8_t*)data_ref.data, 0);
-	return ret_val;
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1disconnect_1socket(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -12874,8 +12928,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1hash(JNIE
 	void* this_arg_ptr = (void*)(((uintptr_t)this_arg) & ~1);
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKSocketDescriptor* this_arg_conv = (LDKSocketDescriptor*)this_arg_ptr;
-	int64_t ret_val = (this_arg_conv->hash)(this_arg_conv->this_arg);
-	return ret_val;
+	int64_t ret_conv = (this_arg_conv->hash)(this_arg_conv->this_arg);
+	return ret_conv;
 }
 
 static jclass LDKEffectiveCapacity_ExactLiquidity_class = NULL;
@@ -12919,13 +12973,16 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEffectiveCapacity_1ref_1
 	LDKEffectiveCapacity *obj = (LDKEffectiveCapacity*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKEffectiveCapacity_ExactLiquidity: {
-			return (*env)->NewObject(env, LDKEffectiveCapacity_ExactLiquidity_class, LDKEffectiveCapacity_ExactLiquidity_meth, obj->exact_liquidity.liquidity_msat);
+			int64_t liquidity_msat_conv = obj->exact_liquidity.liquidity_msat;
+			return (*env)->NewObject(env, LDKEffectiveCapacity_ExactLiquidity_class, LDKEffectiveCapacity_ExactLiquidity_meth, liquidity_msat_conv);
 		}
 		case LDKEffectiveCapacity_MaximumHTLC: {
-			return (*env)->NewObject(env, LDKEffectiveCapacity_MaximumHTLC_class, LDKEffectiveCapacity_MaximumHTLC_meth, obj->maximum_htlc.amount_msat);
+			int64_t amount_msat_conv = obj->maximum_htlc.amount_msat;
+			return (*env)->NewObject(env, LDKEffectiveCapacity_MaximumHTLC_class, LDKEffectiveCapacity_MaximumHTLC_meth, amount_msat_conv);
 		}
 		case LDKEffectiveCapacity_Total: {
-			return (*env)->NewObject(env, LDKEffectiveCapacity_Total_class, LDKEffectiveCapacity_Total_meth, obj->total.capacity_msat);
+			int64_t capacity_msat_conv = obj->total.capacity_msat;
+			return (*env)->NewObject(env, LDKEffectiveCapacity_Total_class, LDKEffectiveCapacity_Total_meth, capacity_msat_conv);
 		}
 		case LDKEffectiveCapacity_Infinite: {
 			return (*env)->NewObject(env, LDKEffectiveCapacity_Infinite_class, LDKEffectiveCapacity_Infinite_meth);
@@ -12971,6 +13028,9 @@ uint64_t channel_penalty_msat_LDKScore_jcall(const void* this_arg, uint64_t shor
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t short_channel_id_conv = short_channel_id;
+	int64_t send_amt_msat_conv = send_amt_msat;
+	int64_t capacity_msat_conv = capacity_msat;
 	LDKNodeId source_var = *source;
 	int64_t source_ref = 0;
 	source_var = NodeId_clone(&source_var);
@@ -12993,7 +13053,7 @@ uint64_t channel_penalty_msat_LDKScore_jcall(const void* this_arg, uint64_t shor
 	}
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int64_t ret = (*env)->CallLongMethod(env, obj, j_calls->channel_penalty_msat_meth, short_channel_id, send_amt_msat, capacity_msat, source_ref, target_ref);
+	int64_t ret = (*env)->CallLongMethod(env, obj, j_calls->channel_penalty_msat_meth, short_channel_id_conv, send_amt_msat_conv, capacity_msat_conv, source_ref, target_ref);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to channel_penalty_msat in LDKScore from rust threw an exception.");
@@ -13030,9 +13090,10 @@ void payment_path_failed_LDKScore_jcall(void* this_arg, LDKCVec_RouteHopZ path, 
 	}
 	(*env)->ReleasePrimitiveArrayCritical(env, path_arr, path_arr_ptr, 0);
 	FREE(path_var.data);
+	int64_t short_channel_id_conv = short_channel_id;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->payment_path_failed_meth, path_arr, short_channel_id);
+	(*env)->CallVoidMethod(env, obj, j_calls->payment_path_failed_meth, path_arr, short_channel_id_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to payment_path_failed in LDKScore from rust threw an exception.");
@@ -13151,8 +13212,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Score_1channel_1penalty_1ms
 	target_conv.inner = (void*)(target & (~1));
 	target_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(target_conv);
-	int64_t ret_val = (this_arg_conv->channel_penalty_msat)(this_arg_conv->this_arg, short_channel_id, send_amt_msat, capacity_msat, &source_conv, &target_conv);
-	return ret_val;
+	int64_t ret_conv = (this_arg_conv->channel_penalty_msat)(this_arg_conv->this_arg, short_channel_id, send_amt_msat, capacity_msat, &source_conv, &target_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Score_1payment_1path_1failed(JNIEnv *env, jclass clz, int64_t this_arg, int64_tArray path, int64_t short_channel_id) {
@@ -14032,8 +14093,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Bech32Error_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKBech32Error* arg_conv = (LDKBech32Error*)arg;
-	int64_t ret_val = Bech32Error_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Bech32Error_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Bech32Error_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14088,8 +14149,8 @@ static inline uintptr_t TxOut_clone_ptr(LDKTxOut *NONNULL_PTR arg) {
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxOut_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKTxOut* arg_conv = (LDKTxOut*)(arg & ~1);
-	int64_t ret_val = TxOut_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = TxOut_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxOut_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14118,8 +14179,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1err(JNI
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneNoneZ* o_conv = (LDKCResult_NoneNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14138,8 +14199,8 @@ static inline uintptr_t CResult_NoneNoneZ_clone_ptr(LDKCResult_NoneNoneZ *NONNUL
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneNoneZ* arg_conv = (LDKCResult_NoneNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14173,8 +14234,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommit
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommitmentSecretsDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ* o_conv = (LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommitmentSecretsDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14193,8 +14254,8 @@ static inline uintptr_t CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommitmentSecretsDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommitmentSecretsDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14222,8 +14283,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1e
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SecretKeyErrorZ* o_conv = (LDKCResult_SecretKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SecretKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SecretKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14242,8 +14303,8 @@ static inline uintptr_t CResult_SecretKeyErrorZ_clone_ptr(LDKCResult_SecretKeyEr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SecretKeyErrorZ* arg_conv = (LDKCResult_SecretKeyErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SecretKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SecretKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14271,8 +14332,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1e
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PublicKeyErrorZ* o_conv = (LDKCResult_PublicKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PublicKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PublicKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14291,8 +14352,8 @@ static inline uintptr_t CResult_PublicKeyErrorZ_clone_ptr(LDKCResult_PublicKeyEr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PublicKeyErrorZ* arg_conv = (LDKCResult_PublicKeyErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PublicKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PublicKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14326,8 +14387,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TxCreationKeysDecodeErrorZ* o_conv = (LDKCResult_TxCreationKeysDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxCreationKeysDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxCreationKeysDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14346,8 +14407,8 @@ static inline uintptr_t CResult_TxCreationKeysDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_TxCreationKeysDecodeErrorZ* arg_conv = (LDKCResult_TxCreationKeysDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_TxCreationKeysDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_TxCreationKeysDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14381,8 +14442,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelPublicKeysDecodeErrorZ* o_conv = (LDKCResult_ChannelPublicKeysDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelPublicKeysDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelPublicKeysDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14401,8 +14462,8 @@ static inline uintptr_t CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelPublicKeysDecodeErrorZ* arg_conv = (LDKCResult_ChannelPublicKeysDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14432,8 +14493,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TxCreationKeysErrorZ* o_conv = (LDKCResult_TxCreationKeysErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxCreationKeysErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxCreationKeysErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14452,8 +14513,8 @@ static inline uintptr_t CResult_TxCreationKeysErrorZ_clone_ptr(LDKCResult_TxCrea
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_TxCreationKeysErrorZ* arg_conv = (LDKCResult_TxCreationKeysErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_TxCreationKeysErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_TxCreationKeysErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14494,8 +14555,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u32Z_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_u32Z* arg_conv = (LDKCOption_u32Z*)arg;
-	int64_t ret_val = COption_u32Z_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_u32Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u32Z_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14530,8 +14591,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommit
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommitmentDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_HTLCOutputInCommitmentDecodeErrorZ* o_conv = (LDKCResult_HTLCOutputInCommitmentDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommitmentDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14550,8 +14611,8 @@ static inline uintptr_t CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(LDK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommitmentDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_HTLCOutputInCommitmentDecodeErrorZ* arg_conv = (LDKCResult_HTLCOutputInCommitmentDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommitmentDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14600,8 +14661,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChanne
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChannelTransactionParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ* o_conv = (LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChannelTransactionParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14620,8 +14681,8 @@ static inline uintptr_t CResult_CounterpartyChannelTransactionParametersDecodeEr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChannelTransactionParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChannelTransactionParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14655,8 +14716,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransaction
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransactionParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelTransactionParametersDecodeErrorZ* o_conv = (LDKCResult_ChannelTransactionParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransactionParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14675,8 +14736,8 @@ static inline uintptr_t CResult_ChannelTransactionParametersDecodeErrorZ_clone_p
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransactionParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelTransactionParametersDecodeErrorZ* arg_conv = (LDKCResult_ChannelTransactionParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransactionParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14727,8 +14788,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTransactionDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_HolderCommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_HolderCommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTransactionDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14747,8 +14808,8 @@ static inline uintptr_t CResult_HolderCommitmentTransactionDecodeErrorZ_clone_pt
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTransactionDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_HolderCommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_HolderCommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTransactionDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14782,8 +14843,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTra
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTransactionDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_BuiltCommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_BuiltCommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTransactionDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14802,8 +14863,8 @@ static inline uintptr_t CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTransactionDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_BuiltCommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_BuiltCommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTransactionDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14832,8 +14893,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedClosingTran
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedClosingTransactionNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TrustedClosingTransactionNoneZ* o_conv = (LDKCResult_TrustedClosingTransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TrustedClosingTransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TrustedClosingTransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedClosingTransactionNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14869,8 +14930,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransact
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransactionDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_CommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransactionDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14889,8 +14950,8 @@ static inline uintptr_t CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransactionDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_CommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransactionDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14919,8 +14980,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedCommitmentT
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedCommitmentTransactionNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TrustedCommitmentTransactionNoneZ* o_conv = (LDKCResult_TrustedCommitmentTransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TrustedCommitmentTransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TrustedCommitmentTransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedCommitmentTransactionNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14959,8 +15020,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNo
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CVec_SignatureZNoneZ* o_conv = (LDKCResult_CVec_SignatureZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_SignatureZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_SignatureZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14979,8 +15040,8 @@ static inline uintptr_t CResult_CVec_SignatureZNoneZ_clone_ptr(LDKCResult_CVec_S
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CVec_SignatureZNoneZ* arg_conv = (LDKCResult_CVec_SignatureZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_CVec_SignatureZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CVec_SignatureZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15014,8 +15075,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ShutdownScriptDecodeErrorZ* o_conv = (LDKCResult_ShutdownScriptDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownScriptDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownScriptDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15034,8 +15095,8 @@ static inline uintptr_t CResult_ShutdownScriptDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ShutdownScriptDecodeErrorZ* arg_conv = (LDKCResult_ShutdownScriptDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ShutdownScriptDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ShutdownScriptDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15069,8 +15130,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInva
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInvalidShutdownScriptZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ShutdownScriptInvalidShutdownScriptZ* o_conv = (LDKCResult_ShutdownScriptInvalidShutdownScriptZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInvalidShutdownScriptZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15089,8 +15150,8 @@ static inline uintptr_t CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(L
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInvalidShutdownScriptZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ShutdownScriptInvalidShutdownScriptZ* arg_conv = (LDKCResult_ShutdownScriptInvalidShutdownScriptZ*)(arg & ~1);
-	int64_t ret_val = CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInvalidShutdownScriptZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15115,8 +15176,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1err(JN
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneErrorZ* o_conv = (LDKCResult_NoneErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15135,8 +15196,8 @@ static inline uintptr_t CResult_NoneErrorZ_clone_ptr(LDKCResult_NoneErrorZ *NONN
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneErrorZ* arg_conv = (LDKCResult_NoneErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15170,8 +15231,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteHopDecodeErrorZ* o_conv = (LDKCResult_RouteHopDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHopDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHopDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15190,8 +15251,8 @@ static inline uintptr_t CResult_RouteHopDecodeErrorZ_clone_ptr(LDKCResult_RouteH
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteHopDecodeErrorZ* arg_conv = (LDKCResult_RouteHopDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteHopDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteHopDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15275,8 +15336,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteDecodeErrorZ* o_conv = (LDKCResult_RouteDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15295,8 +15356,8 @@ static inline uintptr_t CResult_RouteDecodeErrorZ_clone_ptr(LDKCResult_RouteDeco
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteDecodeErrorZ* arg_conv = (LDKCResult_RouteDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15330,8 +15391,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDec
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteParametersDecodeErrorZ* o_conv = (LDKCResult_RouteParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15350,8 +15411,8 @@ static inline uintptr_t CResult_RouteParametersDecodeErrorZ_clone_ptr(LDKCResult
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteParametersDecodeErrorZ* arg_conv = (LDKCResult_RouteParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15412,8 +15473,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u64Z_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_u64Z* arg_conv = (LDKCOption_u64Z*)arg;
-	int64_t ret_val = COption_u64Z_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_u64Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u64Z_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15448,8 +15509,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentParametersDecodeErrorZ* o_conv = (LDKCResult_PaymentParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15468,8 +15529,8 @@ static inline uintptr_t CResult_PaymentParametersDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentParametersDecodeErrorZ* arg_conv = (LDKCResult_PaymentParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15523,8 +15584,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteHintDecodeErrorZ* o_conv = (LDKCResult_RouteHintDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHintDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHintDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15543,8 +15604,8 @@ static inline uintptr_t CResult_RouteHintDecodeErrorZ_clone_ptr(LDKCResult_Route
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteHintDecodeErrorZ* arg_conv = (LDKCResult_RouteHintDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteHintDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteHintDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15578,8 +15639,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteHintHopDecodeErrorZ* o_conv = (LDKCResult_RouteHintHopDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHintHopDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHintHopDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15598,8 +15659,8 @@ static inline uintptr_t CResult_RouteHintHopDecodeErrorZ_clone_ptr(LDKCResult_Ro
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteHintHopDecodeErrorZ* arg_conv = (LDKCResult_RouteHintHopDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteHintHopDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteHintHopDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15653,8 +15714,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteLightningErrorZ* o_conv = (LDKCResult_RouteLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15673,8 +15734,8 @@ static inline uintptr_t CResult_RouteLightningErrorZ_clone_ptr(LDKCResult_RouteL
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteLightningErrorZ* arg_conv = (LDKCResult_RouteLightningErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15703,8 +15764,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TxOutAccessErrorZ* o_conv = (LDKCResult_TxOutAccessErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxOutAccessErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxOutAccessErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15723,8 +15784,8 @@ static inline uintptr_t CResult_TxOutAccessErrorZ_clone_ptr(LDKCResult_TxOutAcce
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_TxOutAccessErrorZ* arg_conv = (LDKCResult_TxOutAccessErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_TxOutAccessErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_TxOutAccessErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15741,8 +15802,8 @@ static inline uintptr_t C2Tuple_usizeTransactionZ_clone_ptr(LDKC2Tuple_usizeTran
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1usizeTransactionZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_usizeTransactionZ* arg_conv = (LDKC2Tuple_usizeTransactionZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_usizeTransactionZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_usizeTransactionZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1usizeTransactionZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15824,8 +15885,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitor
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitorUpdateErrZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneChannelMonitorUpdateErrZ* o_conv = (LDKCResult_NoneChannelMonitorUpdateErrZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneChannelMonitorUpdateErrZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneChannelMonitorUpdateErrZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitorUpdateErrZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15844,8 +15905,8 @@ static inline uintptr_t CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitorUpdateErrZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneChannelMonitorUpdateErrZ* arg_conv = (LDKCResult_NoneChannelMonitorUpdateErrZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitorUpdateErrZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15910,8 +15971,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1C2Tuple_1usizeTransactionZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_C2Tuple_usizeTransactionZZ* arg_conv = (LDKCOption_C2Tuple_usizeTransactionZZ*)arg;
-	int64_t ret_val = COption_C2Tuple_usizeTransactionZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_C2Tuple_usizeTransactionZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1C2Tuple_1usizeTransactionZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15957,8 +16018,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1ClosureReasonZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_ClosureReasonZ* arg_conv = (LDKCOption_ClosureReasonZ*)arg;
-	int64_t ret_val = COption_ClosureReasonZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_ClosureReasonZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1ClosureReasonZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15992,8 +16053,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureRe
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureReasonZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_ClosureReasonZDecodeErrorZ* o_conv = (LDKCResult_COption_ClosureReasonZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureReasonZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16012,8 +16073,8 @@ static inline uintptr_t CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(LDK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureReasonZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_ClosureReasonZDecodeErrorZ* arg_conv = (LDKCResult_COption_ClosureReasonZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureReasonZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16058,8 +16119,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1NetworkUpdateZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_NetworkUpdateZ* arg_conv = (LDKCOption_NetworkUpdateZ*)arg;
-	int64_t ret_val = COption_NetworkUpdateZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_NetworkUpdateZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1NetworkUpdateZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16125,8 +16186,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1EventZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_EventZ* arg_conv = (LDKCOption_EventZ*)arg;
-	int64_t ret_val = COption_EventZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_EventZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1EventZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16160,8 +16221,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDec
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_EventZDecodeErrorZ* o_conv = (LDKCResult_COption_EventZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_EventZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_EventZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16180,8 +16241,8 @@ static inline uintptr_t CResult_COption_EventZDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_EventZDecodeErrorZ* arg_conv = (LDKCResult_COption_EventZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_EventZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_EventZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16235,8 +16296,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorer
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorerDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_FixedPenaltyScorerDecodeErrorZ* o_conv = (LDKCResult_FixedPenaltyScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorerDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16255,8 +16316,8 @@ static inline uintptr_t CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(LDKCRes
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorerDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_FixedPenaltyScorerDecodeErrorZ* arg_conv = (LDKCResult_FixedPenaltyScorerDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorerDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16290,8 +16351,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ScoringParametersDecodeErrorZ* o_conv = (LDKCResult_ScoringParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ScoringParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ScoringParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16310,8 +16371,8 @@ static inline uintptr_t CResult_ScoringParametersDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ScoringParametersDecodeErrorZ* arg_conv = (LDKCResult_ScoringParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ScoringParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ScoringParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16345,8 +16406,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ScorerDecodeErrorZ
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ScorerDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ScorerDecodeErrorZ* o_conv = (LDKCResult_ScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ScorerDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16382,8 +16443,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ProbabilisticScore
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ProbabilisticScorerDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ProbabilisticScorerDecodeErrorZ* o_conv = (LDKCResult_ProbabilisticScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ProbabilisticScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ProbabilisticScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ProbabilisticScorerDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16419,8 +16480,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InitFeaturesDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InitFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InitFeaturesDecodeErrorZ* o_conv = (LDKCResult_InitFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InitFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InitFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InitFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16456,8 +16517,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelFeaturesDec
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelFeaturesDecodeErrorZ* o_conv = (LDKCResult_ChannelFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16493,8 +16554,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeFeaturesDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeFeaturesDecodeErrorZ* o_conv = (LDKCResult_NodeFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16530,8 +16591,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceFeaturesDec
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InvoiceFeaturesDecodeErrorZ* o_conv = (LDKCResult_InvoiceFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16567,8 +16628,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTypeFeature
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTypeFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelTypeFeaturesDecodeErrorZ* o_conv = (LDKCResult_ChannelTypeFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTypeFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16604,8 +16665,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutp
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutputDescriptorDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutputDescriptorDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16624,8 +16685,8 @@ static inline uintptr_t CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutputDescriptorDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutputDescriptorDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16659,8 +16720,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutpu
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutputDescriptorDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutputDescriptorDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16679,8 +16740,8 @@ static inline uintptr_t CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutputDescriptorDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutputDescriptorDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16713,8 +16774,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDes
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDescriptorDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SpendableOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_SpendableOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDescriptorDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16733,8 +16794,8 @@ static inline uintptr_t CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDescriptorDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SpendableOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_SpendableOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDescriptorDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16768,8 +16829,8 @@ static inline uintptr_t C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(LDKC2Tuple_S
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1SignatureCVec_1SignatureZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_SignatureCVec_SignatureZZ* arg_conv = (LDKC2Tuple_SignatureCVec_SignatureZZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1SignatureCVec_1SignatureZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16828,8 +16889,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1Signature
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureCVec_1SignatureZZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ* o_conv = (LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureCVec_1SignatureZZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16848,8 +16909,8 @@ static inline uintptr_t CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureCVec_1SignatureZZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ* arg_conv = (LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureCVec_1SignatureZZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16876,8 +16937,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1er
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SignatureNoneZ* o_conv = (LDKCResult_SignatureNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_SignatureNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignatureNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16896,8 +16957,8 @@ static inline uintptr_t CResult_SignatureNoneZ_clone_ptr(LDKCResult_SignatureNon
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SignatureNoneZ* arg_conv = (LDKCResult_SignatureNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_SignatureNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SignatureNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16914,8 +16975,8 @@ static inline uintptr_t C2Tuple_SignatureSignatureZ_clone_ptr(LDKC2Tuple_Signatu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1SignatureSignatureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_SignatureSignatureZ* arg_conv = (LDKC2Tuple_SignatureSignatureZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_SignatureSignatureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_SignatureSignatureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1SignatureSignatureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16964,8 +17025,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1Signature
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureSignatureZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_SignatureSignatureZNoneZ* o_conv = (LDKCResult_C2Tuple_SignatureSignatureZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureSignatureZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16984,8 +17045,8 @@ static inline uintptr_t CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(LDKCR
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureSignatureZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_SignatureSignatureZNoneZ* arg_conv = (LDKCResult_C2Tuple_SignatureSignatureZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureSignatureZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17012,8 +17073,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1er
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SecretKeyNoneZ* o_conv = (LDKCResult_SecretKeyNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_SecretKeyNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SecretKeyNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17032,8 +17093,8 @@ static inline uintptr_t CResult_SecretKeyNoneZ_clone_ptr(LDKCResult_SecretKeyNon
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SecretKeyNoneZ* arg_conv = (LDKCResult_SecretKeyNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_SecretKeyNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SecretKeyNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17069,8 +17130,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SignDecodeErrorZ* o_conv = (LDKCResult_SignDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SignDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17089,8 +17150,8 @@ static inline uintptr_t CResult_SignDecodeErrorZ_clone_ptr(LDKCResult_SignDecode
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SignDecodeErrorZ* arg_conv = (LDKCResult_SignDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SignDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SignDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17134,8 +17195,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatu
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatureNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RecoverableSignatureNoneZ* o_conv = (LDKCResult_RecoverableSignatureNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_RecoverableSignatureNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RecoverableSignatureNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatureNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17154,8 +17215,8 @@ static inline uintptr_t CResult_RecoverableSignatureNoneZ_clone_ptr(LDKCResult_R
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatureNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RecoverableSignatureNoneZ* arg_conv = (LDKCResult_RecoverableSignatureNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_RecoverableSignatureNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RecoverableSignatureNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatureNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17219,8 +17280,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNo
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CVec_CVec_u8ZZNoneZ* o_conv = (LDKCResult_CVec_CVec_u8ZZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_CVec_u8ZZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_CVec_u8ZZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17239,8 +17300,8 @@ static inline uintptr_t CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(LDKCResult_CVec_CV
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CVec_CVec_u8ZZNoneZ* arg_conv = (LDKCResult_CVec_CVec_u8ZZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17274,8 +17335,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InMemorySignerDecodeErrorZ* o_conv = (LDKCResult_InMemorySignerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InMemorySignerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InMemorySignerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17294,8 +17355,8 @@ static inline uintptr_t CResult_InMemorySignerDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InMemorySignerDecodeErrorZ* arg_conv = (LDKCResult_InMemorySignerDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InMemorySignerDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InMemorySignerDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17344,8 +17405,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TransactionNoneZ* o_conv = (LDKCResult_TransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17364,8 +17425,8 @@ static inline uintptr_t CResult_TransactionNoneZ_clone_ptr(LDKCResult_Transactio
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_TransactionNoneZ* arg_conv = (LDKCResult_TransactionNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_TransactionNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_TransactionNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17382,8 +17443,8 @@ static inline uintptr_t C2Tuple_BlockHashChannelMonitorZ_clone_ptr(LDKC2Tuple_Bl
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1BlockHashChannelMonitorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_BlockHashChannelMonitorZ* arg_conv = (LDKC2Tuple_BlockHashChannelMonitorZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_BlockHashChannelMonitorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_BlockHashChannelMonitorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1BlockHashChannelMonitorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17467,8 +17528,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1Blo
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1BlockHashChannelMonitorZZErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ* o_conv = (LDKCResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1BlockHashChannelMonitorZZErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17487,8 +17548,8 @@ static inline uintptr_t CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_clo
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1BlockHashChannelMonitorZZErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ* arg_conv = (LDKCResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1BlockHashChannelMonitorZZErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17529,8 +17590,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u16Z_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_u16Z* arg_conv = (LDKCOption_u16Z*)arg;
-	int64_t ret_val = COption_u16Z_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_u16Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u16Z_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17559,8 +17620,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1err
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneAPIErrorZ* o_conv = (LDKCResult_NoneAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17579,8 +17640,8 @@ static inline uintptr_t CResult_NoneAPIErrorZ_clone_ptr(LDKCResult_NoneAPIErrorZ
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneAPIErrorZ* arg_conv = (LDKCResult_NoneAPIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17651,8 +17712,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1e
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult__u832APIErrorZ* o_conv = (LDKCResult__u832APIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult__u832APIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult__u832APIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17671,8 +17732,8 @@ static inline uintptr_t CResult__u832APIErrorZ_clone_ptr(LDKCResult__u832APIErro
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult__u832APIErrorZ* arg_conv = (LDKCResult__u832APIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult__u832APIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult__u832APIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17703,8 +17764,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSe
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSendFailureZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentIdPaymentSendFailureZ* o_conv = (LDKCResult_PaymentIdPaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentIdPaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentIdPaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSendFailureZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17723,8 +17784,8 @@ static inline uintptr_t CResult_PaymentIdPaymentSendFailureZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSendFailureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentIdPaymentSendFailureZ* arg_conv = (LDKCResult_PaymentIdPaymentSendFailureZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentIdPaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentIdPaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSendFailureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17752,8 +17813,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFai
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFailureZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NonePaymentSendFailureZ* o_conv = (LDKCResult_NonePaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_NonePaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NonePaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFailureZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17772,8 +17833,8 @@ static inline uintptr_t CResult_NonePaymentSendFailureZ_clone_ptr(LDKCResult_Non
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFailureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NonePaymentSendFailureZ* arg_conv = (LDKCResult_NonePaymentSendFailureZ*)(arg & ~1);
-	int64_t ret_val = CResult_NonePaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NonePaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFailureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17790,8 +17851,8 @@ static inline uintptr_t C2Tuple_PaymentHashPaymentIdZ_clone_ptr(LDKC2Tuple_Payme
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PaymentHashPaymentIdZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_PaymentHashPaymentIdZ* arg_conv = (LDKC2Tuple_PaymentHashPaymentIdZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_PaymentHashPaymentIdZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_PaymentHashPaymentIdZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PaymentHashPaymentIdZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17844,8 +17905,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentIdZPaymentSendFailureZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentIdZPaymentSendFailureZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17864,8 +17925,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentIdZPaymentSendFailureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentIdZPaymentSendFailureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17902,8 +17963,8 @@ static inline uintptr_t C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(LDKC2Tuple_P
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PaymentHashPaymentSecretZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_PaymentHashPaymentSecretZ* arg_conv = (LDKC2Tuple_PaymentHashPaymentSecretZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PaymentHashPaymentSecretZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17952,8 +18013,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17972,8 +18033,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18005,8 +18066,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZAPIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZAPIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18025,8 +18086,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZAPIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZAPIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18053,8 +18114,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentSecretNoneZ* o_conv = (LDKCResult_PaymentSecretNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentSecretNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentSecretNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18073,8 +18134,8 @@ static inline uintptr_t CResult_PaymentSecretNoneZ_clone_ptr(LDKCResult_PaymentS
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentSecretNoneZ* arg_conv = (LDKCResult_PaymentSecretNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentSecretNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentSecretNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18105,8 +18166,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIEr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentSecretAPIErrorZ* o_conv = (LDKCResult_PaymentSecretAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentSecretAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentSecretAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18125,8 +18186,8 @@ static inline uintptr_t CResult_PaymentSecretAPIErrorZ_clone_ptr(LDKCResult_Paym
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentSecretAPIErrorZ* arg_conv = (LDKCResult_PaymentSecretAPIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentSecretAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentSecretAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18157,8 +18218,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPI
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentPreimageAPIErrorZ* o_conv = (LDKCResult_PaymentPreimageAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentPreimageAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentPreimageAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18177,8 +18238,8 @@ static inline uintptr_t CResult_PaymentPreimageAPIErrorZ_clone_ptr(LDKCResult_Pa
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentPreimageAPIErrorZ* arg_conv = (LDKCResult_PaymentPreimageAPIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentPreimageAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentPreimageAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18212,8 +18273,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwar
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwardingInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CounterpartyForwardingInfoDecodeErrorZ* o_conv = (LDKCResult_CounterpartyForwardingInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwardingInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18232,8 +18293,8 @@ static inline uintptr_t CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwardingInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CounterpartyForwardingInfoDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyForwardingInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwardingInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18267,8 +18328,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpart
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpartyDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelCounterpartyDecodeErrorZ* o_conv = (LDKCResult_ChannelCounterpartyDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelCounterpartyDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelCounterpartyDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpartyDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18287,8 +18348,8 @@ static inline uintptr_t CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(LDKCRe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpartyDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelCounterpartyDecodeErrorZ* arg_conv = (LDKCResult_ChannelCounterpartyDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpartyDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18322,8 +18383,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelDetailsDecodeErrorZ* o_conv = (LDKCResult_ChannelDetailsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelDetailsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelDetailsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18342,8 +18403,8 @@ static inline uintptr_t CResult_ChannelDetailsDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelDetailsDecodeErrorZ* arg_conv = (LDKCResult_ChannelDetailsDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelDetailsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelDetailsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18377,8 +18438,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PhantomRouteHintsDecodeErrorZ* o_conv = (LDKCResult_PhantomRouteHintsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PhantomRouteHintsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PhantomRouteHintsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18397,8 +18458,8 @@ static inline uintptr_t CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PhantomRouteHintsDecodeErrorZ* arg_conv = (LDKCResult_PhantomRouteHintsDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18474,8 +18535,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHash
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelManagerZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ* o_conv = (LDKCResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelManagerZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18511,8 +18572,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelConfigDecodeErrorZ* o_conv = (LDKCResult_ChannelConfigDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelConfigDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelConfigDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18531,8 +18592,8 @@ static inline uintptr_t CResult_ChannelConfigDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelConfigDecodeErrorZ* arg_conv = (LDKCResult_ChannelConfigDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelConfigDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelConfigDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18566,8 +18627,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_OutPointDecodeErrorZ* o_conv = (LDKCResult_OutPointDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_OutPointDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_OutPointDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18586,8 +18647,8 @@ static inline uintptr_t CResult_OutPointDecodeErrorZ_clone_ptr(LDKCResult_OutPoi
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_OutPointDecodeErrorZ* arg_conv = (LDKCResult_OutPointDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_OutPointDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_OutPointDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18635,8 +18696,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1TypeZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_TypeZ* arg_conv = (LDKCOption_TypeZ*)arg;
-	int64_t ret_val = COption_TypeZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_TypeZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1TypeZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18670,8 +18731,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_TypeZDecodeErrorZ* o_conv = (LDKCResult_COption_TypeZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_TypeZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_TypeZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18690,8 +18751,8 @@ static inline uintptr_t CResult_COption_TypeZDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_TypeZDecodeErrorZ* arg_conv = (LDKCResult_COption_TypeZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_TypeZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_TypeZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18722,8 +18783,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentEr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentIdPaymentErrorZ* o_conv = (LDKCResult_PaymentIdPaymentErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentIdPaymentErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentIdPaymentErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18742,8 +18803,8 @@ static inline uintptr_t CResult_PaymentIdPaymentErrorZ_clone_ptr(LDKCResult_Paym
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentIdPaymentErrorZ* arg_conv = (LDKCResult_PaymentIdPaymentErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentIdPaymentErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentIdPaymentErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18772,8 +18833,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseError
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SiPrefixParseErrorZ* o_conv = (LDKCResult_SiPrefixParseErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SiPrefixParseErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SiPrefixParseErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18792,8 +18853,8 @@ static inline uintptr_t CResult_SiPrefixParseErrorZ_clone_ptr(LDKCResult_SiPrefi
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SiPrefixParseErrorZ* arg_conv = (LDKCResult_SiPrefixParseErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SiPrefixParseErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SiPrefixParseErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18826,8 +18887,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSema
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSemanticErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InvoiceParseOrSemanticErrorZ* o_conv = (LDKCResult_InvoiceParseOrSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceParseOrSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceParseOrSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSemanticErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18846,8 +18907,8 @@ static inline uintptr_t CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSemanticErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InvoiceParseOrSemanticErrorZ* arg_conv = (LDKCResult_InvoiceParseOrSemanticErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSemanticErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18880,8 +18941,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoicePa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoiceParseErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SignedRawInvoiceParseErrorZ* o_conv = (LDKCResult_SignedRawInvoiceParseErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SignedRawInvoiceParseErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignedRawInvoiceParseErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoiceParseErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18900,8 +18961,8 @@ static inline uintptr_t CResult_SignedRawInvoiceParseErrorZ_clone_ptr(LDKCResult
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoiceParseErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SignedRawInvoiceParseErrorZ* arg_conv = (LDKCResult_SignedRawInvoiceParseErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SignedRawInvoiceParseErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SignedRawInvoiceParseErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoiceParseErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18918,8 +18979,8 @@ static inline uintptr_t C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(LDKC3
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C3Tuple_1RawInvoice_1u832InvoiceSignatureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC3Tuple_RawInvoice_u832InvoiceSignatureZ* arg_conv = (LDKC3Tuple_RawInvoice_u832InvoiceSignatureZ*)(arg & ~1);
-	int64_t ret_val = C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C3Tuple_1RawInvoice_1u832InvoiceSignatureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18977,8 +19038,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PayeePubKeyErrorZ* o_conv = (LDKCResult_PayeePubKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PayeePubKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PayeePubKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18997,8 +19058,8 @@ static inline uintptr_t CResult_PayeePubKeyErrorZ_clone_ptr(LDKCResult_PayeePubK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PayeePubKeyErrorZ* arg_conv = (LDKCResult_PayeePubKeyErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PayeePubKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PayeePubKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19048,8 +19109,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampC
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampCreationErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PositiveTimestampCreationErrorZ* o_conv = (LDKCResult_PositiveTimestampCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PositiveTimestampCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PositiveTimestampCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampCreationErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19068,8 +19129,8 @@ static inline uintptr_t CResult_PositiveTimestampCreationErrorZ_clone_ptr(LDKCRe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampCreationErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PositiveTimestampCreationErrorZ* arg_conv = (LDKCResult_PositiveTimestampCreationErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PositiveTimestampCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PositiveTimestampCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampCreationErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19094,8 +19155,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneSemanticErrorZ* o_conv = (LDKCResult_NoneSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19114,8 +19175,8 @@ static inline uintptr_t CResult_NoneSemanticErrorZ_clone_ptr(LDKCResult_NoneSema
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneSemanticErrorZ* arg_conv = (LDKCResult_NoneSemanticErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19145,8 +19206,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InvoiceSemanticErrorZ* o_conv = (LDKCResult_InvoiceSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19165,8 +19226,8 @@ static inline uintptr_t CResult_InvoiceSemanticErrorZ_clone_ptr(LDKCResult_Invoi
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InvoiceSemanticErrorZ* arg_conv = (LDKCResult_InvoiceSemanticErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InvoiceSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InvoiceSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19196,8 +19257,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreatio
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreationErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_DescriptionCreationErrorZ* o_conv = (LDKCResult_DescriptionCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_DescriptionCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_DescriptionCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreationErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19216,8 +19277,8 @@ static inline uintptr_t CResult_DescriptionCreationErrorZ_clone_ptr(LDKCResult_D
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreationErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_DescriptionCreationErrorZ* arg_conv = (LDKCResult_DescriptionCreationErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_DescriptionCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_DescriptionCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreationErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19247,8 +19308,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreati
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreationErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PrivateRouteCreationErrorZ* o_conv = (LDKCResult_PrivateRouteCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PrivateRouteCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PrivateRouteCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreationErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19267,8 +19328,8 @@ static inline uintptr_t CResult_PrivateRouteCreationErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreationErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PrivateRouteCreationErrorZ* arg_conv = (LDKCResult_PrivateRouteCreationErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PrivateRouteCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PrivateRouteCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreationErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19294,8 +19355,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1StringErrorZ_1err(
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1StringErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_StringErrorZ* o_conv = (LDKCResult_StringErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_StringErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_StringErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1StringErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19331,8 +19392,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpda
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpdateDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelMonitorUpdateDecodeErrorZ* o_conv = (LDKCResult_ChannelMonitorUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpdateDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19351,8 +19412,8 @@ static inline uintptr_t CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(LDKCR
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpdateDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelMonitorUpdateDecodeErrorZ* arg_conv = (LDKCResult_ChannelMonitorUpdateDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpdateDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19397,8 +19458,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1MonitorEventZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_MonitorEventZ* arg_conv = (LDKCOption_MonitorEventZ*)arg;
-	int64_t ret_val = COption_MonitorEventZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_MonitorEventZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1MonitorEventZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19432,8 +19493,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEv
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEventZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* o_conv = (LDKCResult_COption_MonitorEventZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_MonitorEventZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_MonitorEventZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEventZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19452,8 +19513,8 @@ static inline uintptr_t CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEventZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* arg_conv = (LDKCResult_COption_MonitorEventZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEventZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19487,8 +19548,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeEr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_HTLCUpdateDecodeErrorZ* o_conv = (LDKCResult_HTLCUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HTLCUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HTLCUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19507,8 +19568,8 @@ static inline uintptr_t CResult_HTLCUpdateDecodeErrorZ_clone_ptr(LDKCResult_HTLC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_HTLCUpdateDecodeErrorZ* arg_conv = (LDKCResult_HTLCUpdateDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_HTLCUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_HTLCUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19525,8 +19586,8 @@ static inline uintptr_t C2Tuple_OutPointScriptZ_clone_ptr(LDKC2Tuple_OutPointScr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1OutPointScriptZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_OutPointScriptZ* arg_conv = (LDKC2Tuple_OutPointScriptZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_OutPointScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_OutPointScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1OutPointScriptZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19567,8 +19628,8 @@ static inline uintptr_t C2Tuple_u32ScriptZ_clone_ptr(LDKC2Tuple_u32ScriptZ *NONN
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32ScriptZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_u32ScriptZ* arg_conv = (LDKC2Tuple_u32ScriptZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_u32ScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_u32ScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32ScriptZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19624,8 +19685,8 @@ static inline uintptr_t C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(LDKC2Tup
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1TxidCVec_1C2Tuple_1u32ScriptZZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ* arg_conv = (LDKC2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1TxidCVec_1C2Tuple_1u32ScriptZZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19735,8 +19796,8 @@ static inline uintptr_t C2Tuple_u32TxOutZ_clone_ptr(LDKC2Tuple_u32TxOutZ *NONNUL
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32TxOutZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_u32TxOutZ* arg_conv = (LDKC2Tuple_u32TxOutZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_u32TxOutZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_u32TxOutZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32TxOutZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19792,8 +19853,8 @@ static inline uintptr_t C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(LDKC2Tupl
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1TxidCVec_1C2Tuple_1u32TxOutZZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ* arg_conv = (LDKC2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1TxidCVec_1C2Tuple_1u32TxOutZZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19900,8 +19961,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHash
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelMonitorZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ* o_conv = (LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelMonitorZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19920,8 +19981,8 @@ static inline uintptr_t CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clo
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelMonitorZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ* arg_conv = (LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelMonitorZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19950,8 +20011,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningError
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneLightningErrorZ* o_conv = (LDKCResult_NoneLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19970,8 +20031,8 @@ static inline uintptr_t CResult_NoneLightningErrorZ_clone_ptr(LDKCResult_NoneLig
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneLightningErrorZ* arg_conv = (LDKCResult_NoneLightningErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19988,8 +20049,8 @@ static inline uintptr_t C2Tuple_PublicKeyTypeZ_clone_ptr(LDKC2Tuple_PublicKeyTyp
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PublicKeyTypeZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_PublicKeyTypeZ* arg_conv = (LDKC2Tuple_PublicKeyTypeZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_PublicKeyTypeZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_PublicKeyTypeZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PublicKeyTypeZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20063,8 +20124,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningError
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_boolLightningErrorZ* o_conv = (LDKCResult_boolLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_boolLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20083,8 +20144,8 @@ static inline uintptr_t CResult_boolLightningErrorZ_clone_ptr(LDKCResult_boolLig
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_boolLightningErrorZ* arg_conv = (LDKCResult_boolLightningErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_boolLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_boolLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20101,8 +20162,8 @@ static inline uintptr_t C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_c
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C3Tuple_1ChannelAnnouncementChannelUpdateChannelUpdateZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ* arg_conv = (LDKC3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ*)(arg & ~1);
-	int64_t ret_val = C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C3Tuple_1ChannelAnnouncementChannelUpdateChannelUpdateZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20234,8 +20295,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1NetAddressZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_NetAddressZ* arg_conv = (LDKCOption_NetAddressZ*)arg;
-	int64_t ret_val = COption_NetAddressZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_NetAddressZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1NetAddressZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20269,8 +20330,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandl
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandleErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CVec_u8ZPeerHandleErrorZ* o_conv = (LDKCResult_CVec_u8ZPeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_u8ZPeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_u8ZPeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandleErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20289,8 +20350,8 @@ static inline uintptr_t CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(LDKCResult_CV
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandleErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CVec_u8ZPeerHandleErrorZ* arg_conv = (LDKCResult_CVec_u8ZPeerHandleErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandleErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20319,8 +20380,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NonePeerHandleErrorZ* o_conv = (LDKCResult_NonePeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NonePeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NonePeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20339,8 +20400,8 @@ static inline uintptr_t CResult_NonePeerHandleErrorZ_clone_ptr(LDKCResult_NonePe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NonePeerHandleErrorZ* arg_conv = (LDKCResult_NonePeerHandleErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NonePeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NonePeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20369,8 +20430,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_boolPeerHandleErrorZ* o_conv = (LDKCResult_boolPeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_boolPeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolPeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20389,8 +20450,8 @@ static inline uintptr_t CResult_boolPeerHandleErrorZ_clone_ptr(LDKCResult_boolPe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_boolPeerHandleErrorZ* arg_conv = (LDKCResult_boolPeerHandleErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_boolPeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_boolPeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20424,8 +20485,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeIdDecodeErrorZ* o_conv = (LDKCResult_NodeIdDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeIdDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeIdDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20444,8 +20505,8 @@ static inline uintptr_t CResult_NodeIdDecodeErrorZ_clone_ptr(LDKCResult_NodeIdDe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NodeIdDecodeErrorZ* arg_conv = (LDKCResult_NodeIdDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NodeIdDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NodeIdDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20478,8 +20539,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUp
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUpdateZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_NetworkUpdateZDecodeErrorZ* o_conv = (LDKCResult_COption_NetworkUpdateZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUpdateZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20498,8 +20559,8 @@ static inline uintptr_t CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(LDK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUpdateZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_NetworkUpdateZDecodeErrorZ* arg_conv = (LDKCResult_COption_NetworkUpdateZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUpdateZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20563,8 +20624,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelUpdateInfoDecodeErrorZ* o_conv = (LDKCResult_ChannelUpdateInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20583,8 +20644,8 @@ static inline uintptr_t CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelUpdateInfoDecodeErrorZ* arg_conv = (LDKCResult_ChannelUpdateInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20618,8 +20679,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeE
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelInfoDecodeErrorZ* o_conv = (LDKCResult_ChannelInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20638,8 +20699,8 @@ static inline uintptr_t CResult_ChannelInfoDecodeErrorZ_clone_ptr(LDKCResult_Cha
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelInfoDecodeErrorZ* arg_conv = (LDKCResult_ChannelInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20673,8 +20734,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeE
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RoutingFeesDecodeErrorZ* o_conv = (LDKCResult_RoutingFeesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RoutingFeesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RoutingFeesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20693,8 +20754,8 @@ static inline uintptr_t CResult_RoutingFeesDecodeErrorZ_clone_ptr(LDKCResult_Rou
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RoutingFeesDecodeErrorZ* arg_conv = (LDKCResult_RoutingFeesDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RoutingFeesDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RoutingFeesDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20728,8 +20789,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementIn
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeAnnouncementInfoDecodeErrorZ* o_conv = (LDKCResult_NodeAnnouncementInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20748,8 +20809,8 @@ static inline uintptr_t CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(LDKCR
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NodeAnnouncementInfoDecodeErrorZ* arg_conv = (LDKCResult_NodeAnnouncementInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20799,8 +20860,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeInfoDecodeErrorZ* o_conv = (LDKCResult_NodeInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20819,8 +20880,8 @@ static inline uintptr_t CResult_NodeInfoDecodeErrorZ_clone_ptr(LDKCResult_NodeIn
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NodeInfoDecodeErrorZ* arg_conv = (LDKCResult_NodeInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NodeInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NodeInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20854,8 +20915,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NetworkGraphDecodeErrorZ* o_conv = (LDKCResult_NetworkGraphDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NetworkGraphDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NetworkGraphDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20874,8 +20935,8 @@ static inline uintptr_t CResult_NetworkGraphDecodeErrorZ_clone_ptr(LDKCResult_Ne
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NetworkGraphDecodeErrorZ* arg_conv = (LDKCResult_NetworkGraphDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NetworkGraphDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NetworkGraphDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20932,8 +20993,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1CVec_1NetAddressZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_CVec_NetAddressZZ* arg_conv = (LDKCOption_CVec_NetAddressZZ*)arg;
-	int64_t ret_val = COption_CVec_NetAddressZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_CVec_NetAddressZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1CVec_1NetAddressZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20967,8 +21028,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeEr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NetAddressDecodeErrorZ* o_conv = (LDKCResult_NetAddressDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NetAddressDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NetAddressDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20987,8 +21048,8 @@ static inline uintptr_t CResult_NetAddressDecodeErrorZ_clone_ptr(LDKCResult_NetA
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NetAddressDecodeErrorZ* arg_conv = (LDKCResult_NetAddressDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NetAddressDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NetAddressDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21102,8 +21163,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_AcceptChannelDecodeErrorZ* o_conv = (LDKCResult_AcceptChannelDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_AcceptChannelDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_AcceptChannelDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21122,8 +21183,8 @@ static inline uintptr_t CResult_AcceptChannelDecodeErrorZ_clone_ptr(LDKCResult_A
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_AcceptChannelDecodeErrorZ* arg_conv = (LDKCResult_AcceptChannelDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_AcceptChannelDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_AcceptChannelDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21157,8 +21218,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignat
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_AnnouncementSignaturesDecodeErrorZ* o_conv = (LDKCResult_AnnouncementSignaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21177,8 +21238,8 @@ static inline uintptr_t CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(LDK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignaturesDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_AnnouncementSignaturesDecodeErrorZ* arg_conv = (LDKCResult_AnnouncementSignaturesDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignaturesDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21212,8 +21273,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablish
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablishDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelReestablishDecodeErrorZ* o_conv = (LDKCResult_ChannelReestablishDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelReestablishDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelReestablishDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablishDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21232,8 +21293,8 @@ static inline uintptr_t CResult_ChannelReestablishDecodeErrorZ_clone_ptr(LDKCRes
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablishDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelReestablishDecodeErrorZ* arg_conv = (LDKCResult_ChannelReestablishDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelReestablishDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelReestablishDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablishDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21267,8 +21328,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ClosingSignedDecodeErrorZ* o_conv = (LDKCResult_ClosingSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ClosingSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ClosingSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21287,8 +21348,8 @@ static inline uintptr_t CResult_ClosingSignedDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ClosingSignedDecodeErrorZ* arg_conv = (LDKCResult_ClosingSignedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ClosingSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ClosingSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21322,8 +21383,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRangeDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ClosingSignedFeeRangeDecodeErrorZ* o_conv = (LDKCResult_ClosingSignedFeeRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRangeDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21342,8 +21403,8 @@ static inline uintptr_t CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRangeDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ClosingSignedFeeRangeDecodeErrorZ* arg_conv = (LDKCResult_ClosingSignedFeeRangeDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRangeDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21377,8 +21438,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDe
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CommitmentSignedDecodeErrorZ* o_conv = (LDKCResult_CommitmentSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CommitmentSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CommitmentSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21397,8 +21458,8 @@ static inline uintptr_t CResult_CommitmentSignedDecodeErrorZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CommitmentSignedDecodeErrorZ* arg_conv = (LDKCResult_CommitmentSignedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CommitmentSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CommitmentSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21432,8 +21493,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_FundingCreatedDecodeErrorZ* o_conv = (LDKCResult_FundingCreatedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingCreatedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingCreatedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21452,8 +21513,8 @@ static inline uintptr_t CResult_FundingCreatedDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_FundingCreatedDecodeErrorZ* arg_conv = (LDKCResult_FundingCreatedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_FundingCreatedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_FundingCreatedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21487,8 +21548,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_FundingSignedDecodeErrorZ* o_conv = (LDKCResult_FundingSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21507,8 +21568,8 @@ static inline uintptr_t CResult_FundingSignedDecodeErrorZ_clone_ptr(LDKCResult_F
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_FundingSignedDecodeErrorZ* arg_conv = (LDKCResult_FundingSignedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_FundingSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_FundingSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21542,8 +21603,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_FundingLockedDecodeErrorZ* o_conv = (LDKCResult_FundingLockedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingLockedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingLockedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21562,8 +21623,8 @@ static inline uintptr_t CResult_FundingLockedDecodeErrorZ_clone_ptr(LDKCResult_F
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_FundingLockedDecodeErrorZ* arg_conv = (LDKCResult_FundingLockedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_FundingLockedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_FundingLockedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21597,8 +21658,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InitDecodeErrorZ* o_conv = (LDKCResult_InitDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InitDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InitDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21617,8 +21678,8 @@ static inline uintptr_t CResult_InitDecodeErrorZ_clone_ptr(LDKCResult_InitDecode
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InitDecodeErrorZ* arg_conv = (LDKCResult_InitDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InitDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InitDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21652,8 +21713,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeE
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_OpenChannelDecodeErrorZ* o_conv = (LDKCResult_OpenChannelDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_OpenChannelDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_OpenChannelDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21672,8 +21733,8 @@ static inline uintptr_t CResult_OpenChannelDecodeErrorZ_clone_ptr(LDKCResult_Ope
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_OpenChannelDecodeErrorZ* arg_conv = (LDKCResult_OpenChannelDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_OpenChannelDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_OpenChannelDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21707,8 +21768,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RevokeAndACKDecodeErrorZ* o_conv = (LDKCResult_RevokeAndACKDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RevokeAndACKDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RevokeAndACKDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21727,8 +21788,8 @@ static inline uintptr_t CResult_RevokeAndACKDecodeErrorZ_clone_ptr(LDKCResult_Re
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RevokeAndACKDecodeErrorZ* arg_conv = (LDKCResult_RevokeAndACKDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RevokeAndACKDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RevokeAndACKDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21762,8 +21823,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ShutdownDecodeErrorZ* o_conv = (LDKCResult_ShutdownDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21782,8 +21843,8 @@ static inline uintptr_t CResult_ShutdownDecodeErrorZ_clone_ptr(LDKCResult_Shutdo
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ShutdownDecodeErrorZ* arg_conv = (LDKCResult_ShutdownDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ShutdownDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ShutdownDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21817,8 +21878,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateFailHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFailHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFailHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFailHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21837,8 +21898,8 @@ static inline uintptr_t CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateFailHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFailHTLCDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21872,8 +21933,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalforme
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalformedHTLCDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalformedHTLCDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21892,8 +21953,8 @@ static inline uintptr_t CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(LD
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalformedHTLCDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalformedHTLCDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21927,8 +21988,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateFeeDecodeErrorZ* o_conv = (LDKCResult_UpdateFeeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFeeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFeeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21947,8 +22008,8 @@ static inline uintptr_t CResult_UpdateFeeDecodeErrorZ_clone_ptr(LDKCResult_Updat
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateFeeDecodeErrorZ* arg_conv = (LDKCResult_UpdateFeeDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateFeeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateFeeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21982,8 +22043,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateFulfillHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFulfillHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22002,8 +22063,8 @@ static inline uintptr_t CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateFulfillHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFulfillHTLCDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22037,8 +22098,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateAddHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateAddHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateAddHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateAddHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22057,8 +22118,8 @@ static inline uintptr_t CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(LDKCResult_U
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateAddHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateAddHTLCDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22092,8 +22153,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PingDecodeErrorZ* o_conv = (LDKCResult_PingDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PingDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PingDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22112,8 +22173,8 @@ static inline uintptr_t CResult_PingDecodeErrorZ_clone_ptr(LDKCResult_PingDecode
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PingDecodeErrorZ* arg_conv = (LDKCResult_PingDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PingDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PingDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22147,8 +22208,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PongDecodeErrorZ* o_conv = (LDKCResult_PongDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PongDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PongDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22167,8 +22228,8 @@ static inline uintptr_t CResult_PongDecodeErrorZ_clone_ptr(LDKCResult_PongDecode
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PongDecodeErrorZ* arg_conv = (LDKCResult_PongDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PongDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PongDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22202,8 +22263,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnn
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnnouncementDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ* o_conv = (LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnnouncementDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22222,8 +22283,8 @@ static inline uintptr_t CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_pt
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnnouncementDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnnouncementDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22257,8 +22318,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncemen
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncementDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelAnnouncementDecodeErrorZ* o_conv = (LDKCResult_ChannelAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncementDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22277,8 +22338,8 @@ static inline uintptr_t CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(LDKCRe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncementDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_ChannelAnnouncementDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncementDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22312,8 +22373,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpd
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpdateDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UnsignedChannelUpdateDecodeErrorZ* o_conv = (LDKCResult_UnsignedChannelUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpdateDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22332,8 +22393,8 @@ static inline uintptr_t CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpdateDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UnsignedChannelUpdateDecodeErrorZ* arg_conv = (LDKCResult_UnsignedChannelUpdateDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpdateDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22367,8 +22428,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelUpdateDecodeErrorZ* o_conv = (LDKCResult_ChannelUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22387,8 +22448,8 @@ static inline uintptr_t CResult_ChannelUpdateDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelUpdateDecodeErrorZ* arg_conv = (LDKCResult_ChannelUpdateDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22422,8 +22483,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ErrorMessageDecodeErrorZ* o_conv = (LDKCResult_ErrorMessageDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ErrorMessageDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ErrorMessageDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22442,8 +22503,8 @@ static inline uintptr_t CResult_ErrorMessageDecodeErrorZ_clone_ptr(LDKCResult_Er
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ErrorMessageDecodeErrorZ* arg_conv = (LDKCResult_ErrorMessageDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ErrorMessageDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ErrorMessageDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22477,8 +22538,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_WarningMessageDecodeErrorZ* o_conv = (LDKCResult_WarningMessageDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_WarningMessageDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_WarningMessageDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22497,8 +22558,8 @@ static inline uintptr_t CResult_WarningMessageDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_WarningMessageDecodeErrorZ* arg_conv = (LDKCResult_WarningMessageDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_WarningMessageDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_WarningMessageDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22532,8 +22593,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnoun
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnouncementDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* o_conv = (LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnouncementDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22552,8 +22613,8 @@ static inline uintptr_t CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(L
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnouncementDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnouncementDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22587,8 +22648,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDe
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeAnnouncementDecodeErrorZ* o_conv = (LDKCResult_NodeAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22607,8 +22668,8 @@ static inline uintptr_t CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NodeAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_NodeAnnouncementDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22642,8 +22703,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelI
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelIdsDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_QueryShortChannelIdsDecodeErrorZ* o_conv = (LDKCResult_QueryShortChannelIdsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelIdsDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22662,8 +22723,8 @@ static inline uintptr_t CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(LDKCR
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelIdsDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_QueryShortChannelIdsDecodeErrorZ* arg_conv = (LDKCResult_QueryShortChannelIdsDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelIdsDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22697,8 +22758,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelI
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelIdsEndDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ* o_conv = (LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelIdsEndDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22717,8 +22778,8 @@ static inline uintptr_t CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(LD
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelIdsEndDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ* arg_conv = (LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelIdsEndDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22752,8 +22813,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_QueryChannelRangeDecodeErrorZ* o_conv = (LDKCResult_QueryChannelRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_QueryChannelRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_QueryChannelRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22772,8 +22833,8 @@ static inline uintptr_t CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_QueryChannelRangeDecodeErrorZ* arg_conv = (LDKCResult_QueryChannelRangeDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22807,8 +22868,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ReplyChannelRangeDecodeErrorZ* o_conv = (LDKCResult_ReplyChannelRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ReplyChannelRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ReplyChannelRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22827,8 +22888,8 @@ static inline uintptr_t CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ReplyChannelRangeDecodeErrorZ* arg_conv = (LDKCResult_ReplyChannelRangeDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22862,8 +22923,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFil
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFilterDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_GossipTimestampFilterDecodeErrorZ* o_conv = (LDKCResult_GossipTimestampFilterDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_GossipTimestampFilterDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_GossipTimestampFilterDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFilterDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22882,8 +22943,8 @@ static inline uintptr_t CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFilterDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_GossipTimestampFilterDecodeErrorZ* arg_conv = (LDKCResult_GossipTimestampFilterDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFilterDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22936,8 +22997,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreat
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreationErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InvoiceSignOrCreationErrorZ* o_conv = (LDKCResult_InvoiceSignOrCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceSignOrCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceSignOrCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreationErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22956,8 +23017,8 @@ static inline uintptr_t CResult_InvoiceSignOrCreationErrorZ_clone_ptr(LDKCResult
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreationErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InvoiceSignOrCreationErrorZ* arg_conv = (LDKCResult_InvoiceSignOrCreationErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InvoiceSignOrCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InvoiceSignOrCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreationErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23016,8 +23077,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1LockedChannelMonit
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1LockedChannelMonitorNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_LockedChannelMonitorNoneZ* o_conv = (LDKCResult_LockedChannelMonitorNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_LockedChannelMonitorNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_LockedChannelMonitorNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1LockedChannelMonitorNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -23066,8 +23127,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentPurpose_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKPaymentPurpose* arg_conv = (LDKPaymentPurpose*)arg;
-	int64_t ret_val = PaymentPurpose_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentPurpose_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentPurpose_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23118,8 +23179,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosureReason_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKClosureReason* arg_conv = (LDKClosureReason*)arg;
-	int64_t ret_val = ClosureReason_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosureReason_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosureReason_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23224,8 +23285,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Event_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKEvent* arg_conv = (LDKEvent*)arg;
-	int64_t ret_val = Event_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Event_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Event_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23494,8 +23555,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MessageSendEvent_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKMessageSendEvent* arg_conv = (LDKMessageSendEvent*)arg;
-	int64_t ret_val = MessageSendEvent_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = MessageSendEvent_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MessageSendEvent_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23845,8 +23906,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_APIError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKAPIError* arg_conv = (LDKAPIError*)arg;
-	int64_t ret_val = APIError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = APIError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_APIError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23941,9 +24002,9 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_verify(JNIEnv *env, jclass
 	LDKPublicKey pk_ref;
 	CHECK((*env)->GetArrayLength(env, pk) == 33);
 	(*env)->GetByteArrayRegion(env, pk, 0, 33, pk_ref.compressed_form);
-	jboolean ret_val = verify(msg_ref, sig_conv, pk_ref);
+	jboolean ret_conv = verify(msg_ref, sig_conv, pk_ref);
 	(*env)->ReleaseByteArrayElements(env, msg, (int8_t*)msg_ref.data, 0);
-	return ret_val;
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_construct_1invoice_1preimage(JNIEnv *env, jclass clz, int8_tArray hrp_bytes, jobjectArray data_without_signature) {
@@ -24010,14 +24071,14 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_Level_1error(JNIEnv *env, jc
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Level_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKLevel* a_conv = (LDKLevel*)(a & ~1);
 	LDKLevel* b_conv = (LDKLevel*)(b & ~1);
-	jboolean ret_val = Level_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Level_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Level_1hash(JNIEnv *env, jclass clz, int64_t o) {
 	LDKLevel* o_conv = (LDKLevel*)(o & ~1);
-	int64_t ret_val = Level_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Level_hash(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_Level_1max(JNIEnv *env, jclass clz) {
@@ -24116,8 +24177,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_Record_1get_1line(JNIEnv *e
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = Record_get_line(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = Record_get_line(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Record_1set_1line(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24145,8 +24206,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Record_1clone_1ptr(JNIEnv *
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Record_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Record_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Record_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24188,8 +24249,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelHandshakeConfig_get_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelHandshakeConfig_get_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1set_1minimum_1depth(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24205,8 +24266,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeConfig_get_our_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeConfig_get_our_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1set_1our_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -24222,8 +24283,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeConfig_get_our_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeConfig_get_our_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1set_1our_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24239,8 +24300,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelHandshakeConfig_get_negotiate_scid_privacy(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelHandshakeConfig_get_negotiate_scid_privacy(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1set_1negotiate_1scid_1privacy(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24281,8 +24342,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelHandshakeConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24328,8 +24389,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_min_funding_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_min_funding_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1min_1funding_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24345,8 +24406,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_max_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_max_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1max_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24362,8 +24423,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_min_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_min_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1min_1max_1htlc_1value_1in_1flight_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24379,8 +24440,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_max_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_max_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1max_1channel_1reserve_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24396,8 +24457,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeLimits_get_min_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeLimits_get_min_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1min_1max_1accepted_1htlcs(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -24413,8 +24474,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelHandshakeLimits_get_max_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelHandshakeLimits_get_max_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1max_1minimum_1depth(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24430,8 +24491,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelHandshakeLimits_get_force_announced_channel_preference(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelHandshakeLimits_get_force_announced_channel_preference(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1force_1announced_1channel_1preference(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24447,8 +24508,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeLimits_get_their_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeLimits_get_their_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1their_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -24489,8 +24550,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelHandshakeLimits_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24536,8 +24597,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1forward
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelConfig_get_forwarding_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelConfig_get_forwarding_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1forwarding_1fee_1proportional_1millionths(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24553,8 +24614,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1forward
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelConfig_get_forwarding_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelConfig_get_forwarding_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1forwarding_1fee_1base_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24570,8 +24631,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1cltv_1e
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelConfig_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelConfig_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -24587,8 +24648,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1announ
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelConfig_get_announced_channel(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelConfig_get_announced_channel(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1announced_1channel(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24604,8 +24665,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1commit
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelConfig_get_commit_upfront_shutdown_pubkey(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelConfig_get_commit_upfront_shutdown_pubkey(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1commit_1upfront_1shutdown_1pubkey(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24621,8 +24682,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1max_1du
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelConfig_get_max_dust_htlc_exposure_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_get_max_dust_htlc_exposure_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1max_1dust_1htlc_1exposure_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24638,8 +24699,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1force_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelConfig_get_force_close_avoidance_max_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_get_force_close_avoidance_max_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1force_1close_1avoidance_1max_1fee_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24680,8 +24741,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24839,8 +24900,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_UserConfig_1get_1accept_1f
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_accept_forwards_to_priv_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_accept_forwards_to_priv_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UserConfig_1set_1accept_1forwards_1to_1priv_1channels(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24856,8 +24917,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_UserConfig_1get_1accept_1i
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_accept_inbound_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_accept_inbound_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UserConfig_1set_1accept_1inbound_1channels(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24873,8 +24934,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_UserConfig_1get_1manually_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_manually_accept_inbound_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_manually_accept_inbound_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UserConfig_1set_1manually_1accept_1inbound_1channels(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24930,8 +24991,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UserConfig_1clone_1ptr(JNIE
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UserConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UserConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UserConfig_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24989,8 +25050,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_BestBlock_1clone_1ptr(JNIEn
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = BestBlock_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = BestBlock_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_BestBlock_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25055,8 +25116,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_BestBlock_1height(JNIEnv *e
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = BestBlock_height(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = BestBlock_height(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_AccessError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25260,8 +25321,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WatchedOutput_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = WatchedOutput_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = WatchedOutput_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WatchedOutput_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25286,8 +25347,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WatchedOutput_1hash(JNIEnv 
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = WatchedOutput_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = WatchedOutput_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_BroadcasterInterface_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -25323,8 +25384,8 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_ConfirmationTarget_1high_1pr
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ConfirmationTarget_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKConfirmationTarget* a_conv = (LDKConfirmationTarget*)(a & ~1);
 	LDKConfirmationTarget* b_conv = (LDKConfirmationTarget*)(b & ~1);
-	jboolean ret_val = ConfirmationTarget_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = ConfirmationTarget_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_FeeEstimator_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -25361,8 +25422,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = MonitorUpdateId_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = MonitorUpdateId_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25387,8 +25448,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1hash(JNIEn
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = MonitorUpdateId_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = MonitorUpdateId_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -25400,8 +25461,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1eq(JNIEnv
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = MonitorUpdateId_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = MonitorUpdateId_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Persist_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -25632,8 +25693,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitorUpdate_1get_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelMonitorUpdate_get_update_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitorUpdate_get_update_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelMonitorUpdate_1set_1update_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -25661,8 +25722,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitorUpdate_1clone
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelMonitorUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitorUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitorUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25721,8 +25782,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorEvent_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKMonitorEvent* arg_conv = (LDKMonitorEvent*)arg;
-	int64_t ret_val = MonitorEvent_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = MonitorEvent_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorEvent_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25825,8 +25886,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCUpdate_1clone_1ptr(JNIE
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = HTLCUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = HTLCUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25885,8 +25946,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Balance_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKBalance* arg_conv = (LDKBalance*)arg;
-	int64_t ret_val = Balance_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Balance_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Balance_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25928,8 +25989,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Balance_1maybe_1claimable_1
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Balance_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKBalance* a_conv = (LDKBalance*)a;
 	LDKBalance* b_conv = (LDKBalance*)b;
-	jboolean ret_val = Balance_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Balance_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -25957,8 +26018,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelMonitor_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -26018,8 +26079,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1get_1latest
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ChannelMonitor_get_latest_update_id(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitor_get_latest_update_id(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1get_1funding_1txo(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -26459,8 +26520,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1get_1index(JNIEnv
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OutPoint_get_index(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OutPoint_get_index(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OutPoint_1set_1index(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -26504,8 +26565,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1clone_1ptr(JNIEnv
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = OutPoint_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = OutPoint_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -26534,8 +26595,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_OutPoint_1eq(JNIEnv *env, 
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = OutPoint_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = OutPoint_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1hash(JNIEnv *env, jclass clz, int64_t o) {
@@ -26543,8 +26604,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1hash(JNIEnv *env,
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = OutPoint_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = OutPoint_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_OutPoint_1to_1channel_1id(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -26643,8 +26704,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescrip
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = DelayedPaymentOutputDescriptor_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = DelayedPaymentOutputDescriptor_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescriptor_1set_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -26714,8 +26775,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescrip
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = DelayedPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = DelayedPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescriptor_1set_1channel_1value_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -26774,8 +26835,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescrip
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = DelayedPaymentOutputDescriptor_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = DelayedPaymentOutputDescriptor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescriptor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -26893,8 +26954,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_StaticPaymentOutputDescript
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = StaticPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = StaticPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_StaticPaymentOutputDescriptor_1set_1channel_1value_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -26947,8 +27008,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_StaticPaymentOutputDescript
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = StaticPaymentOutputDescriptor_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = StaticPaymentOutputDescriptor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_StaticPaymentOutputDescriptor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27007,8 +27068,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SpendableOutputDescriptor_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKSpendableOutputDescriptor* arg_conv = (LDKSpendableOutputDescriptor*)arg;
-	int64_t ret_val = SpendableOutputDescriptor_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = SpendableOutputDescriptor_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SpendableOutputDescriptor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27096,8 +27157,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sign_1clone_1ptr(JNIEnv *en
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKSign* arg_conv = (LDKSign*)arg_ptr;
-	int64_t ret_val = Sign_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Sign_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sign_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27294,8 +27355,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InMemorySigner_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InMemorySigner_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27374,8 +27435,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1counterpart
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = InMemorySigner_counterparty_selected_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = InMemorySigner_counterparty_selected_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1holder_1selected_1contest_1delay(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -27383,8 +27444,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1holder_1sel
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = InMemorySigner_holder_selected_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = InMemorySigner_holder_selected_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1is_1outbound(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -27392,8 +27453,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1is_1outbou
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InMemorySigner_is_outbound(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InMemorySigner_is_outbound(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1funding_1outpoint(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -27435,8 +27496,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1opt_1ancho
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InMemorySigner_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InMemorySigner_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1sign_1counterparty_1payment_1input(JNIEnv *env, jclass clz, int64_t this_arg, int8_tArray spend_tx, int64_t input_idx, int64_t descriptor) {
@@ -27830,8 +27891,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChainParameters_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChainParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChainParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChainParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27864,8 +27925,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = CounterpartyForwardingInfo_get_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = CounterpartyForwardingInfo_get_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_1set_1fee_1base_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -27881,8 +27942,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = CounterpartyForwardingInfo_get_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = CounterpartyForwardingInfo_get_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_1set_1fee_1proportional_1millionths(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -27898,8 +27959,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = CounterpartyForwardingInfo_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = CounterpartyForwardingInfo_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -27940,8 +28001,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CounterpartyForwardingInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyForwardingInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -28025,8 +28086,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelCounterparty_1get_1u
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelCounterparty_get_unspendable_punishment_reserve(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelCounterparty_get_unspendable_punishment_reserve(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelCounterparty_1set_1unspendable_1punishment_1reserve(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28112,8 +28173,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelCounterparty_1clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelCounterparty_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelCounterparty_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelCounterparty_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -28307,8 +28368,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1channe
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1channel_1value_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28347,8 +28408,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1user_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_user_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_user_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1user_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28364,8 +28425,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1balanc
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_balance_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_balance_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1balance_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28381,8 +28442,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1outbou
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_outbound_capacity_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_outbound_capacity_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1outbound_1capacity_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28398,8 +28459,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1inboun
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_inbound_capacity_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_inbound_capacity_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1inbound_1capacity_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28461,8 +28522,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1is_1o
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_outbound(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_outbound(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1is_1outbound(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -28478,8 +28539,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1is_1f
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_funding_locked(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_funding_locked(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1is_1funding_1locked(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -28495,8 +28556,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1is_1u
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_usable(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_usable(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1is_1usable(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -28512,8 +28573,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1is_1p
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_public(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_public(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1is_1public(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -28591,8 +28652,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelDetails_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -28640,8 +28701,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentSendFailure_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKPaymentSendFailure* arg_conv = (LDKPaymentSendFailure*)arg;
-	int64_t ret_val = PaymentSendFailure_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentSendFailure_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentSendFailure_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -28803,8 +28864,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PhantomRouteHints_1get_1pha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = PhantomRouteHints_get_phantom_scid(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = PhantomRouteHints_get_phantom_scid(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PhantomRouteHints_1set_1phantom_1scid(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28886,8 +28947,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PhantomRouteHints_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PhantomRouteHints_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PhantomRouteHints_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PhantomRouteHints_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -29240,8 +29301,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelManager_1fail_1htlc
 	CHECK((*env)->GetArrayLength(env, payment_hash) == 32);
 	(*env)->GetByteArrayRegion(env, payment_hash, 0, 32, payment_hash_arr);
 	unsigned char (*payment_hash_ref)[32] = &payment_hash_arr;
-	jboolean ret_val = ChannelManager_fail_htlc_backwards(&this_arg_conv, payment_hash_ref);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_fail_htlc_backwards(&this_arg_conv, payment_hash_ref);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelManager_1claim_1funds(JNIEnv *env, jclass clz, int64_t this_arg, int8_tArray payment_preimage) {
@@ -29252,8 +29313,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelManager_1claim_1fun
 	LDKThirtyTwoBytes payment_preimage_ref;
 	CHECK((*env)->GetArrayLength(env, payment_preimage) == 32);
 	(*env)->GetByteArrayRegion(env, payment_preimage, 0, 32, payment_preimage_ref.data);
-	jboolean ret_val = ChannelManager_claim_funds(&this_arg_conv, payment_preimage_ref);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_claim_funds(&this_arg_conv, payment_preimage_ref);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_ChannelManager_1get_1our_1node_1id(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -29363,8 +29424,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelManager_1get_1phanto
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ChannelManager_get_phantom_scid(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelManager_get_phantom_scid(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelManager_1get_1phantom_1route_1hints(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -29429,8 +29490,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelManager_1await_1per
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelManager_await_persistable_update_timeout(&this_arg_conv, max_wait);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_await_persistable_update_timeout(&this_arg_conv, max_wait);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelManager_1await_1persistable_1update(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -29840,8 +29901,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DecodeError_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = DecodeError_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = DecodeError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DecodeError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -29960,8 +30021,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Init_1clone_1ptr(JNIEnv *en
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Init_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Init_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Init_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30064,8 +30125,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ErrorMessage_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ErrorMessage_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ErrorMessage_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ErrorMessage_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30168,8 +30229,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WarningMessage_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = WarningMessage_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = WarningMessage_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WarningMessage_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30202,8 +30263,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_Ping_1get_1ponglen(JNIEnv *
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Ping_get_ponglen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Ping_get_ponglen(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Ping_1set_1ponglen(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30219,8 +30280,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_Ping_1get_1byteslen(JNIEnv 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Ping_get_byteslen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Ping_get_byteslen(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Ping_1set_1byteslen(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30261,8 +30322,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Ping_1clone_1ptr(JNIEnv *en
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Ping_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Ping_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Ping_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30295,8 +30356,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_Pong_1get_1byteslen(JNIEnv 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Pong_get_byteslen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Pong_get_byteslen(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Pong_1set_1byteslen(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30337,8 +30398,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Pong_1clone_1ptr(JNIEnv *en
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Pong_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Pong_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Pong_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30413,8 +30474,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1funding_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_funding_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_funding_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1funding_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30430,8 +30491,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1push_1msa
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_push_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_push_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1push_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30447,8 +30508,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1dust_1lim
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_dust_limit_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_dust_limit_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1dust_1limit_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30464,8 +30525,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1max_1htlc
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1max_1htlc_1value_1in_1flight_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30481,8 +30542,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1channel_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1channel_1reserve_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30498,8 +30559,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1htlc_1min
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30515,8 +30576,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1feerate_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = OpenChannel_get_feerate_per_kw(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = OpenChannel_get_feerate_per_kw(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1feerate_1per_1kw(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -30532,8 +30593,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1to_1self_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OpenChannel_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OpenChannel_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30549,8 +30610,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1max_1acce
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OpenChannel_get_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OpenChannel_get_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1max_1accepted_1htlcs(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30692,8 +30753,8 @@ JNIEXPORT int8_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1channel_1f
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int8_t ret_val = OpenChannel_get_channel_flags(&this_ptr_conv);
-	return ret_val;
+	int8_t ret_conv = OpenChannel_get_channel_flags(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1channel_1flags(JNIEnv *env, jclass clz, int64_t this_ptr, int8_t val) {
@@ -30753,8 +30814,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = OpenChannel_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30808,8 +30869,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1dust_1l
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_dust_limit_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_dust_limit_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1dust_1limit_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30825,8 +30886,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1max_1ht
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1max_1htlc_1value_1in_1flight_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30842,8 +30903,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1channel
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1channel_1reserve_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30859,8 +30920,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1htlc_1m
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30876,8 +30937,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1minimum
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = AcceptChannel_get_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = AcceptChannel_get_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1minimum_1depth(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -30893,8 +30954,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1to_1sel
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = AcceptChannel_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = AcceptChannel_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30910,8 +30971,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1max_1ac
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = AcceptChannel_get_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = AcceptChannel_get_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1max_1accepted_1htlcs(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -31097,8 +31158,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = AcceptChannel_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31173,8 +31234,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_FundingCreated_1get_1fundin
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = FundingCreated_get_funding_output_index(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = FundingCreated_get_funding_output_index(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_FundingCreated_1set_1funding_1output_1index(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -31245,8 +31306,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingCreated_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = FundingCreated_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = FundingCreated_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingCreated_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31352,8 +31413,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingSigned_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = FundingSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = FundingSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingSigned_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31486,8 +31547,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingLocked_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = FundingLocked_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = FundingLocked_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingLocked_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31596,8 +31657,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Shutdown_1clone_1ptr(JNIEnv
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Shutdown_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Shutdown_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Shutdown_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31630,8 +31691,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSignedFeeRange_get_min_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_get_min_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1set_1min_1fee_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31647,8 +31708,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSignedFeeRange_get_max_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_get_max_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1set_1max_1fee_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31689,8 +31750,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ClosingSignedFeeRange_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31744,8 +31805,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSigned_1get_1fee_1sa
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSigned_get_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSigned_get_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ClosingSigned_1set_1fee_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31850,8 +31911,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSigned_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ClosingSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSigned_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31905,8 +31966,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1get_1htlc_1i
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateAddHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1set_1htlc_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31922,8 +31983,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1get_1amount_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateAddHTLC_get_amount_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_get_amount_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1set_1amount_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31960,8 +32021,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1get_1cltv_1e
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UpdateAddHTLC_get_cltv_expiry(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UpdateAddHTLC_get_cltv_expiry(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1set_1cltv_1expiry(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -31989,8 +32050,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateAddHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32044,8 +32105,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFulfillHTLC_1get_1htl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFulfillHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFulfillHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFulfillHTLC_1set_1htlc_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32113,8 +32174,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFulfillHTLC_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateFulfillHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFulfillHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFulfillHTLC_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32168,8 +32229,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailHTLC_1get_1htlc_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFailHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFailHTLC_1set_1htlc_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32197,8 +32258,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailHTLC_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateFailHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailHTLC_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32252,8 +32313,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFailMalformedHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailMalformedHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1set_1htlc_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32269,8 +32330,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = UpdateFailMalformedHTLC_get_failure_code(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = UpdateFailMalformedHTLC_get_failure_code(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1set_1failure_1code(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -32298,8 +32359,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateFailMalformedHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailMalformedHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32439,8 +32500,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentSigned_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CommitmentSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentSigned_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32570,8 +32631,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RevokeAndACK_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RevokeAndACK_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RevokeAndACK_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RevokeAndACK_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32625,8 +32686,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UpdateFee_1get_1feerate_1pe
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UpdateFee_get_feerate_per_kw(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UpdateFee_get_feerate_per_kw(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFee_1set_1feerate_1per_1kw(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -32670,8 +32731,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFee_1clone_1ptr(JNIEn
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateFee_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFee_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFee_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32777,8 +32838,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DataLossProtect_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = DataLossProtect_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = DataLossProtect_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DataLossProtect_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32832,8 +32893,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1get_1ne
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelReestablish_get_next_local_commitment_number(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_get_next_local_commitment_number(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1set_1next_1local_1commitment_1number(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32849,8 +32910,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1get_1ne
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelReestablish_get_next_remote_commitment_number(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_get_next_remote_commitment_number(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1set_1next_1remote_1commitment_1number(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32878,8 +32939,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1clone_1
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelReestablish_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32933,8 +32994,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AnnouncementSignatures_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AnnouncementSignatures_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AnnouncementSignatures_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AnnouncementSignatures_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -33026,8 +33087,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AnnouncementSignatures_1clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = AnnouncementSignatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = AnnouncementSignatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AnnouncementSignatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33064,8 +33125,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetAddress_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKNetAddress* arg_conv = (LDKNetAddress*)arg;
-	int64_t ret_val = NetAddress_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = NetAddress_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetAddress_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33178,8 +33239,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UnsignedNodeAnnouncement_1g
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedNodeAnnouncement_get_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedNodeAnnouncement_get_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedNodeAnnouncement_1set_1timestamp(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -33294,8 +33355,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedNodeAnnouncement_1c
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UnsignedNodeAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedNodeAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedNodeAnnouncement_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33412,8 +33473,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncement_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncement_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33497,8 +33558,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelAnnouncement
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelAnnouncement_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelAnnouncement_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelAnnouncement_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -33610,8 +33671,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelAnnouncement
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UnsignedChannelAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelAnnouncement_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33800,8 +33861,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelAnnouncement_1clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelAnnouncement_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33855,8 +33916,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelUpdate_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -33872,8 +33933,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1timestamp(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -33889,8 +33950,8 @@ JNIEXPORT int8_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int8_t ret_val = UnsignedChannelUpdate_get_flags(&this_ptr_conv);
-	return ret_val;
+	int8_t ret_conv = UnsignedChannelUpdate_get_flags(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1flags(JNIEnv *env, jclass clz, int64_t this_ptr, int8_t val) {
@@ -33906,8 +33967,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = UnsignedChannelUpdate_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = UnsignedChannelUpdate_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -33923,8 +33984,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelUpdate_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -33940,8 +34001,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1fee_1base_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -33957,8 +34018,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1fee_1proportional_1millionths(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -33986,8 +34047,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UnsignedChannelUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34104,8 +34165,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdate_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34159,8 +34220,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1get_1fir
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = QueryChannelRange_get_first_blocknum(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_get_first_blocknum(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1set_1first_1blocknum(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34176,8 +34237,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1get_1num
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = QueryChannelRange_get_number_of_blocks(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_get_number_of_blocks(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1set_1number_1of_1blocks(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34221,8 +34282,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = QueryChannelRange_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = QueryChannelRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34276,8 +34337,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1get_1fir
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ReplyChannelRange_get_first_blocknum(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ReplyChannelRange_get_first_blocknum(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1set_1first_1blocknum(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34293,8 +34354,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1get_1num
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ReplyChannelRange_get_number_of_blocks(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ReplyChannelRange_get_number_of_blocks(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1set_1number_1of_1blocks(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34310,8 +34371,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1get_1sy
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ReplyChannelRange_get_sync_complete(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ReplyChannelRange_get_sync_complete(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1set_1sync_1complete(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -34387,8 +34448,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ReplyChannelRange_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ReplyChannelRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34502,8 +34563,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_QueryShortChannelIds_1clone
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = QueryShortChannelIds_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = QueryShortChannelIds_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_QueryShortChannelIds_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34557,8 +34618,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ReplyShortChannelIdsEnd_1g
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ReplyShortChannelIdsEnd_get_full_information(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ReplyShortChannelIdsEnd_get_full_information(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ReplyShortChannelIdsEnd_1set_1full_1information(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -34602,8 +34663,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ReplyShortChannelIdsEnd_1cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ReplyShortChannelIdsEnd_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ReplyShortChannelIdsEnd_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ReplyShortChannelIdsEnd_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34657,8 +34718,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = GossipTimestampFilter_get_first_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = GossipTimestampFilter_get_first_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1set_1first_1timestamp(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34674,8 +34735,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = GossipTimestampFilter_get_timestamp_range(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = GossipTimestampFilter_get_timestamp_range(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1set_1timestamp_1range(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34719,8 +34780,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = GossipTimestampFilter_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = GossipTimestampFilter_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34757,8 +34818,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ErrorAction_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKErrorAction* arg_conv = (LDKErrorAction*)arg;
-	int64_t ret_val = ErrorAction_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = ErrorAction_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ErrorAction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34914,8 +34975,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_LightningError_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = LightningError_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = LightningError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_LightningError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -35317,8 +35378,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentUpdate_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CommitmentUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -36021,8 +36082,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1end_1blo
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = QueryChannelRange_end_blocknum(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_end_blocknum(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -36296,8 +36357,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1clone_1pt
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKSocketDescriptor* arg_conv = (LDKSocketDescriptor*)arg_ptr;
-	int64_t ret_val = SocketDescriptor_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = SocketDescriptor_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -36331,8 +36392,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PeerHandleError_1get_1no_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = PeerHandleError_get_no_connection_possible(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = PeerHandleError_get_no_connection_possible(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PeerHandleError_1set_1no_1connection_1possible(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -36373,8 +36434,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PeerHandleError_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PeerHandleError_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PeerHandleError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PeerHandleError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -36580,13 +36641,13 @@ JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PeerManager_1timer_1tick_1occu
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_htlc_1success_1tx_1weight(JNIEnv *env, jclass clz, jboolean opt_anchors) {
-	int64_t ret_val = htlc_success_tx_weight(opt_anchors);
-	return ret_val;
+	int64_t ret_conv = htlc_success_tx_weight(opt_anchors);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_htlc_1timeout_1tx_1weight(JNIEnv *env, jclass clz, jboolean opt_anchors) {
-	int64_t ret_val = htlc_timeout_tx_weight(opt_anchors);
-	return ret_val;
+	int64_t ret_conv = htlc_timeout_tx_weight(opt_anchors);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_build_1commitment_1secret(JNIEnv *env, jclass clz, int8_tArray commitment_seed, int64_t idx) {
@@ -36645,8 +36706,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyCommitmentSecre
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CounterpartyCommitmentSecrets_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyCommitmentSecrets_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyCommitmentSecrets_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -36684,8 +36745,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyCommitmentSecre
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CounterpartyCommitmentSecrets_get_min_seen_secret(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyCommitmentSecrets_get_min_seen_secret(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyCommitmentSecrets_1provide_1secret(JNIEnv *env, jclass clz, int64_t this_arg, int64_t idx, int8_tArray secret) {
@@ -36942,8 +37003,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxCreationKeys_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = TxCreationKeys_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = TxCreationKeys_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxCreationKeys_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37143,8 +37204,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelPublicKeys_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelPublicKeys_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelPublicKeys_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelPublicKeys_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37251,8 +37312,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = HTLCOutputInCommitment_get_offered(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = HTLCOutputInCommitment_get_offered(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1set_1offered(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -37268,8 +37329,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = HTLCOutputInCommitment_get_amount_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = HTLCOutputInCommitment_get_amount_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1set_1amount_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -37285,8 +37346,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = HTLCOutputInCommitment_get_cltv_expiry(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = HTLCOutputInCommitment_get_cltv_expiry(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1set_1cltv_1expiry(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -37378,8 +37439,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = HTLCOutputInCommitment_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = HTLCOutputInCommitment_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37527,8 +37588,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameter
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelTransactionParameters_get_holder_selected_contest_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelTransactionParameters_get_holder_selected_contest_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameters_1set_1holder_1selected_1contest_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -37544,8 +37605,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParamete
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelTransactionParameters_get_is_outbound_from_holder(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTransactionParameters_get_is_outbound_from_holder(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameters_1set_1is_1outbound_1from_1holder(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -37684,8 +37745,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameter
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelTransactionParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelTransactionParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37748,8 +37809,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_CounterpartyChannelTransact
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = CounterpartyChannelTransactionParameters_get_selected_contest_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = CounterpartyChannelTransactionParameters_get_selected_contest_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CounterpartyChannelTransactionParameters_1set_1selected_1contest_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -37795,8 +37856,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyChannelTransact
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CounterpartyChannelTransactionParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyChannelTransactionParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyChannelTransactionParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37821,8 +37882,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParamete
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelTransactionParameters_is_populated(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTransactionParameters_is_populated(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameters_1as_1holder_1broadcastable(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -37950,8 +38011,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransactionP
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = DirectedChannelTransactionParameters_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = DirectedChannelTransactionParameters_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransactionParameters_1is_1outbound(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -37959,8 +38020,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransaction
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = DirectedChannelTransactionParameters_is_outbound(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = DirectedChannelTransactionParameters_is_outbound(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransactionParameters_1funding_1outpoint(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -37985,8 +38046,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransaction
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = DirectedChannelTransactionParameters_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = DirectedChannelTransactionParameters_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_HolderCommitmentTransaction_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -38056,8 +38117,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HolderCommitmentTransaction
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = HolderCommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = HolderCommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HolderCommitmentTransaction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38231,8 +38292,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_BuiltCommitmentTransaction_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = BuiltCommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = BuiltCommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_BuiltCommitmentTransaction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38331,8 +38392,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1clone_1
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ClosingTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38357,8 +38418,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1hash(JN
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = ClosingTransaction_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1new(JNIEnv *env, jclass clz, int64_t to_holder_value_sat, int64_t to_counterparty_value_sat, int8_tArray to_holder_script, int8_tArray to_counterparty_script, int64_t funding_outpoint) {
@@ -38424,8 +38485,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1to_1hol
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ClosingTransaction_to_holder_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_to_holder_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1to_1counterparty_1value_1sat(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38433,8 +38494,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1to_1cou
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ClosingTransaction_to_counterparty_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_to_counterparty_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1to_1holder_1script(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38536,8 +38597,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38584,8 +38645,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1comm
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_commitment_number(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_commitment_number(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1to_1broadcaster_1value_1sat(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38593,8 +38654,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1to_1
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_to_broadcaster_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_to_broadcaster_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1to_1countersignatory_1value_1sat(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38602,8 +38663,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1to_1
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_to_countersignatory_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_to_countersignatory_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1feerate_1per_1kw(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38611,8 +38672,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1feer
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = CommitmentTransaction_feerate_per_kw(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = CommitmentTransaction_feerate_per_kw(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1trust(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38711,8 +38772,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_TrustedCommitmentTransacti
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = TrustedCommitmentTransaction_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = TrustedCommitmentTransaction_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TrustedCommitmentTransaction_1get_1htlc_1sigs(JNIEnv *env, jclass clz, int64_t this_arg, int8_tArray htlc_base_key, int64_t channel_parameters) {
@@ -38740,8 +38801,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_get_1commitment_1transactio
 	LDKPublicKey countersignatory_payment_basepoint_ref;
 	CHECK((*env)->GetArrayLength(env, countersignatory_payment_basepoint) == 33);
 	(*env)->GetByteArrayRegion(env, countersignatory_payment_basepoint, 0, 33, countersignatory_payment_basepoint_ref.compressed_form);
-	int64_t ret_val = get_commitment_transaction_number_obscure_factor(broadcaster_payment_basepoint_ref, countersignatory_payment_basepoint_ref, outbound_from_broadcaster);
-	return ret_val;
+	int64_t ret_conv = get_commitment_transaction_number_obscure_factor(broadcaster_payment_basepoint_ref, countersignatory_payment_basepoint_ref, outbound_from_broadcaster);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InitFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38753,8 +38814,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InitFeatures_1eq(JNIEnv *e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InitFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InitFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38766,8 +38827,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1eq(JNIEnv *e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = NodeFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = NodeFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38779,8 +38840,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1eq(JNIEnv
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ChannelFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38792,8 +38853,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1eq(JNIEnv
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InvoiceFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38805,8 +38866,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1eq(JN
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ChannelTypeFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTypeFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t InitFeatures_clone_ptr(LDKInitFeatures *NONNULL_PTR arg) {
@@ -38826,8 +38887,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InitFeatures_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InitFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InitFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InitFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38864,8 +38925,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38902,8 +38963,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38940,8 +39001,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InvoiceFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InvoiceFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38978,8 +39039,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelTypeFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelTypeFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39070,8 +39131,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InitFeatures_1requires_1un
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InitFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InitFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1empty(JNIEnv *env, jclass clz) {
@@ -39105,8 +39166,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1requires_1un
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = NodeFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = NodeFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1empty(JNIEnv *env, jclass clz) {
@@ -39140,8 +39201,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1requires_
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1empty(JNIEnv *env, jclass clz) {
@@ -39175,8 +39236,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1requires_
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InvoiceFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1empty(JNIEnv *env, jclass clz) {
@@ -39210,8 +39271,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1requi
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelTypeFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTypeFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_InitFeatures_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -39349,8 +39410,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ShutdownScript_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ShutdownScript_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ShutdownScript_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ShutdownScript_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39435,8 +39496,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvalidShutdownScript_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InvalidShutdownScript_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InvalidShutdownScript_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvalidShutdownScript_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39554,8 +39615,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ShutdownScript_1is_1compat
 	features_conv.inner = (void*)(features & (~1));
 	features_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(features_conv);
-	jboolean ret_val = ShutdownScript_is_compatible(&this_arg_conv, &features_conv);
-	return ret_val;
+	jboolean ret_conv = ShutdownScript_is_compatible(&this_arg_conv, &features_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CustomMessageReader_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -39576,8 +39637,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Type_1clone_1ptr(JNIEnv *en
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKType* arg_conv = (LDKType*)arg_ptr;
-	int64_t ret_val = Type_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Type_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Type_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39623,8 +39684,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeId_1clone_1ptr(JNIEnv *
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeId_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeId_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeId_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39676,8 +39737,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeId_1hash(JNIEnv *env, j
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = NodeId_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = NodeId_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_NodeId_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -39727,8 +39788,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetworkGraph_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NetworkGraph_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NetworkGraph_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetworkGraph_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39773,8 +39834,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetworkUpdate_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKNetworkUpdate* arg_conv = (LDKNetworkUpdate*)arg;
-	int64_t ret_val = NetworkUpdate_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = NetworkUpdate_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetworkUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39938,8 +39999,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1get_1las
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelUpdateInfo_get_last_update(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelUpdateInfo_get_last_update(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1set_1last_1update(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -39955,8 +40016,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1get_1en
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelUpdateInfo_get_enabled(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelUpdateInfo_get_enabled(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1set_1enabled(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -39972,8 +40033,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1get_1clt
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelUpdateInfo_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelUpdateInfo_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -39989,8 +40050,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1get_1htl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelUpdateInfo_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelUpdateInfo_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1set_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -40130,8 +40191,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelUpdateInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelUpdateInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40407,8 +40468,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelInfo_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40475,8 +40536,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DirectedChannelInfo_1clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = DirectedChannelInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = DirectedChannelInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DirectedChannelInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40560,8 +40621,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_EffectiveCapacity_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKEffectiveCapacity* arg_conv = (LDKEffectiveCapacity*)arg;
-	int64_t ret_val = EffectiveCapacity_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = EffectiveCapacity_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_EffectiveCapacity_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40609,8 +40670,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_EffectiveCapacity_1unknown(
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_EffectiveCapacity_1as_1msat(JNIEnv *env, jclass clz, int64_t this_arg) {
 	LDKEffectiveCapacity* this_arg_conv = (LDKEffectiveCapacity*)this_arg;
-	int64_t ret_val = EffectiveCapacity_as_msat(this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = EffectiveCapacity_as_msat(this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RoutingFees_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -40626,8 +40687,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1get_1base_1msa
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RoutingFees_get_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RoutingFees_get_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RoutingFees_1set_1base_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -40643,8 +40704,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1get_1proportio
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RoutingFees_get_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RoutingFees_get_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RoutingFees_1set_1proportional_1millionths(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -40677,8 +40738,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RoutingFees_1eq(JNIEnv *en
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RoutingFees_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RoutingFees_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RoutingFees_clone_ptr(LDKRoutingFees *NONNULL_PTR arg) {
@@ -40698,8 +40759,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RoutingFees_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RoutingFees_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40724,8 +40785,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1hash(JNIEnv *e
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RoutingFees_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RoutingFees_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RoutingFees_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -40793,8 +40854,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncementInfo_1get_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = NodeAnnouncementInfo_get_last_update(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = NodeAnnouncementInfo_get_last_update(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_NodeAnnouncementInfo_1set_1last_1update(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -40964,8 +41025,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncementInfo_1clone
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeAnnouncementInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeAnnouncementInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncementInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -41151,8 +41212,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeInfo_1clone_1ptr(JNIEnv
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -41468,8 +41529,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1get_1short_1chann
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHop_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHop_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -41515,8 +41576,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1get_1fee_1msat(JN
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHop_get_fee_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_get_fee_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHop_1set_1fee_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -41532,8 +41593,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1get_1cltv_1expiry
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RouteHop_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RouteHop_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHop_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -41587,8 +41648,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1clone_1ptr(JNIEnv
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RouteHop_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -41613,8 +41674,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1hash(JNIEnv *env,
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHop_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHop_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -41626,8 +41687,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHop_1eq(JNIEnv *env, 
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHop_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHop_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RouteHop_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -41824,8 +41885,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1clone_1ptr(JNIEnv *e
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Route_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -41850,8 +41911,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1hash(JNIEnv *env, jc
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Route_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Route_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Route_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -41863,8 +41924,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Route_1eq(JNIEnv *env, jcl
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Route_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Route_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1get_1total_1fees(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -41872,8 +41933,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1get_1total_1fees(JNI
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Route_get_total_fees(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_get_total_fees(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1get_1total_1amount(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -41881,8 +41942,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1get_1total_1amount(J
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Route_get_total_amount(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_get_total_amount(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_Route_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -41950,8 +42011,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteParameters_1get_1final
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteParameters_get_final_value_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteParameters_get_final_value_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteParameters_1set_1final_1value_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -41967,8 +42028,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_RouteParameters_1get_1final
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RouteParameters_get_final_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RouteParameters_get_final_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteParameters_1set_1final_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -42014,8 +42075,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteParameters_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RouteParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RouteParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42197,8 +42258,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1get_1max
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = PaymentParameters_get_max_total_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = PaymentParameters_get_max_total_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1set_1max_1total_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -42268,8 +42329,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PaymentParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42294,8 +42355,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1hash(JNI
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PaymentParameters_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentParameters_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -42307,8 +42368,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1eq(JNIE
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PaymentParameters_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PaymentParameters_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -42471,8 +42532,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHint_1clone_1ptr(JNIEn
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RouteHint_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHint_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHint_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42497,8 +42558,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHint_1hash(JNIEnv *env
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHint_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHint_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHint_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -42510,8 +42571,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHint_1eq(JNIEnv *env,
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHint_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHint_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RouteHint_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -42570,8 +42631,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1get_1short_1c
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHintHop_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -42617,8 +42678,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1get_1cltv_1ex
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = RouteHintHop_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = RouteHintHop_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -42721,8 +42782,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RouteHintHop_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42747,8 +42808,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1hash(JNIEnv *
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHintHop_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -42760,8 +42821,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1eq(JNIEnv *e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHintHop_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHintHop_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -42909,8 +42970,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FixedPenaltyScorer_1clone_1
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = FixedPenaltyScorer_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = FixedPenaltyScorer_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FixedPenaltyScorer_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42996,8 +43057,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1bas
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_base_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_base_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1base_1penalty_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43013,8 +43074,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1fai
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_failure_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_failure_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1failure_1penalty_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43030,8 +43091,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1ove
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ScoringParameters_get_overuse_penalty_start_1024th(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ScoringParameters_get_overuse_penalty_start_1024th(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1overuse_1penalty_1start_11024th(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -43047,8 +43108,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1ove
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_overuse_penalty_msat_per_1024th(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_overuse_penalty_msat_per_1024th(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1overuse_1penalty_1msat_1per_11024th(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43064,8 +43125,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1fai
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_failure_penalty_half_life(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_failure_penalty_half_life(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1failure_1penalty_1half_1life(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43106,8 +43167,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ScoringParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43246,8 +43307,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_base_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_base_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1set_1base_1penalty_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43263,8 +43324,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_liquidity_penalty_multiplier_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_liquidity_penalty_multiplier_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1set_1liquidity_1penalty_1multiplier_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43280,8 +43341,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_liquidity_offset_half_life(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_liquidity_offset_half_life(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1set_1liquidity_1offset_1half_1life(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43297,8 +43358,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_amount_penalty_multiplier_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_amount_penalty_multiplier_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1set_1amount_1penalty_1multiplier_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43339,8 +43400,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43624,8 +43685,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ParseError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKParseError* arg_conv = (LDKParseError*)arg;
-	int64_t ret_val = ParseError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = ParseError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ParseError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43787,8 +43848,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ParseOrSemanticError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKParseOrSemanticError* arg_conv = (LDKParseOrSemanticError*)arg;
-	int64_t ret_val = ParseOrSemanticError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = ParseOrSemanticError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ParseOrSemanticError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43835,8 +43896,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1eq(JNIEnv *env, j
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Invoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Invoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t Invoice_clone_ptr(LDKInvoice *NONNULL_PTR arg) {
@@ -43856,8 +43917,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1clone_1ptr(JNIEnv 
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Invoice_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43894,8 +43955,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1eq(JNIEn
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = SignedRawInvoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = SignedRawInvoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t SignedRawInvoice_clone_ptr(LDKSignedRawInvoice *NONNULL_PTR arg) {
@@ -43915,8 +43976,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = SignedRawInvoice_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = SignedRawInvoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43983,8 +44044,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RawInvoice_1eq(JNIEnv *env
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RawInvoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RawInvoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RawInvoice_clone_ptr(LDKRawInvoice *NONNULL_PTR arg) {
@@ -44004,8 +44065,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RawInvoice_1clone_1ptr(JNIE
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RawInvoice_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RawInvoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RawInvoice_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44072,8 +44133,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RawDataPart_1eq(JNIEnv *en
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RawDataPart_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RawDataPart_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RawDataPart_clone_ptr(LDKRawDataPart *NONNULL_PTR arg) {
@@ -44093,8 +44154,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RawDataPart_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RawDataPart_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RawDataPart_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RawDataPart_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44131,8 +44192,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1eq(JNIE
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PositiveTimestamp_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PositiveTimestamp_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t PositiveTimestamp_clone_ptr(LDKPositiveTimestamp *NONNULL_PTR arg) {
@@ -44152,8 +44213,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PositiveTimestamp_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44202,14 +44263,14 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_SiPrefix_1pico(JNIEnv *env, 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SiPrefix_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKSiPrefix* a_conv = (LDKSiPrefix*)(a & ~1);
 	LDKSiPrefix* b_conv = (LDKSiPrefix*)(b & ~1);
-	jboolean ret_val = SiPrefix_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SiPrefix_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SiPrefix_1multiplier(JNIEnv *env, jclass clz, int64_t this_arg) {
 	LDKSiPrefix* this_arg_conv = (LDKSiPrefix*)(this_arg & ~1);
-	int64_t ret_val = SiPrefix_multiplier(this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = SiPrefix_multiplier(this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_Currency_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44245,15 +44306,15 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_Currency_1signet(JNIEnv *env
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Currency_1hash(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCurrency* o_conv = (LDKCurrency*)(o & ~1);
-	int64_t ret_val = Currency_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Currency_hash(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Currency_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKCurrency* a_conv = (LDKCurrency*)(a & ~1);
 	LDKCurrency* b_conv = (LDKCurrency*)(b & ~1);
-	jboolean ret_val = Currency_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Currency_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Sha256_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44281,8 +44342,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sha256_1clone_1ptr(JNIEnv *
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Sha256_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Sha256_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sha256_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44307,8 +44368,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sha256_1hash(JNIEnv *env, j
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Sha256_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Sha256_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Sha256_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44320,8 +44381,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Sha256_1eq(JNIEnv *env, jc
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Sha256_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Sha256_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Description_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44349,8 +44410,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Description_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Description_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Description_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Description_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44375,8 +44436,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Description_1hash(JNIEnv *e
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Description_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Description_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Description_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44388,8 +44449,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Description_1eq(JNIEnv *en
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Description_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Description_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44454,8 +44515,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PayeePubKey_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PayeePubKey_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44480,8 +44541,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1hash(JNIEnv *e
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PayeePubKey_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PayeePubKey_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44493,8 +44554,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1eq(JNIEnv *en
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PayeePubKey_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PayeePubKey_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44522,8 +44583,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1clone_1ptr(JNIE
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ExpiryTime_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44548,8 +44609,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1hash(JNIEnv *en
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = ExpiryTime_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44561,8 +44622,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1eq(JNIEnv *env
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ExpiryTime_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ExpiryTime_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44578,8 +44639,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1get_1a(
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = MinFinalCltvExpiry_get_a(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_get_a(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1set_1a(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -44620,8 +44681,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1clone_1
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = MinFinalCltvExpiry_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44646,8 +44707,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1hash(JN
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = MinFinalCltvExpiry_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44659,8 +44720,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1eq(JNI
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = MinFinalCltvExpiry_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = MinFinalCltvExpiry_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Fallback_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -44680,8 +44741,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Fallback_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKFallback* arg_conv = (LDKFallback*)arg;
-	int64_t ret_val = Fallback_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Fallback_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Fallback_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44726,15 +44787,15 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Fallback_1script_1hash(JNIE
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Fallback_1hash(JNIEnv *env, jclass clz, int64_t o) {
 	LDKFallback* o_conv = (LDKFallback*)o;
-	int64_t ret_val = Fallback_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Fallback_hash(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Fallback_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKFallback* a_conv = (LDKFallback*)a;
 	LDKFallback* b_conv = (LDKFallback*)b;
-	jboolean ret_val = Fallback_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Fallback_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_InvoiceSignature_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44762,8 +44823,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceSignature_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InvoiceSignature_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InvoiceSignature_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceSignature_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44792,8 +44853,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InvoiceSignature_1eq(JNIEn
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InvoiceSignature_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceSignature_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44821,8 +44882,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PrivateRoute_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PrivateRoute_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44847,8 +44908,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1hash(JNIEnv *
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PrivateRoute_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PrivateRoute_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44860,8 +44921,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1eq(JNIEnv *e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PrivateRoute_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PrivateRoute_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1into_1parts(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -44934,8 +44995,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1check_1s
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = SignedRawInvoice_check_signature(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = SignedRawInvoice_check_signature(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RawInvoice_1hash(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45160,8 +45221,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1unix
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_unix_timestamp(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_unix_timestamp(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1duration_1since_1epoch(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45169,8 +45230,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1dura
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_duration_since_epoch(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_duration_since_epoch(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1time(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45178,8 +45239,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1time
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_time(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_time(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1into_1signed_1raw(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45226,8 +45287,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1timestamp(JNIEnv *
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_timestamp(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_timestamp(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1duration_1since_1epoch(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45235,8 +45296,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1duration_1since_1e
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_duration_since_epoch(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_duration_since_epoch(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_Invoice_1payment_1hash(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45303,8 +45364,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1expiry_1time(JNIEn
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_expiry_time(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_expiry_time(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1is_1expired(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45312,8 +45373,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1is_1expired(JNIEn
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = Invoice_is_expired(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = Invoice_is_expired(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1would_1expire(JNIEnv *env, jclass clz, int64_t this_arg, int64_t at_time) {
@@ -45321,8 +45382,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1would_1expire(JNI
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = Invoice_would_expire(&this_arg_conv, at_time);
-	return ret_val;
+	jboolean ret_conv = Invoice_would_expire(&this_arg_conv, at_time);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1min_1final_1cltv_1expiry(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45330,8 +45391,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1min_1final_1cltv_1
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_min_final_cltv_expiry(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_min_final_cltv_expiry(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_tArray JNICALL Java_org_ldk_impl_bindings_Invoice_1private_1routes(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45456,8 +45517,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1as_1seconds(JNI
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ExpiryTime_as_seconds(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_as_seconds(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1as_1duration(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45465,8 +45526,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1as_1duration(JN
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ExpiryTime_as_duration(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_as_duration(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1new(JNIEnv *env, jclass clz, int64_t hops) {
@@ -45532,8 +45593,8 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_CreationError_1missing_1rout
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CreationError_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKCreationError* a_conv = (LDKCreationError*)(a & ~1);
 	LDKCreationError* b_conv = (LDKCreationError*)(b & ~1);
-	jboolean ret_val = CreationError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = CreationError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jstring JNICALL Java_org_ldk_impl_bindings_CreationError_1to_1str(JNIEnv *env, jclass clz, int64_t o) {
@@ -45603,8 +45664,8 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_SemanticError_1imprecise_1am
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SemanticError_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKSemanticError* a_conv = (LDKSemanticError*)(a & ~1);
 	LDKSemanticError* b_conv = (LDKSemanticError*)(b & ~1);
-	jboolean ret_val = SemanticError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SemanticError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jstring JNICALL Java_org_ldk_impl_bindings_SemanticError_1to_1str(JNIEnv *env, jclass clz, int64_t o) {
@@ -45632,8 +45693,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKSignOrCreationError* arg_conv = (LDKSignOrCreationError*)arg;
-	int64_t ret_val = SignOrCreationError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = SignOrCreationError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -45662,8 +45723,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1creati
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKSignOrCreationError* a_conv = (LDKSignOrCreationError*)a;
 	LDKSignOrCreationError* b_conv = (LDKSignOrCreationError*)b;
-	jboolean ret_val = SignOrCreationError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SignOrCreationError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jstring JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1to_1str(JNIEnv *env, jclass clz, int64_t o) {
@@ -45713,8 +45774,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1get_1a(JNIEn
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RetryAttempts_get_a(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RetryAttempts_get_a(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1set_1a(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -45755,8 +45816,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RetryAttempts_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RetryAttempts_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -45785,8 +45846,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1eq(JNIEnv *
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RetryAttempts_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RetryAttempts_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1hash(JNIEnv *env, jclass clz, int64_t o) {
@@ -45794,8 +45855,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1hash(JNIEnv 
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RetryAttempts_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RetryAttempts_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PaymentError_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -45815,8 +45876,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKPaymentError* arg_conv = (LDKPaymentError*)arg;
-	int64_t ret_val = PaymentError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentError_1clone(JNIEnv *env, jclass clz, int64_t orig) {

--- a/src/main/jni/bindings.c.body
+++ b/src/main/jni/bindings.c.body
@@ -935,10 +935,12 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKBech32Error_1ref_1from_1
 			return (*env)->NewObject(env, LDKBech32Error_InvalidLength_class, LDKBech32Error_InvalidLength_meth);
 		}
 		case LDKBech32Error_InvalidChar: {
-			return (*env)->NewObject(env, LDKBech32Error_InvalidChar_class, LDKBech32Error_InvalidChar_meth, obj->invalid_char);
+			int32_t invalid_char_conv = obj->invalid_char;
+			return (*env)->NewObject(env, LDKBech32Error_InvalidChar_class, LDKBech32Error_InvalidChar_meth, invalid_char_conv);
 		}
 		case LDKBech32Error_InvalidData: {
-			return (*env)->NewObject(env, LDKBech32Error_InvalidData_class, LDKBech32Error_InvalidData_meth, obj->invalid_data);
+			int8_t invalid_data_conv = obj->invalid_data;
+			return (*env)->NewObject(env, LDKBech32Error_InvalidData_class, LDKBech32Error_InvalidData_meth, invalid_data_conv);
 		}
 		case LDKBech32Error_InvalidPadding: {
 			return (*env)->NewObject(env, LDKBech32Error_InvalidPadding_class, LDKBech32Error_InvalidPadding_meth);
@@ -965,8 +967,8 @@ struct LDKCVec_u8Z TxOut_get_script_pubkey (struct LDKTxOut* thing) {	return CVe
 
 uint64_t TxOut_get_value (struct LDKTxOut* thing) {	return thing->value;}JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxOut_1get_1value(JNIEnv *env, jclass clz, int64_t thing) {
 	LDKTxOut* thing_conv = (LDKTxOut*)(thing & ~1);
-	int64_t ret_val = TxOut_get_value(thing_conv);
-	return ret_val;
+	int64_t ret_conv = TxOut_get_value(thing_conv);
+	return ret_conv;
 }
 
 static inline void CResult_NoneNoneZ_get_ok(LDKCResult_NoneNoneZ *NONNULL_PTR owner){
@@ -1185,7 +1187,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKCOption_1u32Z_1ref_1from
 	LDKCOption_u32Z *obj = (LDKCOption_u32Z*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKCOption_u32Z_Some: {
-			return (*env)->NewObject(env, LDKCOption_u32Z_Some_class, LDKCOption_u32Z_Some_meth, obj->some);
+			int32_t some_conv = obj->some;
+			return (*env)->NewObject(env, LDKCOption_u32Z_Some_class, LDKCOption_u32Z_Some_meth, some_conv);
 		}
 		case LDKCOption_u32Z_None: {
 			return (*env)->NewObject(env, LDKCOption_u32Z_None_class, LDKCOption_u32Z_None_meth);
@@ -1725,7 +1728,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKCOption_1u64Z_1ref_1from
 	LDKCOption_u64Z *obj = (LDKCOption_u64Z*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKCOption_u64Z_Some: {
-			return (*env)->NewObject(env, LDKCOption_u64Z_Some_class, LDKCOption_u64Z_Some_meth, obj->some);
+			int64_t some_conv = obj->some;
+			return (*env)->NewObject(env, LDKCOption_u64Z_Some_class, LDKCOption_u64Z_Some_meth, some_conv);
 		}
 		case LDKCOption_u64Z_None: {
 			return (*env)->NewObject(env, LDKCOption_u64Z_None_class, LDKCOption_u64Z_None_meth);
@@ -1917,8 +1921,8 @@ static inline uintptr_t C2Tuple_usizeTransactionZ_get_a(LDKC2Tuple_usizeTransact
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1usizeTransactionZ_1get_1a(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKC2Tuple_usizeTransactionZ* owner_conv = (LDKC2Tuple_usizeTransactionZ*)(owner & ~1);
-	int64_t ret_val = C2Tuple_usizeTransactionZ_get_a(owner_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_usizeTransactionZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKTransaction C2Tuple_usizeTransactionZ_get_b(LDKC2Tuple_usizeTransactionZ *NONNULL_PTR owner){
@@ -2023,7 +2027,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKMonitorEvent_1ref_1from_
 			CHECK((((uintptr_t)&funding_txo_var) & 1) == 0); // We rely on a free low bit, pointer alignment guarantees this.
 			CHECK_INNER_FIELD_ACCESS_OR_NULL(funding_txo_var);
 			funding_txo_ref = (uintptr_t)funding_txo_var.inner & ~1;
-			return (*env)->NewObject(env, LDKMonitorEvent_UpdateCompleted_class, LDKMonitorEvent_UpdateCompleted_meth, funding_txo_ref, obj->update_completed.monitor_update_id);
+			int64_t monitor_update_id_conv = obj->update_completed.monitor_update_id;
+			return (*env)->NewObject(env, LDKMonitorEvent_UpdateCompleted_class, LDKMonitorEvent_UpdateCompleted_meth, funding_txo_ref, monitor_update_id_conv);
 		}
 		case LDKMonitorEvent_UpdateFailed: {
 			LDKOutPoint update_failed_var = obj->update_failed;
@@ -2262,12 +2267,15 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKNetworkUpdate_1ref_1from
 			return (*env)->NewObject(env, LDKNetworkUpdate_ChannelUpdateMessage_class, LDKNetworkUpdate_ChannelUpdateMessage_meth, msg_ref);
 		}
 		case LDKNetworkUpdate_ChannelClosed: {
-			return (*env)->NewObject(env, LDKNetworkUpdate_ChannelClosed_class, LDKNetworkUpdate_ChannelClosed_meth, obj->channel_closed.short_channel_id, obj->channel_closed.is_permanent);
+			int64_t short_channel_id_conv = obj->channel_closed.short_channel_id;
+			jboolean is_permanent_conv = obj->channel_closed.is_permanent;
+			return (*env)->NewObject(env, LDKNetworkUpdate_ChannelClosed_class, LDKNetworkUpdate_ChannelClosed_meth, short_channel_id_conv, is_permanent_conv);
 		}
 		case LDKNetworkUpdate_NodeFailure: {
 			int8_tArray node_id_arr = (*env)->NewByteArray(env, 33);
 			(*env)->SetByteArrayRegion(env, node_id_arr, 0, 33, obj->node_failure.node_id.compressed_form);
-			return (*env)->NewObject(env, LDKNetworkUpdate_NodeFailure_class, LDKNetworkUpdate_NodeFailure_meth, node_id_arr, obj->node_failure.is_permanent);
+			jboolean is_permanent_conv = obj->node_failure.is_permanent;
+			return (*env)->NewObject(env, LDKNetworkUpdate_NodeFailure_class, LDKNetworkUpdate_NodeFailure_meth, node_id_arr, is_permanent_conv);
 		}
 		default: abort();
 	}
@@ -2491,16 +2499,19 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 		case LDKEvent_FundingGenerationReady: {
 			int8_tArray temporary_channel_id_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, temporary_channel_id_arr, 0, 32, obj->funding_generation_ready.temporary_channel_id.data);
+			int64_t channel_value_satoshis_conv = obj->funding_generation_ready.channel_value_satoshis;
 			LDKCVec_u8Z output_script_var = obj->funding_generation_ready.output_script;
 			int8_tArray output_script_arr = (*env)->NewByteArray(env, output_script_var.datalen);
 			(*env)->SetByteArrayRegion(env, output_script_arr, 0, output_script_var.datalen, output_script_var.data);
-			return (*env)->NewObject(env, LDKEvent_FundingGenerationReady_class, LDKEvent_FundingGenerationReady_meth, temporary_channel_id_arr, obj->funding_generation_ready.channel_value_satoshis, output_script_arr, obj->funding_generation_ready.user_channel_id);
+			int64_t user_channel_id_conv = obj->funding_generation_ready.user_channel_id;
+			return (*env)->NewObject(env, LDKEvent_FundingGenerationReady_class, LDKEvent_FundingGenerationReady_meth, temporary_channel_id_arr, channel_value_satoshis_conv, output_script_arr, user_channel_id_conv);
 		}
 		case LDKEvent_PaymentReceived: {
 			int8_tArray payment_hash_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, payment_hash_arr, 0, 32, obj->payment_received.payment_hash.data);
+			int64_t amt_conv = obj->payment_received.amt;
 			int64_t purpose_ref = ((uintptr_t)&obj->payment_received.purpose) | 1;
-			return (*env)->NewObject(env, LDKEvent_PaymentReceived_class, LDKEvent_PaymentReceived_meth, payment_hash_arr, obj->payment_received.amt, purpose_ref);
+			return (*env)->NewObject(env, LDKEvent_PaymentReceived_class, LDKEvent_PaymentReceived_meth, payment_hash_arr, amt_conv, purpose_ref);
 		}
 		case LDKEvent_PaymentSent: {
 			int8_tArray payment_id_arr = (*env)->NewByteArray(env, 32);
@@ -2517,7 +2528,9 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 			(*env)->SetByteArrayRegion(env, payment_id_arr, 0, 32, obj->payment_path_failed.payment_id.data);
 			int8_tArray payment_hash_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, payment_hash_arr, 0, 32, obj->payment_path_failed.payment_hash.data);
+			jboolean rejected_by_dest_conv = obj->payment_path_failed.rejected_by_dest;
 			int64_t network_update_ref = ((uintptr_t)&obj->payment_path_failed.network_update) | 1;
+			jboolean all_paths_failed_conv = obj->payment_path_failed.all_paths_failed;
 			LDKCVec_RouteHopZ path_var = obj->payment_path_failed.path;
 			int64_tArray path_arr = NULL;
 			path_arr = (*env)->NewLongArray(env, path_var.datalen);
@@ -2541,7 +2554,7 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 			CHECK_INNER_FIELD_ACCESS_OR_NULL(retry_var);
 				retry_ref = (uintptr_t)retry_var.inner & ~1;
 			}
-			return (*env)->NewObject(env, LDKEvent_PaymentPathFailed_class, LDKEvent_PaymentPathFailed_meth, payment_id_arr, payment_hash_arr, obj->payment_path_failed.rejected_by_dest, network_update_ref, obj->payment_path_failed.all_paths_failed, path_arr, short_channel_id_ref, retry_ref);
+			return (*env)->NewObject(env, LDKEvent_PaymentPathFailed_class, LDKEvent_PaymentPathFailed_meth, payment_id_arr, payment_hash_arr, rejected_by_dest_conv, network_update_ref, all_paths_failed_conv, path_arr, short_channel_id_ref, retry_ref);
 		}
 		case LDKEvent_PaymentFailed: {
 			int8_tArray payment_id_arr = (*env)->NewByteArray(env, 32);
@@ -2551,7 +2564,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 			return (*env)->NewObject(env, LDKEvent_PaymentFailed_class, LDKEvent_PaymentFailed_meth, payment_id_arr, payment_hash_arr);
 		}
 		case LDKEvent_PendingHTLCsForwardable: {
-			return (*env)->NewObject(env, LDKEvent_PendingHTLCsForwardable_class, LDKEvent_PendingHTLCsForwardable_meth, obj->pending_htl_cs_forwardable.time_forwardable);
+			int64_t time_forwardable_conv = obj->pending_htl_cs_forwardable.time_forwardable;
+			return (*env)->NewObject(env, LDKEvent_PendingHTLCsForwardable_class, LDKEvent_PendingHTLCsForwardable_meth, time_forwardable_conv);
 		}
 		case LDKEvent_SpendableOutputs: {
 			LDKCVec_SpendableOutputDescriptorZ outputs_var = obj->spendable_outputs.outputs;
@@ -2567,13 +2581,15 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 		}
 		case LDKEvent_PaymentForwarded: {
 			int64_t fee_earned_msat_ref = ((uintptr_t)&obj->payment_forwarded.fee_earned_msat) | 1;
-			return (*env)->NewObject(env, LDKEvent_PaymentForwarded_class, LDKEvent_PaymentForwarded_meth, fee_earned_msat_ref, obj->payment_forwarded.claim_from_onchain_tx);
+			jboolean claim_from_onchain_tx_conv = obj->payment_forwarded.claim_from_onchain_tx;
+			return (*env)->NewObject(env, LDKEvent_PaymentForwarded_class, LDKEvent_PaymentForwarded_meth, fee_earned_msat_ref, claim_from_onchain_tx_conv);
 		}
 		case LDKEvent_ChannelClosed: {
 			int8_tArray channel_id_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, channel_id_arr, 0, 32, obj->channel_closed.channel_id.data);
+			int64_t user_channel_id_conv = obj->channel_closed.user_channel_id;
 			int64_t reason_ref = ((uintptr_t)&obj->channel_closed.reason) | 1;
-			return (*env)->NewObject(env, LDKEvent_ChannelClosed_class, LDKEvent_ChannelClosed_meth, channel_id_arr, obj->channel_closed.user_channel_id, reason_ref);
+			return (*env)->NewObject(env, LDKEvent_ChannelClosed_class, LDKEvent_ChannelClosed_meth, channel_id_arr, user_channel_id_conv, reason_ref);
 		}
 		case LDKEvent_DiscardFunding: {
 			int8_tArray channel_id_arr = (*env)->NewByteArray(env, 32);
@@ -2609,13 +2625,15 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEvent_1ref_1from_1ptr(JN
 			(*env)->SetByteArrayRegion(env, temporary_channel_id_arr, 0, 32, obj->open_channel_request.temporary_channel_id.data);
 			int8_tArray counterparty_node_id_arr = (*env)->NewByteArray(env, 33);
 			(*env)->SetByteArrayRegion(env, counterparty_node_id_arr, 0, 33, obj->open_channel_request.counterparty_node_id.compressed_form);
+			int64_t funding_satoshis_conv = obj->open_channel_request.funding_satoshis;
+			int64_t push_msat_conv = obj->open_channel_request.push_msat;
 			LDKChannelTypeFeatures channel_type_var = obj->open_channel_request.channel_type;
 			int64_t channel_type_ref = 0;
 			CHECK((((uintptr_t)channel_type_var.inner) & 1) == 0); // We rely on a free low bit, malloc guarantees this.
 			CHECK((((uintptr_t)&channel_type_var) & 1) == 0); // We rely on a free low bit, pointer alignment guarantees this.
 			CHECK_INNER_FIELD_ACCESS_OR_NULL(channel_type_var);
 			channel_type_ref = (uintptr_t)channel_type_var.inner & ~1;
-			return (*env)->NewObject(env, LDKEvent_OpenChannelRequest_class, LDKEvent_OpenChannelRequest_meth, temporary_channel_id_arr, counterparty_node_id_arr, obj->open_channel_request.funding_satoshis, obj->open_channel_request.push_msat, channel_type_ref);
+			return (*env)->NewObject(env, LDKEvent_OpenChannelRequest_class, LDKEvent_OpenChannelRequest_meth, temporary_channel_id_arr, counterparty_node_id_arr, funding_satoshis_conv, push_msat_conv, channel_type_ref);
 		}
 		default: abort();
 	}
@@ -3738,9 +3756,10 @@ LDKPublicKey get_per_commitment_point_LDKBaseSign_jcall(const void* this_arg, ui
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t idx_conv = idx;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int8_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_per_commitment_point_meth, idx);
+	int8_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_per_commitment_point_meth, idx_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_per_commitment_point in LDKBaseSign from rust threw an exception.");
@@ -3762,9 +3781,10 @@ LDKThirtyTwoBytes release_commitment_secret_LDKBaseSign_jcall(const void* this_a
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t idx_conv = idx;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int8_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->release_commitment_secret_meth, idx);
+	int8_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->release_commitment_secret_meth, idx_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to release_commitment_secret in LDKBaseSign from rust threw an exception.");
@@ -3902,11 +3922,12 @@ LDKCResult_NoneNoneZ validate_counterparty_revocation_LDKBaseSign_jcall(const vo
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t idx_conv = idx;
 	int8_tArray secret_arr = (*env)->NewByteArray(env, 32);
 	(*env)->SetByteArrayRegion(env, secret_arr, 0, 32, *secret);
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->validate_counterparty_revocation_meth, idx, secret_arr);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->validate_counterparty_revocation_meth, idx_conv, secret_arr);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to validate_counterparty_revocation in LDKBaseSign from rust threw an exception.");
@@ -3968,11 +3989,13 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_output_LDKBaseSign_jcall(const vo
 	int8_tArray justice_tx_arr = (*env)->NewByteArray(env, justice_tx_var.datalen);
 	(*env)->SetByteArrayRegion(env, justice_tx_arr, 0, justice_tx_var.datalen, justice_tx_var.data);
 	Transaction_free(justice_tx_var);
+	int64_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_key_arr = (*env)->NewByteArray(env, 32);
 	(*env)->SetByteArrayRegion(env, per_commitment_key_arr, 0, 32, *per_commitment_key);
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_justice_revoked_output_meth, justice_tx_arr, input, amount, per_commitment_key_arr);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_justice_revoked_output_meth, justice_tx_arr, input_conv, amount_conv, per_commitment_key_arr);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to sign_justice_revoked_output in LDKBaseSign from rust threw an exception.");
@@ -3999,6 +4022,8 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_htlc_LDKBaseSign_jcall(const void
 	int8_tArray justice_tx_arr = (*env)->NewByteArray(env, justice_tx_var.datalen);
 	(*env)->SetByteArrayRegion(env, justice_tx_arr, 0, justice_tx_var.datalen, justice_tx_var.data);
 	Transaction_free(justice_tx_var);
+	int64_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_key_arr = (*env)->NewByteArray(env, 32);
 	(*env)->SetByteArrayRegion(env, per_commitment_key_arr, 0, 32, *per_commitment_key);
 	LDKHTLCOutputInCommitment htlc_var = *htlc;
@@ -4013,7 +4038,7 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_htlc_LDKBaseSign_jcall(const void
 	}
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_justice_revoked_htlc_meth, justice_tx_arr, input, amount, per_commitment_key_arr, htlc_ref);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_justice_revoked_htlc_meth, justice_tx_arr, input_conv, amount_conv, per_commitment_key_arr, htlc_ref);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to sign_justice_revoked_htlc in LDKBaseSign from rust threw an exception.");
@@ -4040,6 +4065,8 @@ LDKCResult_SignatureNoneZ sign_counterparty_htlc_transaction_LDKBaseSign_jcall(c
 	int8_tArray htlc_tx_arr = (*env)->NewByteArray(env, htlc_tx_var.datalen);
 	(*env)->SetByteArrayRegion(env, htlc_tx_arr, 0, htlc_tx_var.datalen, htlc_tx_var.data);
 	Transaction_free(htlc_tx_var);
+	int64_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_point_arr = (*env)->NewByteArray(env, 33);
 	(*env)->SetByteArrayRegion(env, per_commitment_point_arr, 0, 33, per_commitment_point.compressed_form);
 	LDKHTLCOutputInCommitment htlc_var = *htlc;
@@ -4054,7 +4081,7 @@ LDKCResult_SignatureNoneZ sign_counterparty_htlc_transaction_LDKBaseSign_jcall(c
 	}
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_counterparty_htlc_transaction_meth, htlc_tx_arr, input, amount, per_commitment_point_arr, htlc_ref);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->sign_counterparty_htlc_transaction_meth, htlc_tx_arr, input_conv, amount_conv, per_commitment_point_arr, htlc_ref);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to sign_counterparty_htlc_transaction in LDKBaseSign from rust threw an exception.");
@@ -4793,7 +4820,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKCOption_1u16Z_1ref_1from
 	LDKCOption_u16Z *obj = (LDKCOption_u16Z*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKCOption_u16Z_Some: {
-			return (*env)->NewObject(env, LDKCOption_u16Z_Some_class, LDKCOption_u16Z_Some_meth, obj->some);
+			int16_t some_conv = obj->some;
+			return (*env)->NewObject(env, LDKCOption_u16Z_Some_class, LDKCOption_u16Z_Some_meth, some_conv);
 		}
 		case LDKCOption_u16Z_None: {
 			return (*env)->NewObject(env, LDKCOption_u16Z_None_class, LDKCOption_u16Z_None_meth);
@@ -4856,7 +4884,8 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKAPIError_1ref_1from_1ptr
 		case LDKAPIError_FeeRateTooHigh: {
 			LDKStr err_str = obj->fee_rate_too_high.err;
 			jstring err_conv = str_ref_to_java(env, err_str.chars, err_str.len);
-			return (*env)->NewObject(env, LDKAPIError_FeeRateTooHigh_class, LDKAPIError_FeeRateTooHigh_meth, err_conv, obj->fee_rate_too_high.feerate);
+			int32_t feerate_conv = obj->fee_rate_too_high.feerate;
+			return (*env)->NewObject(env, LDKAPIError_FeeRateTooHigh_class, LDKAPIError_FeeRateTooHigh_meth, err_conv, feerate_conv);
 		}
 		case LDKAPIError_RouteError: {
 			LDKStr err_str = obj->route_error.err;
@@ -5154,12 +5183,14 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKNetAddress_1ref_1from_1p
 		case LDKNetAddress_IPv4: {
 			int8_tArray addr_arr = (*env)->NewByteArray(env, 4);
 			(*env)->SetByteArrayRegion(env, addr_arr, 0, 4, obj->i_pv4.addr.data);
-			return (*env)->NewObject(env, LDKNetAddress_IPv4_class, LDKNetAddress_IPv4_meth, addr_arr, obj->i_pv4.port);
+			int16_t port_conv = obj->i_pv4.port;
+			return (*env)->NewObject(env, LDKNetAddress_IPv4_class, LDKNetAddress_IPv4_meth, addr_arr, port_conv);
 		}
 		case LDKNetAddress_IPv6: {
 			int8_tArray addr_arr = (*env)->NewByteArray(env, 16);
 			(*env)->SetByteArrayRegion(env, addr_arr, 0, 16, obj->i_pv6.addr.data);
-			return (*env)->NewObject(env, LDKNetAddress_IPv6_class, LDKNetAddress_IPv6_meth, addr_arr, obj->i_pv6.port);
+			int16_t port_conv = obj->i_pv6.port;
+			return (*env)->NewObject(env, LDKNetAddress_IPv6_class, LDKNetAddress_IPv6_meth, addr_arr, port_conv);
 		}
 		case LDKNetAddress_OnionV2: {
 			int8_tArray onion_v2_arr = (*env)->NewByteArray(env, 12);
@@ -5169,7 +5200,10 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKNetAddress_1ref_1from_1p
 		case LDKNetAddress_OnionV3: {
 			int8_tArray ed25519_pubkey_arr = (*env)->NewByteArray(env, 32);
 			(*env)->SetByteArrayRegion(env, ed25519_pubkey_arr, 0, 32, obj->onion_v3.ed25519_pubkey.data);
-			return (*env)->NewObject(env, LDKNetAddress_OnionV3_class, LDKNetAddress_OnionV3_meth, ed25519_pubkey_arr, obj->onion_v3.checksum, obj->onion_v3.version, obj->onion_v3.port);
+			int16_t checksum_conv = obj->onion_v3.checksum;
+			int8_t version_conv = obj->onion_v3.version;
+			int16_t port_conv = obj->onion_v3.port;
+			return (*env)->NewObject(env, LDKNetAddress_OnionV3_class, LDKNetAddress_OnionV3_meth, ed25519_pubkey_arr, checksum_conv, version_conv, port_conv);
 		}
 		default: abort();
 	}
@@ -5898,9 +5932,11 @@ LDKSign get_channel_signer_LDKKeysInterface_jcall(const void* this_arg, bool inb
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	jboolean inbound_conv = inbound;
+	int64_t channel_value_satoshis_conv = channel_value_satoshis;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->get_channel_signer_meth, inbound, channel_value_satoshis);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->get_channel_signer_meth, inbound_conv, channel_value_satoshis_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_channel_signer in LDKKeysInterface from rust threw an exception.");
@@ -6256,8 +6292,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_FeeEstimator_1get_1est_1sat
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKFeeEstimator* this_arg_conv = (LDKFeeEstimator*)this_arg_ptr;
 	LDKConfirmationTarget confirmation_target_conv = LDKConfirmationTarget_from_java(env, confirmation_target);
-	int32_t ret_val = (this_arg_conv->get_est_sat_per_1000_weight)(this_arg_conv->this_arg, confirmation_target_conv);
-	return ret_val;
+	int32_t ret_conv = (this_arg_conv->get_est_sat_per_1000_weight)(this_arg_conv->this_arg, confirmation_target_conv);
+	return ret_conv;
 }
 
 typedef struct LDKLogger_JCalls {
@@ -6593,8 +6629,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_Type_1type_1id(JNIEnv *env,
 	void* this_arg_ptr = (void*)(((uintptr_t)this_arg) & ~1);
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKType* this_arg_conv = (LDKType*)this_arg_ptr;
-	int16_t ret_val = (this_arg_conv->type_id)(this_arg_conv->this_arg);
-	return ret_val;
+	int16_t ret_conv = (this_arg_conv->type_id)(this_arg_conv->this_arg);
+	return ret_conv;
 }
 
 JNIEXPORT jstring JNICALL Java_org_ldk_impl_bindings_Type_1debug_1str(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -7450,8 +7486,8 @@ static inline uint32_t C2Tuple_u32ScriptZ_get_a(LDKC2Tuple_u32ScriptZ *NONNULL_P
 }
 JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32ScriptZ_1get_1a(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKC2Tuple_u32ScriptZ* owner_conv = (LDKC2Tuple_u32ScriptZ*)(owner & ~1);
-	int32_t ret_val = C2Tuple_u32ScriptZ_get_a(owner_conv);
-	return ret_val;
+	int32_t ret_conv = C2Tuple_u32ScriptZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKCVec_u8Z C2Tuple_u32ScriptZ_get_b(LDKC2Tuple_u32ScriptZ *NONNULL_PTR owner){
@@ -7521,8 +7557,8 @@ static inline uint32_t C2Tuple_u32TxOutZ_get_a(LDKC2Tuple_u32TxOutZ *NONNULL_PTR
 }
 JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32TxOutZ_1get_1a(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKC2Tuple_u32TxOutZ* owner_conv = (LDKC2Tuple_u32TxOutZ*)(owner & ~1);
-	int32_t ret_val = C2Tuple_u32TxOutZ_get_a(owner_conv);
-	return ret_val;
+	int32_t ret_conv = C2Tuple_u32TxOutZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKTxOut C2Tuple_u32TxOutZ_get_b(LDKC2Tuple_u32TxOutZ *NONNULL_PTR owner){
@@ -7612,16 +7648,23 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKBalance_1ref_1from_1ptr(
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKBalance_ClaimableOnChannelClose: {
-			return (*env)->NewObject(env, LDKBalance_ClaimableOnChannelClose_class, LDKBalance_ClaimableOnChannelClose_meth, obj->claimable_on_channel_close.claimable_amount_satoshis);
+			int64_t claimable_amount_satoshis_conv = obj->claimable_on_channel_close.claimable_amount_satoshis;
+			return (*env)->NewObject(env, LDKBalance_ClaimableOnChannelClose_class, LDKBalance_ClaimableOnChannelClose_meth, claimable_amount_satoshis_conv);
 		}
 		case LDKBalance_ClaimableAwaitingConfirmations: {
-			return (*env)->NewObject(env, LDKBalance_ClaimableAwaitingConfirmations_class, LDKBalance_ClaimableAwaitingConfirmations_meth, obj->claimable_awaiting_confirmations.claimable_amount_satoshis, obj->claimable_awaiting_confirmations.confirmation_height);
+			int64_t claimable_amount_satoshis_conv = obj->claimable_awaiting_confirmations.claimable_amount_satoshis;
+			int32_t confirmation_height_conv = obj->claimable_awaiting_confirmations.confirmation_height;
+			return (*env)->NewObject(env, LDKBalance_ClaimableAwaitingConfirmations_class, LDKBalance_ClaimableAwaitingConfirmations_meth, claimable_amount_satoshis_conv, confirmation_height_conv);
 		}
 		case LDKBalance_ContentiousClaimable: {
-			return (*env)->NewObject(env, LDKBalance_ContentiousClaimable_class, LDKBalance_ContentiousClaimable_meth, obj->contentious_claimable.claimable_amount_satoshis, obj->contentious_claimable.timeout_height);
+			int64_t claimable_amount_satoshis_conv = obj->contentious_claimable.claimable_amount_satoshis;
+			int32_t timeout_height_conv = obj->contentious_claimable.timeout_height;
+			return (*env)->NewObject(env, LDKBalance_ContentiousClaimable_class, LDKBalance_ContentiousClaimable_meth, claimable_amount_satoshis_conv, timeout_height_conv);
 		}
 		case LDKBalance_MaybeClaimableHTLCAwaitingTimeout: {
-			return (*env)->NewObject(env, LDKBalance_MaybeClaimableHTLCAwaitingTimeout_class, LDKBalance_MaybeClaimableHTLCAwaitingTimeout_meth, obj->maybe_claimable_htlc_awaiting_timeout.claimable_amount_satoshis, obj->maybe_claimable_htlc_awaiting_timeout.claimable_height);
+			int64_t claimable_amount_satoshis_conv = obj->maybe_claimable_htlc_awaiting_timeout.claimable_amount_satoshis;
+			int32_t claimable_height_conv = obj->maybe_claimable_htlc_awaiting_timeout.claimable_height;
+			return (*env)->NewObject(env, LDKBalance_MaybeClaimableHTLCAwaitingTimeout_class, LDKBalance_MaybeClaimableHTLCAwaitingTimeout_meth, claimable_amount_satoshis_conv, claimable_height_conv);
 		}
 		default: abort();
 	}
@@ -7722,8 +7765,8 @@ CHECK(owner->result_ok);
 }
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1get_1ok(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKCResult_boolLightningErrorZ* owner_conv = (LDKCResult_boolLightningErrorZ*)(owner & ~1);
-	jboolean ret_val = CResult_boolLightningErrorZ_get_ok(owner_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolLightningErrorZ_get_ok(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKLightningError CResult_boolLightningErrorZ_get_err(LDKCResult_boolLightningErrorZ *NONNULL_PTR owner){
@@ -7902,8 +7945,8 @@ CHECK(owner->result_ok);
 }
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1get_1ok(JNIEnv *env, jclass clz, int64_t owner) {
 	LDKCResult_boolPeerHandleErrorZ* owner_conv = (LDKCResult_boolPeerHandleErrorZ*)(owner & ~1);
-	jboolean ret_val = CResult_boolPeerHandleErrorZ_get_ok(owner_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolPeerHandleErrorZ_get_ok(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKPeerHandleError CResult_boolPeerHandleErrorZ_get_err(LDKCResult_boolPeerHandleErrorZ *NONNULL_PTR owner){
@@ -8024,9 +8067,10 @@ LDKCResult_TxOutAccessErrorZ get_utxo_LDKAccess_jcall(const void* this_arg, cons
 	}
 	int8_tArray genesis_hash_arr = (*env)->NewByteArray(env, 32);
 	(*env)->SetByteArrayRegion(env, genesis_hash_arr, 0, 32, *genesis_hash);
+	int64_t short_channel_id_conv = short_channel_id;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->get_utxo_meth, genesis_hash_arr, short_channel_id);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->get_utxo_meth, genesis_hash_arr, short_channel_id_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_utxo in LDKAccess from rust threw an exception.");
@@ -10197,9 +10241,10 @@ void block_connected_LDKListen_jcall(const void* this_arg, LDKu8slice block, uin
 	LDKu8slice block_var = block;
 	int8_tArray block_arr = (*env)->NewByteArray(env, block_var.datalen);
 	(*env)->SetByteArrayRegion(env, block_arr, 0, block_var.datalen, block_var.data);
+	int32_t height_conv = height;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->block_connected_meth, block_arr, height);
+	(*env)->CallVoidMethod(env, obj, j_calls->block_connected_meth, block_arr, height_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to block_connected in LDKListen from rust threw an exception.");
@@ -10219,9 +10264,10 @@ void block_disconnected_LDKListen_jcall(const void* this_arg, const uint8_t (* h
 	}
 	int8_tArray header_arr = (*env)->NewByteArray(env, 80);
 	(*env)->SetByteArrayRegion(env, header_arr, 0, 80, *header);
+	int32_t height_conv = height;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->block_disconnected_meth, header_arr, height);
+	(*env)->CallVoidMethod(env, obj, j_calls->block_disconnected_meth, header_arr, height_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to block_disconnected in LDKListen from rust threw an exception.");
@@ -10329,9 +10375,10 @@ void transactions_confirmed_LDKConfirm_jcall(const void* this_arg, const uint8_t
 	}
 	(*env)->ReleasePrimitiveArrayCritical(env, txdata_arr, txdata_arr_ptr, 0);
 	FREE(txdata_var.data);
+	int32_t height_conv = height;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->transactions_confirmed_meth, header_arr, txdata_arr, height);
+	(*env)->CallVoidMethod(env, obj, j_calls->transactions_confirmed_meth, header_arr, txdata_arr, height_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to transactions_confirmed in LDKConfirm from rust threw an exception.");
@@ -10373,9 +10420,10 @@ void best_block_updated_LDKConfirm_jcall(const void* this_arg, const uint8_t (* 
 	}
 	int8_tArray header_arr = (*env)->NewByteArray(env, 80);
 	(*env)->SetByteArrayRegion(env, header_arr, 0, 80, *header);
+	int32_t height_conv = height;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->best_block_updated_meth, header_arr, height);
+	(*env)->CallVoidMethod(env, obj, j_calls->best_block_updated_meth, header_arr, height_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to best_block_updated in LDKConfirm from rust threw an exception.");
@@ -11303,9 +11351,10 @@ void peer_disconnected_LDKChannelMessageHandler_jcall(const void* this_arg, LDKP
 	}
 	int8_tArray their_node_id_arr = (*env)->NewByteArray(env, 33);
 	(*env)->SetByteArrayRegion(env, their_node_id_arr, 0, 33, their_node_id.compressed_form);
+	jboolean no_connection_possible_conv = no_connection_possible;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->peer_disconnected_meth, their_node_id_arr, no_connection_possible);
+	(*env)->CallVoidMethod(env, obj, j_calls->peer_disconnected_meth, their_node_id_arr, no_connection_possible_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to peer_disconnected in LDKChannelMessageHandler from rust threw an exception.");
@@ -11971,9 +12020,11 @@ LDKCVec_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZZ get_next_channel
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t starting_point_conv = starting_point;
+	int8_t batch_amount_conv = batch_amount;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int64_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_next_channel_announcements_meth, starting_point, batch_amount);
+	int64_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_next_channel_announcements_meth, starting_point_conv, batch_amount_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_next_channel_announcements in LDKRoutingMessageHandler from rust threw an exception.");
@@ -12010,9 +12061,10 @@ LDKCVec_NodeAnnouncementZ get_next_node_announcements_LDKRoutingMessageHandler_j
 	}
 	int8_tArray starting_point_arr = (*env)->NewByteArray(env, 33);
 	(*env)->SetByteArrayRegion(env, starting_point_arr, 0, 33, starting_point.compressed_form);
+	int8_t batch_amount_conv = batch_amount;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int64_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_next_node_announcements_meth, starting_point_arr, batch_amount);
+	int64_tArray ret = (*env)->CallObjectMethod(env, obj, j_calls->get_next_node_announcements_meth, starting_point_arr, batch_amount_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to get_next_node_announcements in LDKRoutingMessageHandler from rust threw an exception.");
@@ -12475,12 +12527,13 @@ LDKCResult_COption_TypeZDecodeErrorZ read_LDKCustomMessageReader_jcall(const voi
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int16_t message_type_conv = message_type;
 	LDKu8slice buffer_var = buffer;
 	int8_tArray buffer_arr = (*env)->NewByteArray(env, buffer_var.datalen);
 	(*env)->SetByteArrayRegion(env, buffer_arr, 0, buffer_var.datalen, buffer_var.data);
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->read_meth, message_type, buffer_arr);
+	uint64_t ret = (*env)->CallLongMethod(env, obj, j_calls->read_meth, message_type_conv, buffer_arr);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to read in LDKCustomMessageReader from rust threw an exception.");
@@ -12737,9 +12790,10 @@ uintptr_t send_data_LDKSocketDescriptor_jcall(void* this_arg, LDKu8slice data, b
 	LDKu8slice data_var = data;
 	int8_tArray data_arr = (*env)->NewByteArray(env, data_var.datalen);
 	(*env)->SetByteArrayRegion(env, data_arr, 0, data_var.datalen, data_var.data);
+	jboolean resume_read_conv = resume_read;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int64_t ret = (*env)->CallLongMethod(env, obj, j_calls->send_data_meth, data_arr, resume_read);
+	int64_t ret = (*env)->CallLongMethod(env, obj, j_calls->send_data_meth, data_arr, resume_read_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to send_data in LDKSocketDescriptor from rust threw an exception.");
@@ -12856,9 +12910,9 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1send_1dat
 	LDKu8slice data_ref;
 	data_ref.datalen = (*env)->GetArrayLength(env, data);
 	data_ref.data = (*env)->GetByteArrayElements (env, data, NULL);
-	int64_t ret_val = (this_arg_conv->send_data)(this_arg_conv->this_arg, data_ref, resume_read);
+	int64_t ret_conv = (this_arg_conv->send_data)(this_arg_conv->this_arg, data_ref, resume_read);
 	(*env)->ReleaseByteArrayElements(env, data, (int8_t*)data_ref.data, 0);
-	return ret_val;
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1disconnect_1socket(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -12872,8 +12926,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1hash(JNIE
 	void* this_arg_ptr = (void*)(((uintptr_t)this_arg) & ~1);
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKSocketDescriptor* this_arg_conv = (LDKSocketDescriptor*)this_arg_ptr;
-	int64_t ret_val = (this_arg_conv->hash)(this_arg_conv->this_arg);
-	return ret_val;
+	int64_t ret_conv = (this_arg_conv->hash)(this_arg_conv->this_arg);
+	return ret_conv;
 }
 
 static jclass LDKEffectiveCapacity_ExactLiquidity_class = NULL;
@@ -12917,13 +12971,16 @@ JNIEXPORT jobject JNICALL Java_org_ldk_impl_bindings_LDKEffectiveCapacity_1ref_1
 	LDKEffectiveCapacity *obj = (LDKEffectiveCapacity*)(ptr & ~1);
 	switch(obj->tag) {
 		case LDKEffectiveCapacity_ExactLiquidity: {
-			return (*env)->NewObject(env, LDKEffectiveCapacity_ExactLiquidity_class, LDKEffectiveCapacity_ExactLiquidity_meth, obj->exact_liquidity.liquidity_msat);
+			int64_t liquidity_msat_conv = obj->exact_liquidity.liquidity_msat;
+			return (*env)->NewObject(env, LDKEffectiveCapacity_ExactLiquidity_class, LDKEffectiveCapacity_ExactLiquidity_meth, liquidity_msat_conv);
 		}
 		case LDKEffectiveCapacity_MaximumHTLC: {
-			return (*env)->NewObject(env, LDKEffectiveCapacity_MaximumHTLC_class, LDKEffectiveCapacity_MaximumHTLC_meth, obj->maximum_htlc.amount_msat);
+			int64_t amount_msat_conv = obj->maximum_htlc.amount_msat;
+			return (*env)->NewObject(env, LDKEffectiveCapacity_MaximumHTLC_class, LDKEffectiveCapacity_MaximumHTLC_meth, amount_msat_conv);
 		}
 		case LDKEffectiveCapacity_Total: {
-			return (*env)->NewObject(env, LDKEffectiveCapacity_Total_class, LDKEffectiveCapacity_Total_meth, obj->total.capacity_msat);
+			int64_t capacity_msat_conv = obj->total.capacity_msat;
+			return (*env)->NewObject(env, LDKEffectiveCapacity_Total_class, LDKEffectiveCapacity_Total_meth, capacity_msat_conv);
 		}
 		case LDKEffectiveCapacity_Infinite: {
 			return (*env)->NewObject(env, LDKEffectiveCapacity_Infinite_class, LDKEffectiveCapacity_Infinite_meth);
@@ -12969,6 +13026,9 @@ uint64_t channel_penalty_msat_LDKScore_jcall(const void* this_arg, uint64_t shor
 	} else {
 		DO_ASSERT(get_jenv_res == JNI_OK);
 	}
+	int64_t short_channel_id_conv = short_channel_id;
+	int64_t send_amt_msat_conv = send_amt_msat;
+	int64_t capacity_msat_conv = capacity_msat;
 	LDKNodeId source_var = *source;
 	int64_t source_ref = 0;
 	source_var = NodeId_clone(&source_var);
@@ -12991,7 +13051,7 @@ uint64_t channel_penalty_msat_LDKScore_jcall(const void* this_arg, uint64_t shor
 	}
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	int64_t ret = (*env)->CallLongMethod(env, obj, j_calls->channel_penalty_msat_meth, short_channel_id, send_amt_msat, capacity_msat, source_ref, target_ref);
+	int64_t ret = (*env)->CallLongMethod(env, obj, j_calls->channel_penalty_msat_meth, short_channel_id_conv, send_amt_msat_conv, capacity_msat_conv, source_ref, target_ref);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to channel_penalty_msat in LDKScore from rust threw an exception.");
@@ -13028,9 +13088,10 @@ void payment_path_failed_LDKScore_jcall(void* this_arg, LDKCVec_RouteHopZ path, 
 	}
 	(*env)->ReleasePrimitiveArrayCritical(env, path_arr, path_arr_ptr, 0);
 	FREE(path_var.data);
+	int64_t short_channel_id_conv = short_channel_id;
 	jobject obj = (*env)->NewLocalRef(env, j_calls->o);
 	CHECK(obj != NULL);
-	(*env)->CallVoidMethod(env, obj, j_calls->payment_path_failed_meth, path_arr, short_channel_id);
+	(*env)->CallVoidMethod(env, obj, j_calls->payment_path_failed_meth, path_arr, short_channel_id_conv);
 	if (UNLIKELY((*env)->ExceptionCheck(env))) {
 		(*env)->ExceptionDescribe(env);
 		(*env)->FatalError(env, "A call to payment_path_failed in LDKScore from rust threw an exception.");
@@ -13149,8 +13210,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Score_1channel_1penalty_1ms
 	target_conv.inner = (void*)(target & (~1));
 	target_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(target_conv);
-	int64_t ret_val = (this_arg_conv->channel_penalty_msat)(this_arg_conv->this_arg, short_channel_id, send_amt_msat, capacity_msat, &source_conv, &target_conv);
-	return ret_val;
+	int64_t ret_conv = (this_arg_conv->channel_penalty_msat)(this_arg_conv->this_arg, short_channel_id, send_amt_msat, capacity_msat, &source_conv, &target_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Score_1payment_1path_1failed(JNIEnv *env, jclass clz, int64_t this_arg, int64_tArray path, int64_t short_channel_id) {
@@ -14030,8 +14091,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Bech32Error_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKBech32Error* arg_conv = (LDKBech32Error*)arg;
-	int64_t ret_val = Bech32Error_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Bech32Error_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Bech32Error_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14086,8 +14147,8 @@ static inline uintptr_t TxOut_clone_ptr(LDKTxOut *NONNULL_PTR arg) {
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxOut_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKTxOut* arg_conv = (LDKTxOut*)(arg & ~1);
-	int64_t ret_val = TxOut_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = TxOut_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxOut_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14116,8 +14177,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1err(JNI
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneNoneZ* o_conv = (LDKCResult_NoneNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14136,8 +14197,8 @@ static inline uintptr_t CResult_NoneNoneZ_clone_ptr(LDKCResult_NoneNoneZ *NONNUL
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneNoneZ* arg_conv = (LDKCResult_NoneNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14171,8 +14232,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommit
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommitmentSecretsDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ* o_conv = (LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommitmentSecretsDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14191,8 +14252,8 @@ static inline uintptr_t CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommitmentSecretsDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyCommitmentSecretsDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14220,8 +14281,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1e
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SecretKeyErrorZ* o_conv = (LDKCResult_SecretKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SecretKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SecretKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14240,8 +14301,8 @@ static inline uintptr_t CResult_SecretKeyErrorZ_clone_ptr(LDKCResult_SecretKeyEr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SecretKeyErrorZ* arg_conv = (LDKCResult_SecretKeyErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SecretKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SecretKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14269,8 +14330,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1e
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PublicKeyErrorZ* o_conv = (LDKCResult_PublicKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PublicKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PublicKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14289,8 +14350,8 @@ static inline uintptr_t CResult_PublicKeyErrorZ_clone_ptr(LDKCResult_PublicKeyEr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PublicKeyErrorZ* arg_conv = (LDKCResult_PublicKeyErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PublicKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PublicKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PublicKeyErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14324,8 +14385,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TxCreationKeysDecodeErrorZ* o_conv = (LDKCResult_TxCreationKeysDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxCreationKeysDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxCreationKeysDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14344,8 +14405,8 @@ static inline uintptr_t CResult_TxCreationKeysDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_TxCreationKeysDecodeErrorZ* arg_conv = (LDKCResult_TxCreationKeysDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_TxCreationKeysDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_TxCreationKeysDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14379,8 +14440,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelPublicKeysDecodeErrorZ* o_conv = (LDKCResult_ChannelPublicKeysDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelPublicKeysDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelPublicKeysDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14399,8 +14460,8 @@ static inline uintptr_t CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelPublicKeysDecodeErrorZ* arg_conv = (LDKCResult_ChannelPublicKeysDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelPublicKeysDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14430,8 +14491,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TxCreationKeysErrorZ* o_conv = (LDKCResult_TxCreationKeysErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxCreationKeysErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxCreationKeysErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14450,8 +14511,8 @@ static inline uintptr_t CResult_TxCreationKeysErrorZ_clone_ptr(LDKCResult_TxCrea
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_TxCreationKeysErrorZ* arg_conv = (LDKCResult_TxCreationKeysErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_TxCreationKeysErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_TxCreationKeysErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxCreationKeysErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14492,8 +14553,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u32Z_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_u32Z* arg_conv = (LDKCOption_u32Z*)arg;
-	int64_t ret_val = COption_u32Z_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_u32Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u32Z_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14528,8 +14589,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommit
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommitmentDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_HTLCOutputInCommitmentDecodeErrorZ* o_conv = (LDKCResult_HTLCOutputInCommitmentDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommitmentDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14548,8 +14609,8 @@ static inline uintptr_t CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(LDK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommitmentDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_HTLCOutputInCommitmentDecodeErrorZ* arg_conv = (LDKCResult_HTLCOutputInCommitmentDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCOutputInCommitmentDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14598,8 +14659,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChanne
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChannelTransactionParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ* o_conv = (LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChannelTransactionParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14618,8 +14679,8 @@ static inline uintptr_t CResult_CounterpartyChannelTransactionParametersDecodeEr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChannelTransactionParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyChannelTransactionParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14653,8 +14714,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransaction
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransactionParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelTransactionParametersDecodeErrorZ* o_conv = (LDKCResult_ChannelTransactionParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransactionParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14673,8 +14734,8 @@ static inline uintptr_t CResult_ChannelTransactionParametersDecodeErrorZ_clone_p
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransactionParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelTransactionParametersDecodeErrorZ* arg_conv = (LDKCResult_ChannelTransactionParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTransactionParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14725,8 +14786,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTransactionDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_HolderCommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_HolderCommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTransactionDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14745,8 +14806,8 @@ static inline uintptr_t CResult_HolderCommitmentTransactionDecodeErrorZ_clone_pt
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTransactionDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_HolderCommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_HolderCommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HolderCommitmentTransactionDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14780,8 +14841,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTra
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTransactionDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_BuiltCommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_BuiltCommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTransactionDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14800,8 +14861,8 @@ static inline uintptr_t CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTransactionDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_BuiltCommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_BuiltCommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1BuiltCommitmentTransactionDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14830,8 +14891,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedClosingTran
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedClosingTransactionNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TrustedClosingTransactionNoneZ* o_conv = (LDKCResult_TrustedClosingTransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TrustedClosingTransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TrustedClosingTransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedClosingTransactionNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14867,8 +14928,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransact
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransactionDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_CommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransactionDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14887,8 +14948,8 @@ static inline uintptr_t CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransactionDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_CommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentTransactionDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -14917,8 +14978,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedCommitmentT
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedCommitmentTransactionNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TrustedCommitmentTransactionNoneZ* o_conv = (LDKCResult_TrustedCommitmentTransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TrustedCommitmentTransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TrustedCommitmentTransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TrustedCommitmentTransactionNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14957,8 +15018,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNo
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CVec_SignatureZNoneZ* o_conv = (LDKCResult_CVec_SignatureZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_SignatureZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_SignatureZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -14977,8 +15038,8 @@ static inline uintptr_t CResult_CVec_SignatureZNoneZ_clone_ptr(LDKCResult_CVec_S
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CVec_SignatureZNoneZ* arg_conv = (LDKCResult_CVec_SignatureZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_CVec_SignatureZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CVec_SignatureZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1SignatureZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15012,8 +15073,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ShutdownScriptDecodeErrorZ* o_conv = (LDKCResult_ShutdownScriptDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownScriptDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownScriptDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15032,8 +15093,8 @@ static inline uintptr_t CResult_ShutdownScriptDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ShutdownScriptDecodeErrorZ* arg_conv = (LDKCResult_ShutdownScriptDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ShutdownScriptDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ShutdownScriptDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15067,8 +15128,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInva
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInvalidShutdownScriptZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ShutdownScriptInvalidShutdownScriptZ* o_conv = (LDKCResult_ShutdownScriptInvalidShutdownScriptZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInvalidShutdownScriptZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15087,8 +15148,8 @@ static inline uintptr_t CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(L
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInvalidShutdownScriptZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ShutdownScriptInvalidShutdownScriptZ* arg_conv = (LDKCResult_ShutdownScriptInvalidShutdownScriptZ*)(arg & ~1);
-	int64_t ret_val = CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownScriptInvalidShutdownScriptZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15113,8 +15174,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1err(JN
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneErrorZ* o_conv = (LDKCResult_NoneErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15133,8 +15194,8 @@ static inline uintptr_t CResult_NoneErrorZ_clone_ptr(LDKCResult_NoneErrorZ *NONN
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneErrorZ* arg_conv = (LDKCResult_NoneErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15168,8 +15229,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteHopDecodeErrorZ* o_conv = (LDKCResult_RouteHopDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHopDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHopDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15188,8 +15249,8 @@ static inline uintptr_t CResult_RouteHopDecodeErrorZ_clone_ptr(LDKCResult_RouteH
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteHopDecodeErrorZ* arg_conv = (LDKCResult_RouteHopDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteHopDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteHopDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHopDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15273,8 +15334,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteDecodeErrorZ* o_conv = (LDKCResult_RouteDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15293,8 +15354,8 @@ static inline uintptr_t CResult_RouteDecodeErrorZ_clone_ptr(LDKCResult_RouteDeco
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteDecodeErrorZ* arg_conv = (LDKCResult_RouteDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15328,8 +15389,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDec
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteParametersDecodeErrorZ* o_conv = (LDKCResult_RouteParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15348,8 +15409,8 @@ static inline uintptr_t CResult_RouteParametersDecodeErrorZ_clone_ptr(LDKCResult
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteParametersDecodeErrorZ* arg_conv = (LDKCResult_RouteParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15410,8 +15471,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u64Z_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_u64Z* arg_conv = (LDKCOption_u64Z*)arg;
-	int64_t ret_val = COption_u64Z_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_u64Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u64Z_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15446,8 +15507,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentParametersDecodeErrorZ* o_conv = (LDKCResult_PaymentParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15466,8 +15527,8 @@ static inline uintptr_t CResult_PaymentParametersDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentParametersDecodeErrorZ* arg_conv = (LDKCResult_PaymentParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15521,8 +15582,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteHintDecodeErrorZ* o_conv = (LDKCResult_RouteHintDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHintDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHintDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15541,8 +15602,8 @@ static inline uintptr_t CResult_RouteHintDecodeErrorZ_clone_ptr(LDKCResult_Route
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteHintDecodeErrorZ* arg_conv = (LDKCResult_RouteHintDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteHintDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteHintDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15576,8 +15637,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteHintHopDecodeErrorZ* o_conv = (LDKCResult_RouteHintHopDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHintHopDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHintHopDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15596,8 +15657,8 @@ static inline uintptr_t CResult_RouteHintHopDecodeErrorZ_clone_ptr(LDKCResult_Ro
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteHintHopDecodeErrorZ* arg_conv = (LDKCResult_RouteHintHopDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteHintHopDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteHintHopDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteHintHopDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15651,8 +15712,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RouteLightningErrorZ* o_conv = (LDKCResult_RouteLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15671,8 +15732,8 @@ static inline uintptr_t CResult_RouteLightningErrorZ_clone_ptr(LDKCResult_RouteL
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RouteLightningErrorZ* arg_conv = (LDKCResult_RouteLightningErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RouteLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RouteLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RouteLightningErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15701,8 +15762,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TxOutAccessErrorZ* o_conv = (LDKCResult_TxOutAccessErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxOutAccessErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxOutAccessErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15721,8 +15782,8 @@ static inline uintptr_t CResult_TxOutAccessErrorZ_clone_ptr(LDKCResult_TxOutAcce
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_TxOutAccessErrorZ* arg_conv = (LDKCResult_TxOutAccessErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_TxOutAccessErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_TxOutAccessErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TxOutAccessErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15739,8 +15800,8 @@ static inline uintptr_t C2Tuple_usizeTransactionZ_clone_ptr(LDKC2Tuple_usizeTran
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1usizeTransactionZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_usizeTransactionZ* arg_conv = (LDKC2Tuple_usizeTransactionZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_usizeTransactionZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_usizeTransactionZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1usizeTransactionZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15822,8 +15883,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitor
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitorUpdateErrZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneChannelMonitorUpdateErrZ* o_conv = (LDKCResult_NoneChannelMonitorUpdateErrZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneChannelMonitorUpdateErrZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneChannelMonitorUpdateErrZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitorUpdateErrZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -15842,8 +15903,8 @@ static inline uintptr_t CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitorUpdateErrZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneChannelMonitorUpdateErrZ* arg_conv = (LDKCResult_NoneChannelMonitorUpdateErrZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneChannelMonitorUpdateErrZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15908,8 +15969,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1C2Tuple_1usizeTransactionZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_C2Tuple_usizeTransactionZZ* arg_conv = (LDKCOption_C2Tuple_usizeTransactionZZ*)arg;
-	int64_t ret_val = COption_C2Tuple_usizeTransactionZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_C2Tuple_usizeTransactionZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1C2Tuple_1usizeTransactionZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15955,8 +16016,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1ClosureReasonZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_ClosureReasonZ* arg_conv = (LDKCOption_ClosureReasonZ*)arg;
-	int64_t ret_val = COption_ClosureReasonZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_ClosureReasonZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1ClosureReasonZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -15990,8 +16051,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureRe
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureReasonZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_ClosureReasonZDecodeErrorZ* o_conv = (LDKCResult_COption_ClosureReasonZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureReasonZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16010,8 +16071,8 @@ static inline uintptr_t CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(LDK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureReasonZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_ClosureReasonZDecodeErrorZ* arg_conv = (LDKCResult_COption_ClosureReasonZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1ClosureReasonZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16056,8 +16117,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1NetworkUpdateZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_NetworkUpdateZ* arg_conv = (LDKCOption_NetworkUpdateZ*)arg;
-	int64_t ret_val = COption_NetworkUpdateZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_NetworkUpdateZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1NetworkUpdateZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16123,8 +16184,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1EventZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_EventZ* arg_conv = (LDKCOption_EventZ*)arg;
-	int64_t ret_val = COption_EventZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_EventZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1EventZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16158,8 +16219,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDec
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_EventZDecodeErrorZ* o_conv = (LDKCResult_COption_EventZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_EventZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_EventZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16178,8 +16239,8 @@ static inline uintptr_t CResult_COption_EventZDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_EventZDecodeErrorZ* arg_conv = (LDKCResult_COption_EventZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_EventZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_EventZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1EventZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16233,8 +16294,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorer
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorerDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_FixedPenaltyScorerDecodeErrorZ* o_conv = (LDKCResult_FixedPenaltyScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorerDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16253,8 +16314,8 @@ static inline uintptr_t CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(LDKCRes
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorerDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_FixedPenaltyScorerDecodeErrorZ* arg_conv = (LDKCResult_FixedPenaltyScorerDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FixedPenaltyScorerDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16288,8 +16349,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ScoringParametersDecodeErrorZ* o_conv = (LDKCResult_ScoringParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ScoringParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ScoringParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16308,8 +16369,8 @@ static inline uintptr_t CResult_ScoringParametersDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ScoringParametersDecodeErrorZ* arg_conv = (LDKCResult_ScoringParametersDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ScoringParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ScoringParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ScoringParametersDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16343,8 +16404,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ScorerDecodeErrorZ
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ScorerDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ScorerDecodeErrorZ* o_conv = (LDKCResult_ScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ScorerDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16380,8 +16441,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ProbabilisticScore
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ProbabilisticScorerDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ProbabilisticScorerDecodeErrorZ* o_conv = (LDKCResult_ProbabilisticScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ProbabilisticScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ProbabilisticScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ProbabilisticScorerDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16417,8 +16478,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InitFeaturesDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InitFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InitFeaturesDecodeErrorZ* o_conv = (LDKCResult_InitFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InitFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InitFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InitFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16454,8 +16515,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelFeaturesDec
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelFeaturesDecodeErrorZ* o_conv = (LDKCResult_ChannelFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16491,8 +16552,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeFeaturesDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeFeaturesDecodeErrorZ* o_conv = (LDKCResult_NodeFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16528,8 +16589,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceFeaturesDec
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InvoiceFeaturesDecodeErrorZ* o_conv = (LDKCResult_InvoiceFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16565,8 +16626,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTypeFeature
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTypeFeaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelTypeFeaturesDecodeErrorZ* o_conv = (LDKCResult_ChannelTypeFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelTypeFeaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16602,8 +16663,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutp
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutputDescriptorDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutputDescriptorDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16622,8 +16683,8 @@ static inline uintptr_t CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutputDescriptorDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DelayedPaymentOutputDescriptorDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16657,8 +16718,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutpu
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutputDescriptorDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutputDescriptorDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16677,8 +16738,8 @@ static inline uintptr_t CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutputDescriptorDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1StaticPaymentOutputDescriptorDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16711,8 +16772,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDes
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDescriptorDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SpendableOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_SpendableOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDescriptorDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16731,8 +16792,8 @@ static inline uintptr_t CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDescriptorDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SpendableOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_SpendableOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SpendableOutputDescriptorDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16766,8 +16827,8 @@ static inline uintptr_t C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(LDKC2Tuple_S
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1SignatureCVec_1SignatureZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_SignatureCVec_SignatureZZ* arg_conv = (LDKC2Tuple_SignatureCVec_SignatureZZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1SignatureCVec_1SignatureZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16826,8 +16887,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1Signature
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureCVec_1SignatureZZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ* o_conv = (LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureCVec_1SignatureZZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16846,8 +16907,8 @@ static inline uintptr_t CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureCVec_1SignatureZZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ* arg_conv = (LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureCVec_1SignatureZZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16874,8 +16935,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1er
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SignatureNoneZ* o_conv = (LDKCResult_SignatureNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_SignatureNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignatureNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16894,8 +16955,8 @@ static inline uintptr_t CResult_SignatureNoneZ_clone_ptr(LDKCResult_SignatureNon
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SignatureNoneZ* arg_conv = (LDKCResult_SignatureNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_SignatureNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SignatureNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignatureNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16912,8 +16973,8 @@ static inline uintptr_t C2Tuple_SignatureSignatureZ_clone_ptr(LDKC2Tuple_Signatu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1SignatureSignatureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_SignatureSignatureZ* arg_conv = (LDKC2Tuple_SignatureSignatureZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_SignatureSignatureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_SignatureSignatureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1SignatureSignatureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -16962,8 +17023,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1Signature
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureSignatureZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_SignatureSignatureZNoneZ* o_conv = (LDKCResult_C2Tuple_SignatureSignatureZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureSignatureZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -16982,8 +17043,8 @@ static inline uintptr_t CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(LDKCR
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureSignatureZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_SignatureSignatureZNoneZ* arg_conv = (LDKCResult_C2Tuple_SignatureSignatureZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1SignatureSignatureZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17010,8 +17071,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1er
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SecretKeyNoneZ* o_conv = (LDKCResult_SecretKeyNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_SecretKeyNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SecretKeyNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17030,8 +17091,8 @@ static inline uintptr_t CResult_SecretKeyNoneZ_clone_ptr(LDKCResult_SecretKeyNon
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SecretKeyNoneZ* arg_conv = (LDKCResult_SecretKeyNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_SecretKeyNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SecretKeyNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SecretKeyNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17067,8 +17128,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SignDecodeErrorZ* o_conv = (LDKCResult_SignDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SignDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17087,8 +17148,8 @@ static inline uintptr_t CResult_SignDecodeErrorZ_clone_ptr(LDKCResult_SignDecode
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SignDecodeErrorZ* arg_conv = (LDKCResult_SignDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SignDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SignDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17132,8 +17193,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatu
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatureNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RecoverableSignatureNoneZ* o_conv = (LDKCResult_RecoverableSignatureNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_RecoverableSignatureNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RecoverableSignatureNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatureNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17152,8 +17213,8 @@ static inline uintptr_t CResult_RecoverableSignatureNoneZ_clone_ptr(LDKCResult_R
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatureNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RecoverableSignatureNoneZ* arg_conv = (LDKCResult_RecoverableSignatureNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_RecoverableSignatureNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RecoverableSignatureNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RecoverableSignatureNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17217,8 +17278,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNo
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CVec_CVec_u8ZZNoneZ* o_conv = (LDKCResult_CVec_CVec_u8ZZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_CVec_u8ZZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_CVec_u8ZZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17237,8 +17298,8 @@ static inline uintptr_t CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(LDKCResult_CVec_CV
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CVec_CVec_u8ZZNoneZ* arg_conv = (LDKCResult_CVec_CVec_u8ZZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1CVec_1u8ZZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17272,8 +17333,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InMemorySignerDecodeErrorZ* o_conv = (LDKCResult_InMemorySignerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InMemorySignerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InMemorySignerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17292,8 +17353,8 @@ static inline uintptr_t CResult_InMemorySignerDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InMemorySignerDecodeErrorZ* arg_conv = (LDKCResult_InMemorySignerDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InMemorySignerDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InMemorySignerDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InMemorySignerDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17342,8 +17403,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_TransactionNoneZ* o_conv = (LDKCResult_TransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17362,8 +17423,8 @@ static inline uintptr_t CResult_TransactionNoneZ_clone_ptr(LDKCResult_Transactio
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_TransactionNoneZ* arg_conv = (LDKCResult_TransactionNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_TransactionNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_TransactionNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1TransactionNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17380,8 +17441,8 @@ static inline uintptr_t C2Tuple_BlockHashChannelMonitorZ_clone_ptr(LDKC2Tuple_Bl
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1BlockHashChannelMonitorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_BlockHashChannelMonitorZ* arg_conv = (LDKC2Tuple_BlockHashChannelMonitorZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_BlockHashChannelMonitorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_BlockHashChannelMonitorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1BlockHashChannelMonitorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17465,8 +17526,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1Blo
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1BlockHashChannelMonitorZZErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ* o_conv = (LDKCResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1BlockHashChannelMonitorZZErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17485,8 +17546,8 @@ static inline uintptr_t CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_clo
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1BlockHashChannelMonitorZZErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ* arg_conv = (LDKCResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1C2Tuple_1BlockHashChannelMonitorZZErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17527,8 +17588,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u16Z_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_u16Z* arg_conv = (LDKCOption_u16Z*)arg;
-	int64_t ret_val = COption_u16Z_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_u16Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1u16Z_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17557,8 +17618,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1err
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneAPIErrorZ* o_conv = (LDKCResult_NoneAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17577,8 +17638,8 @@ static inline uintptr_t CResult_NoneAPIErrorZ_clone_ptr(LDKCResult_NoneAPIErrorZ
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneAPIErrorZ* arg_conv = (LDKCResult_NoneAPIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneAPIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17649,8 +17710,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1e
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult__u832APIErrorZ* o_conv = (LDKCResult__u832APIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult__u832APIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult__u832APIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17669,8 +17730,8 @@ static inline uintptr_t CResult__u832APIErrorZ_clone_ptr(LDKCResult__u832APIErro
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult__u832APIErrorZ* arg_conv = (LDKCResult__u832APIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult__u832APIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult__u832APIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1_1u832APIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17701,8 +17762,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSe
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSendFailureZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentIdPaymentSendFailureZ* o_conv = (LDKCResult_PaymentIdPaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentIdPaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentIdPaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSendFailureZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17721,8 +17782,8 @@ static inline uintptr_t CResult_PaymentIdPaymentSendFailureZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSendFailureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentIdPaymentSendFailureZ* arg_conv = (LDKCResult_PaymentIdPaymentSendFailureZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentIdPaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentIdPaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentSendFailureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17750,8 +17811,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFai
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFailureZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NonePaymentSendFailureZ* o_conv = (LDKCResult_NonePaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_NonePaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NonePaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFailureZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17770,8 +17831,8 @@ static inline uintptr_t CResult_NonePaymentSendFailureZ_clone_ptr(LDKCResult_Non
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFailureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NonePaymentSendFailureZ* arg_conv = (LDKCResult_NonePaymentSendFailureZ*)(arg & ~1);
-	int64_t ret_val = CResult_NonePaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NonePaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePaymentSendFailureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17788,8 +17849,8 @@ static inline uintptr_t C2Tuple_PaymentHashPaymentIdZ_clone_ptr(LDKC2Tuple_Payme
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PaymentHashPaymentIdZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_PaymentHashPaymentIdZ* arg_conv = (LDKC2Tuple_PaymentHashPaymentIdZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_PaymentHashPaymentIdZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_PaymentHashPaymentIdZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PaymentHashPaymentIdZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17842,8 +17903,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentIdZPaymentSendFailureZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentIdZPaymentSendFailureZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17862,8 +17923,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentIdZPaymentSendFailureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentIdZPaymentSendFailureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17900,8 +17961,8 @@ static inline uintptr_t C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(LDKC2Tuple_P
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PaymentHashPaymentSecretZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_PaymentHashPaymentSecretZ* arg_conv = (LDKC2Tuple_PaymentHashPaymentSecretZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PaymentHashPaymentSecretZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -17950,8 +18011,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -17970,8 +18031,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18003,8 +18064,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZAPIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZAPIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18023,8 +18084,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZAPIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1PaymentHashPaymentSecretZAPIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18051,8 +18112,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentSecretNoneZ* o_conv = (LDKCResult_PaymentSecretNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentSecretNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentSecretNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18071,8 +18132,8 @@ static inline uintptr_t CResult_PaymentSecretNoneZ_clone_ptr(LDKCResult_PaymentS
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentSecretNoneZ* arg_conv = (LDKCResult_PaymentSecretNoneZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentSecretNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentSecretNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretNoneZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18103,8 +18164,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIEr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentSecretAPIErrorZ* o_conv = (LDKCResult_PaymentSecretAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentSecretAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentSecretAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18123,8 +18184,8 @@ static inline uintptr_t CResult_PaymentSecretAPIErrorZ_clone_ptr(LDKCResult_Paym
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentSecretAPIErrorZ* arg_conv = (LDKCResult_PaymentSecretAPIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentSecretAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentSecretAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentSecretAPIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18155,8 +18216,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPI
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPIErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentPreimageAPIErrorZ* o_conv = (LDKCResult_PaymentPreimageAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentPreimageAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentPreimageAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPIErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18175,8 +18236,8 @@ static inline uintptr_t CResult_PaymentPreimageAPIErrorZ_clone_ptr(LDKCResult_Pa
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPIErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentPreimageAPIErrorZ* arg_conv = (LDKCResult_PaymentPreimageAPIErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentPreimageAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentPreimageAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentPreimageAPIErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18210,8 +18271,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwar
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwardingInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CounterpartyForwardingInfoDecodeErrorZ* o_conv = (LDKCResult_CounterpartyForwardingInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwardingInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18230,8 +18291,8 @@ static inline uintptr_t CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwardingInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CounterpartyForwardingInfoDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyForwardingInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CounterpartyForwardingInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18265,8 +18326,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpart
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpartyDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelCounterpartyDecodeErrorZ* o_conv = (LDKCResult_ChannelCounterpartyDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelCounterpartyDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelCounterpartyDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpartyDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18285,8 +18346,8 @@ static inline uintptr_t CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(LDKCRe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpartyDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelCounterpartyDecodeErrorZ* arg_conv = (LDKCResult_ChannelCounterpartyDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelCounterpartyDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18320,8 +18381,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelDetailsDecodeErrorZ* o_conv = (LDKCResult_ChannelDetailsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelDetailsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelDetailsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18340,8 +18401,8 @@ static inline uintptr_t CResult_ChannelDetailsDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelDetailsDecodeErrorZ* arg_conv = (LDKCResult_ChannelDetailsDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelDetailsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelDetailsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelDetailsDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18375,8 +18436,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PhantomRouteHintsDecodeErrorZ* o_conv = (LDKCResult_PhantomRouteHintsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PhantomRouteHintsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PhantomRouteHintsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18395,8 +18456,8 @@ static inline uintptr_t CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PhantomRouteHintsDecodeErrorZ* arg_conv = (LDKCResult_PhantomRouteHintsDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PhantomRouteHintsDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18472,8 +18533,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHash
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelManagerZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ* o_conv = (LDKCResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelManagerZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18509,8 +18570,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelConfigDecodeErrorZ* o_conv = (LDKCResult_ChannelConfigDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelConfigDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelConfigDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18529,8 +18590,8 @@ static inline uintptr_t CResult_ChannelConfigDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelConfigDecodeErrorZ* arg_conv = (LDKCResult_ChannelConfigDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelConfigDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelConfigDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelConfigDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18564,8 +18625,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_OutPointDecodeErrorZ* o_conv = (LDKCResult_OutPointDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_OutPointDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_OutPointDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18584,8 +18645,8 @@ static inline uintptr_t CResult_OutPointDecodeErrorZ_clone_ptr(LDKCResult_OutPoi
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_OutPointDecodeErrorZ* arg_conv = (LDKCResult_OutPointDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_OutPointDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_OutPointDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OutPointDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18633,8 +18694,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1TypeZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_TypeZ* arg_conv = (LDKCOption_TypeZ*)arg;
-	int64_t ret_val = COption_TypeZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_TypeZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1TypeZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18668,8 +18729,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_TypeZDecodeErrorZ* o_conv = (LDKCResult_COption_TypeZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_TypeZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_TypeZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18688,8 +18749,8 @@ static inline uintptr_t CResult_COption_TypeZDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_TypeZDecodeErrorZ* arg_conv = (LDKCResult_COption_TypeZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_TypeZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_TypeZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1TypeZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18720,8 +18781,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentEr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PaymentIdPaymentErrorZ* o_conv = (LDKCResult_PaymentIdPaymentErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentIdPaymentErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentIdPaymentErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18740,8 +18801,8 @@ static inline uintptr_t CResult_PaymentIdPaymentErrorZ_clone_ptr(LDKCResult_Paym
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PaymentIdPaymentErrorZ* arg_conv = (LDKCResult_PaymentIdPaymentErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PaymentIdPaymentErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PaymentIdPaymentErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PaymentIdPaymentErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18770,8 +18831,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseError
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SiPrefixParseErrorZ* o_conv = (LDKCResult_SiPrefixParseErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SiPrefixParseErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SiPrefixParseErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18790,8 +18851,8 @@ static inline uintptr_t CResult_SiPrefixParseErrorZ_clone_ptr(LDKCResult_SiPrefi
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SiPrefixParseErrorZ* arg_conv = (LDKCResult_SiPrefixParseErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SiPrefixParseErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SiPrefixParseErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SiPrefixParseErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18824,8 +18885,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSema
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSemanticErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InvoiceParseOrSemanticErrorZ* o_conv = (LDKCResult_InvoiceParseOrSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceParseOrSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceParseOrSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSemanticErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18844,8 +18905,8 @@ static inline uintptr_t CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSemanticErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InvoiceParseOrSemanticErrorZ* arg_conv = (LDKCResult_InvoiceParseOrSemanticErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceParseOrSemanticErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18878,8 +18939,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoicePa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoiceParseErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_SignedRawInvoiceParseErrorZ* o_conv = (LDKCResult_SignedRawInvoiceParseErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SignedRawInvoiceParseErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignedRawInvoiceParseErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoiceParseErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18898,8 +18959,8 @@ static inline uintptr_t CResult_SignedRawInvoiceParseErrorZ_clone_ptr(LDKCResult
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoiceParseErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_SignedRawInvoiceParseErrorZ* arg_conv = (LDKCResult_SignedRawInvoiceParseErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_SignedRawInvoiceParseErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_SignedRawInvoiceParseErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1SignedRawInvoiceParseErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18916,8 +18977,8 @@ static inline uintptr_t C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(LDKC3
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C3Tuple_1RawInvoice_1u832InvoiceSignatureZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC3Tuple_RawInvoice_u832InvoiceSignatureZ* arg_conv = (LDKC3Tuple_RawInvoice_u832InvoiceSignatureZ*)(arg & ~1);
-	int64_t ret_val = C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C3Tuple_1RawInvoice_1u832InvoiceSignatureZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -18975,8 +19036,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PayeePubKeyErrorZ* o_conv = (LDKCResult_PayeePubKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PayeePubKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PayeePubKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -18995,8 +19056,8 @@ static inline uintptr_t CResult_PayeePubKeyErrorZ_clone_ptr(LDKCResult_PayeePubK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PayeePubKeyErrorZ* arg_conv = (LDKCResult_PayeePubKeyErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PayeePubKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PayeePubKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PayeePubKeyErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19046,8 +19107,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampC
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampCreationErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PositiveTimestampCreationErrorZ* o_conv = (LDKCResult_PositiveTimestampCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PositiveTimestampCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PositiveTimestampCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampCreationErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19066,8 +19127,8 @@ static inline uintptr_t CResult_PositiveTimestampCreationErrorZ_clone_ptr(LDKCRe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampCreationErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PositiveTimestampCreationErrorZ* arg_conv = (LDKCResult_PositiveTimestampCreationErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PositiveTimestampCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PositiveTimestampCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PositiveTimestampCreationErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19092,8 +19153,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneSemanticErrorZ* o_conv = (LDKCResult_NoneSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19112,8 +19173,8 @@ static inline uintptr_t CResult_NoneSemanticErrorZ_clone_ptr(LDKCResult_NoneSema
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneSemanticErrorZ* arg_conv = (LDKCResult_NoneSemanticErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneSemanticErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19143,8 +19204,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InvoiceSemanticErrorZ* o_conv = (LDKCResult_InvoiceSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19163,8 +19224,8 @@ static inline uintptr_t CResult_InvoiceSemanticErrorZ_clone_ptr(LDKCResult_Invoi
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InvoiceSemanticErrorZ* arg_conv = (LDKCResult_InvoiceSemanticErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InvoiceSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InvoiceSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSemanticErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19194,8 +19255,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreatio
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreationErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_DescriptionCreationErrorZ* o_conv = (LDKCResult_DescriptionCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_DescriptionCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_DescriptionCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreationErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19214,8 +19275,8 @@ static inline uintptr_t CResult_DescriptionCreationErrorZ_clone_ptr(LDKCResult_D
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreationErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_DescriptionCreationErrorZ* arg_conv = (LDKCResult_DescriptionCreationErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_DescriptionCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_DescriptionCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1DescriptionCreationErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19245,8 +19306,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreati
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreationErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PrivateRouteCreationErrorZ* o_conv = (LDKCResult_PrivateRouteCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PrivateRouteCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PrivateRouteCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreationErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19265,8 +19326,8 @@ static inline uintptr_t CResult_PrivateRouteCreationErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreationErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PrivateRouteCreationErrorZ* arg_conv = (LDKCResult_PrivateRouteCreationErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PrivateRouteCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PrivateRouteCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PrivateRouteCreationErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19292,8 +19353,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1StringErrorZ_1err(
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1StringErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_StringErrorZ* o_conv = (LDKCResult_StringErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_StringErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_StringErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1StringErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19329,8 +19390,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpda
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpdateDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelMonitorUpdateDecodeErrorZ* o_conv = (LDKCResult_ChannelMonitorUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpdateDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19349,8 +19410,8 @@ static inline uintptr_t CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(LDKCR
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpdateDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelMonitorUpdateDecodeErrorZ* arg_conv = (LDKCResult_ChannelMonitorUpdateDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelMonitorUpdateDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19395,8 +19456,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1MonitorEventZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_MonitorEventZ* arg_conv = (LDKCOption_MonitorEventZ*)arg;
-	int64_t ret_val = COption_MonitorEventZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_MonitorEventZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1MonitorEventZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19430,8 +19491,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEv
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEventZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* o_conv = (LDKCResult_COption_MonitorEventZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_MonitorEventZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_MonitorEventZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEventZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19450,8 +19511,8 @@ static inline uintptr_t CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEventZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* arg_conv = (LDKCResult_COption_MonitorEventZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1MonitorEventZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19485,8 +19546,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeEr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_HTLCUpdateDecodeErrorZ* o_conv = (LDKCResult_HTLCUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HTLCUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HTLCUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19505,8 +19566,8 @@ static inline uintptr_t CResult_HTLCUpdateDecodeErrorZ_clone_ptr(LDKCResult_HTLC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_HTLCUpdateDecodeErrorZ* arg_conv = (LDKCResult_HTLCUpdateDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_HTLCUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_HTLCUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1HTLCUpdateDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19523,8 +19584,8 @@ static inline uintptr_t C2Tuple_OutPointScriptZ_clone_ptr(LDKC2Tuple_OutPointScr
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1OutPointScriptZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_OutPointScriptZ* arg_conv = (LDKC2Tuple_OutPointScriptZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_OutPointScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_OutPointScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1OutPointScriptZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19565,8 +19626,8 @@ static inline uintptr_t C2Tuple_u32ScriptZ_clone_ptr(LDKC2Tuple_u32ScriptZ *NONN
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32ScriptZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_u32ScriptZ* arg_conv = (LDKC2Tuple_u32ScriptZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_u32ScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_u32ScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32ScriptZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19622,8 +19683,8 @@ static inline uintptr_t C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(LDKC2Tup
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1TxidCVec_1C2Tuple_1u32ScriptZZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ* arg_conv = (LDKC2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1TxidCVec_1C2Tuple_1u32ScriptZZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19733,8 +19794,8 @@ static inline uintptr_t C2Tuple_u32TxOutZ_clone_ptr(LDKC2Tuple_u32TxOutZ *NONNUL
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32TxOutZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_u32TxOutZ* arg_conv = (LDKC2Tuple_u32TxOutZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_u32TxOutZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_u32TxOutZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1u32TxOutZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19790,8 +19851,8 @@ static inline uintptr_t C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(LDKC2Tupl
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1TxidCVec_1C2Tuple_1u32TxOutZZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ* arg_conv = (LDKC2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1TxidCVec_1C2Tuple_1u32TxOutZZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19898,8 +19959,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHash
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelMonitorZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ* o_conv = (LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelMonitorZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19918,8 +19979,8 @@ static inline uintptr_t CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clo
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelMonitorZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ* arg_conv = (LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1C2Tuple_1BlockHashChannelMonitorZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19948,8 +20009,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningError
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NoneLightningErrorZ* o_conv = (LDKCResult_NoneLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -19968,8 +20029,8 @@ static inline uintptr_t CResult_NoneLightningErrorZ_clone_ptr(LDKCResult_NoneLig
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NoneLightningErrorZ* arg_conv = (LDKCResult_NoneLightningErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NoneLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NoneLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NoneLightningErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -19986,8 +20047,8 @@ static inline uintptr_t C2Tuple_PublicKeyTypeZ_clone_ptr(LDKC2Tuple_PublicKeyTyp
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PublicKeyTypeZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC2Tuple_PublicKeyTypeZ* arg_conv = (LDKC2Tuple_PublicKeyTypeZ*)(arg & ~1);
-	int64_t ret_val = C2Tuple_PublicKeyTypeZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C2Tuple_PublicKeyTypeZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C2Tuple_1PublicKeyTypeZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20061,8 +20122,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningError
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_boolLightningErrorZ* o_conv = (LDKCResult_boolLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_boolLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20081,8 +20142,8 @@ static inline uintptr_t CResult_boolLightningErrorZ_clone_ptr(LDKCResult_boolLig
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_boolLightningErrorZ* arg_conv = (LDKCResult_boolLightningErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_boolLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_boolLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolLightningErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20099,8 +20160,8 @@ static inline uintptr_t C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_c
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C3Tuple_1ChannelAnnouncementChannelUpdateChannelUpdateZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKC3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ* arg_conv = (LDKC3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ*)(arg & ~1);
-	int64_t ret_val = C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_C3Tuple_1ChannelAnnouncementChannelUpdateChannelUpdateZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20232,8 +20293,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1NetAddressZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_NetAddressZ* arg_conv = (LDKCOption_NetAddressZ*)arg;
-	int64_t ret_val = COption_NetAddressZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_NetAddressZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1NetAddressZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20267,8 +20328,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandl
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandleErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CVec_u8ZPeerHandleErrorZ* o_conv = (LDKCResult_CVec_u8ZPeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_u8ZPeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_u8ZPeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandleErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20287,8 +20348,8 @@ static inline uintptr_t CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(LDKCResult_CV
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandleErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CVec_u8ZPeerHandleErrorZ* arg_conv = (LDKCResult_CVec_u8ZPeerHandleErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CVec_1u8ZPeerHandleErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20317,8 +20378,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NonePeerHandleErrorZ* o_conv = (LDKCResult_NonePeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NonePeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NonePeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20337,8 +20398,8 @@ static inline uintptr_t CResult_NonePeerHandleErrorZ_clone_ptr(LDKCResult_NonePe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NonePeerHandleErrorZ* arg_conv = (LDKCResult_NonePeerHandleErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NonePeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NonePeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NonePeerHandleErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20367,8 +20428,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_boolPeerHandleErrorZ* o_conv = (LDKCResult_boolPeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_boolPeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolPeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20387,8 +20448,8 @@ static inline uintptr_t CResult_boolPeerHandleErrorZ_clone_ptr(LDKCResult_boolPe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_boolPeerHandleErrorZ* arg_conv = (LDKCResult_boolPeerHandleErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_boolPeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_boolPeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1boolPeerHandleErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20422,8 +20483,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeIdDecodeErrorZ* o_conv = (LDKCResult_NodeIdDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeIdDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeIdDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20442,8 +20503,8 @@ static inline uintptr_t CResult_NodeIdDecodeErrorZ_clone_ptr(LDKCResult_NodeIdDe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NodeIdDecodeErrorZ* arg_conv = (LDKCResult_NodeIdDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NodeIdDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NodeIdDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeIdDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20476,8 +20537,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUp
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUpdateZDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_COption_NetworkUpdateZDecodeErrorZ* o_conv = (LDKCResult_COption_NetworkUpdateZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUpdateZDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20496,8 +20557,8 @@ static inline uintptr_t CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(LDK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUpdateZDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_COption_NetworkUpdateZDecodeErrorZ* arg_conv = (LDKCResult_COption_NetworkUpdateZDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1COption_1NetworkUpdateZDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20561,8 +20622,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelUpdateInfoDecodeErrorZ* o_conv = (LDKCResult_ChannelUpdateInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20581,8 +20642,8 @@ static inline uintptr_t CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelUpdateInfoDecodeErrorZ* arg_conv = (LDKCResult_ChannelUpdateInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20616,8 +20677,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeE
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelInfoDecodeErrorZ* o_conv = (LDKCResult_ChannelInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20636,8 +20697,8 @@ static inline uintptr_t CResult_ChannelInfoDecodeErrorZ_clone_ptr(LDKCResult_Cha
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelInfoDecodeErrorZ* arg_conv = (LDKCResult_ChannelInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20671,8 +20732,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeE
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RoutingFeesDecodeErrorZ* o_conv = (LDKCResult_RoutingFeesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RoutingFeesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RoutingFeesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20691,8 +20752,8 @@ static inline uintptr_t CResult_RoutingFeesDecodeErrorZ_clone_ptr(LDKCResult_Rou
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RoutingFeesDecodeErrorZ* arg_conv = (LDKCResult_RoutingFeesDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RoutingFeesDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RoutingFeesDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RoutingFeesDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20726,8 +20787,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementIn
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeAnnouncementInfoDecodeErrorZ* o_conv = (LDKCResult_NodeAnnouncementInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20746,8 +20807,8 @@ static inline uintptr_t CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(LDKCR
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NodeAnnouncementInfoDecodeErrorZ* arg_conv = (LDKCResult_NodeAnnouncementInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20797,8 +20858,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeInfoDecodeErrorZ* o_conv = (LDKCResult_NodeInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20817,8 +20878,8 @@ static inline uintptr_t CResult_NodeInfoDecodeErrorZ_clone_ptr(LDKCResult_NodeIn
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NodeInfoDecodeErrorZ* arg_conv = (LDKCResult_NodeInfoDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NodeInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NodeInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeInfoDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20852,8 +20913,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NetworkGraphDecodeErrorZ* o_conv = (LDKCResult_NetworkGraphDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NetworkGraphDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NetworkGraphDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20872,8 +20933,8 @@ static inline uintptr_t CResult_NetworkGraphDecodeErrorZ_clone_ptr(LDKCResult_Ne
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NetworkGraphDecodeErrorZ* arg_conv = (LDKCResult_NetworkGraphDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NetworkGraphDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NetworkGraphDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetworkGraphDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20930,8 +20991,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1CVec_1NetAddressZZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCOption_CVec_NetAddressZZ* arg_conv = (LDKCOption_CVec_NetAddressZZ*)arg;
-	int64_t ret_val = COption_CVec_NetAddressZZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = COption_CVec_NetAddressZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_COption_1CVec_1NetAddressZZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -20965,8 +21026,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeEr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NetAddressDecodeErrorZ* o_conv = (LDKCResult_NetAddressDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NetAddressDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NetAddressDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -20985,8 +21046,8 @@ static inline uintptr_t CResult_NetAddressDecodeErrorZ_clone_ptr(LDKCResult_NetA
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NetAddressDecodeErrorZ* arg_conv = (LDKCResult_NetAddressDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NetAddressDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NetAddressDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NetAddressDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21100,8 +21161,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_AcceptChannelDecodeErrorZ* o_conv = (LDKCResult_AcceptChannelDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_AcceptChannelDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_AcceptChannelDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21120,8 +21181,8 @@ static inline uintptr_t CResult_AcceptChannelDecodeErrorZ_clone_ptr(LDKCResult_A
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_AcceptChannelDecodeErrorZ* arg_conv = (LDKCResult_AcceptChannelDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_AcceptChannelDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_AcceptChannelDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AcceptChannelDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21155,8 +21216,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignat
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignaturesDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_AnnouncementSignaturesDecodeErrorZ* o_conv = (LDKCResult_AnnouncementSignaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignaturesDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21175,8 +21236,8 @@ static inline uintptr_t CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(LDK
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignaturesDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_AnnouncementSignaturesDecodeErrorZ* arg_conv = (LDKCResult_AnnouncementSignaturesDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1AnnouncementSignaturesDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21210,8 +21271,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablish
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablishDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelReestablishDecodeErrorZ* o_conv = (LDKCResult_ChannelReestablishDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelReestablishDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelReestablishDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablishDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21230,8 +21291,8 @@ static inline uintptr_t CResult_ChannelReestablishDecodeErrorZ_clone_ptr(LDKCRes
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablishDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelReestablishDecodeErrorZ* arg_conv = (LDKCResult_ChannelReestablishDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelReestablishDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelReestablishDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelReestablishDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21265,8 +21326,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ClosingSignedDecodeErrorZ* o_conv = (LDKCResult_ClosingSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ClosingSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ClosingSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21285,8 +21346,8 @@ static inline uintptr_t CResult_ClosingSignedDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ClosingSignedDecodeErrorZ* arg_conv = (LDKCResult_ClosingSignedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ClosingSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ClosingSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21320,8 +21381,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRa
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRangeDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ClosingSignedFeeRangeDecodeErrorZ* o_conv = (LDKCResult_ClosingSignedFeeRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRangeDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21340,8 +21401,8 @@ static inline uintptr_t CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRangeDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ClosingSignedFeeRangeDecodeErrorZ* arg_conv = (LDKCResult_ClosingSignedFeeRangeDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ClosingSignedFeeRangeDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21375,8 +21436,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDe
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_CommitmentSignedDecodeErrorZ* o_conv = (LDKCResult_CommitmentSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CommitmentSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CommitmentSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21395,8 +21456,8 @@ static inline uintptr_t CResult_CommitmentSignedDecodeErrorZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_CommitmentSignedDecodeErrorZ* arg_conv = (LDKCResult_CommitmentSignedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_CommitmentSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_CommitmentSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1CommitmentSignedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21430,8 +21491,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_FundingCreatedDecodeErrorZ* o_conv = (LDKCResult_FundingCreatedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingCreatedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingCreatedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21450,8 +21511,8 @@ static inline uintptr_t CResult_FundingCreatedDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_FundingCreatedDecodeErrorZ* arg_conv = (LDKCResult_FundingCreatedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_FundingCreatedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_FundingCreatedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingCreatedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21485,8 +21546,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_FundingSignedDecodeErrorZ* o_conv = (LDKCResult_FundingSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21505,8 +21566,8 @@ static inline uintptr_t CResult_FundingSignedDecodeErrorZ_clone_ptr(LDKCResult_F
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_FundingSignedDecodeErrorZ* arg_conv = (LDKCResult_FundingSignedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_FundingSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_FundingSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingSignedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21540,8 +21601,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_FundingLockedDecodeErrorZ* o_conv = (LDKCResult_FundingLockedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingLockedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingLockedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21560,8 +21621,8 @@ static inline uintptr_t CResult_FundingLockedDecodeErrorZ_clone_ptr(LDKCResult_F
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_FundingLockedDecodeErrorZ* arg_conv = (LDKCResult_FundingLockedDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_FundingLockedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_FundingLockedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1FundingLockedDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21595,8 +21656,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InitDecodeErrorZ* o_conv = (LDKCResult_InitDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InitDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InitDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21615,8 +21676,8 @@ static inline uintptr_t CResult_InitDecodeErrorZ_clone_ptr(LDKCResult_InitDecode
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InitDecodeErrorZ* arg_conv = (LDKCResult_InitDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InitDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InitDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InitDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21650,8 +21711,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeE
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_OpenChannelDecodeErrorZ* o_conv = (LDKCResult_OpenChannelDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_OpenChannelDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_OpenChannelDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21670,8 +21731,8 @@ static inline uintptr_t CResult_OpenChannelDecodeErrorZ_clone_ptr(LDKCResult_Ope
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_OpenChannelDecodeErrorZ* arg_conv = (LDKCResult_OpenChannelDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_OpenChannelDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_OpenChannelDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1OpenChannelDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21705,8 +21766,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_RevokeAndACKDecodeErrorZ* o_conv = (LDKCResult_RevokeAndACKDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RevokeAndACKDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RevokeAndACKDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21725,8 +21786,8 @@ static inline uintptr_t CResult_RevokeAndACKDecodeErrorZ_clone_ptr(LDKCResult_Re
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_RevokeAndACKDecodeErrorZ* arg_conv = (LDKCResult_RevokeAndACKDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_RevokeAndACKDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_RevokeAndACKDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1RevokeAndACKDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21760,8 +21821,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErro
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ShutdownDecodeErrorZ* o_conv = (LDKCResult_ShutdownDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21780,8 +21841,8 @@ static inline uintptr_t CResult_ShutdownDecodeErrorZ_clone_ptr(LDKCResult_Shutdo
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ShutdownDecodeErrorZ* arg_conv = (LDKCResult_ShutdownDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ShutdownDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ShutdownDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ShutdownDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21815,8 +21876,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateFailHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFailHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFailHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFailHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21835,8 +21896,8 @@ static inline uintptr_t CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateFailHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFailHTLCDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailHTLCDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21870,8 +21931,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalforme
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalformedHTLCDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalformedHTLCDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21890,8 +21951,8 @@ static inline uintptr_t CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(LD
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalformedHTLCDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFailMalformedHTLCDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21925,8 +21986,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErr
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateFeeDecodeErrorZ* o_conv = (LDKCResult_UpdateFeeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFeeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFeeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -21945,8 +22006,8 @@ static inline uintptr_t CResult_UpdateFeeDecodeErrorZ_clone_ptr(LDKCResult_Updat
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateFeeDecodeErrorZ* arg_conv = (LDKCResult_UpdateFeeDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateFeeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateFeeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFeeDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -21980,8 +22041,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateFulfillHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFulfillHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22000,8 +22061,8 @@ static inline uintptr_t CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateFulfillHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFulfillHTLCDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateFulfillHTLCDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22035,8 +22096,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UpdateAddHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateAddHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateAddHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateAddHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22055,8 +22116,8 @@ static inline uintptr_t CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(LDKCResult_U
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UpdateAddHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateAddHTLCDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UpdateAddHTLCDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22090,8 +22151,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PingDecodeErrorZ* o_conv = (LDKCResult_PingDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PingDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PingDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22110,8 +22171,8 @@ static inline uintptr_t CResult_PingDecodeErrorZ_clone_ptr(LDKCResult_PingDecode
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PingDecodeErrorZ* arg_conv = (LDKCResult_PingDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PingDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PingDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PingDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22145,8 +22206,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_PongDecodeErrorZ* o_conv = (LDKCResult_PongDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PongDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PongDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22165,8 +22226,8 @@ static inline uintptr_t CResult_PongDecodeErrorZ_clone_ptr(LDKCResult_PongDecode
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_PongDecodeErrorZ* arg_conv = (LDKCResult_PongDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_PongDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_PongDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1PongDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22200,8 +22261,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnn
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnnouncementDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ* o_conv = (LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnnouncementDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22220,8 +22281,8 @@ static inline uintptr_t CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_pt
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnnouncementDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelAnnouncementDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22255,8 +22316,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncemen
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncementDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelAnnouncementDecodeErrorZ* o_conv = (LDKCResult_ChannelAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncementDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22275,8 +22336,8 @@ static inline uintptr_t CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(LDKCRe
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncementDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_ChannelAnnouncementDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelAnnouncementDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22310,8 +22371,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpd
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpdateDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UnsignedChannelUpdateDecodeErrorZ* o_conv = (LDKCResult_UnsignedChannelUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpdateDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22330,8 +22391,8 @@ static inline uintptr_t CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpdateDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UnsignedChannelUpdateDecodeErrorZ* arg_conv = (LDKCResult_UnsignedChannelUpdateDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedChannelUpdateDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22365,8 +22426,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecod
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ChannelUpdateDecodeErrorZ* o_conv = (LDKCResult_ChannelUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22385,8 +22446,8 @@ static inline uintptr_t CResult_ChannelUpdateDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ChannelUpdateDecodeErrorZ* arg_conv = (LDKCResult_ChannelUpdateDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ChannelUpdateDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22420,8 +22481,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecode
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ErrorMessageDecodeErrorZ* o_conv = (LDKCResult_ErrorMessageDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ErrorMessageDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ErrorMessageDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22440,8 +22501,8 @@ static inline uintptr_t CResult_ErrorMessageDecodeErrorZ_clone_ptr(LDKCResult_Er
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ErrorMessageDecodeErrorZ* arg_conv = (LDKCResult_ErrorMessageDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ErrorMessageDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ErrorMessageDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ErrorMessageDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22475,8 +22536,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDeco
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_WarningMessageDecodeErrorZ* o_conv = (LDKCResult_WarningMessageDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_WarningMessageDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_WarningMessageDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22495,8 +22556,8 @@ static inline uintptr_t CResult_WarningMessageDecodeErrorZ_clone_ptr(LDKCResult_
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_WarningMessageDecodeErrorZ* arg_conv = (LDKCResult_WarningMessageDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_WarningMessageDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_WarningMessageDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1WarningMessageDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22530,8 +22591,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnoun
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnouncementDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* o_conv = (LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnouncementDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22550,8 +22611,8 @@ static inline uintptr_t CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(L
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnouncementDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1UnsignedNodeAnnouncementDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22585,8 +22646,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDe
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_NodeAnnouncementDecodeErrorZ* o_conv = (LDKCResult_NodeAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22605,8 +22666,8 @@ static inline uintptr_t CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(LDKCResul
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_NodeAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_NodeAnnouncementDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1NodeAnnouncementDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22640,8 +22701,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelI
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelIdsDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_QueryShortChannelIdsDecodeErrorZ* o_conv = (LDKCResult_QueryShortChannelIdsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelIdsDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22660,8 +22721,8 @@ static inline uintptr_t CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(LDKCR
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelIdsDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_QueryShortChannelIdsDecodeErrorZ* arg_conv = (LDKCResult_QueryShortChannelIdsDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryShortChannelIdsDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22695,8 +22756,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelI
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelIdsEndDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ* o_conv = (LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelIdsEndDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22715,8 +22776,8 @@ static inline uintptr_t CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(LD
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelIdsEndDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ* arg_conv = (LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyShortChannelIdsEndDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22750,8 +22811,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_QueryChannelRangeDecodeErrorZ* o_conv = (LDKCResult_QueryChannelRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_QueryChannelRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_QueryChannelRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22770,8 +22831,8 @@ static inline uintptr_t CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_QueryChannelRangeDecodeErrorZ* arg_conv = (LDKCResult_QueryChannelRangeDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1QueryChannelRangeDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22805,8 +22866,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeD
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_ReplyChannelRangeDecodeErrorZ* o_conv = (LDKCResult_ReplyChannelRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ReplyChannelRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ReplyChannelRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22825,8 +22886,8 @@ static inline uintptr_t CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(LDKCResu
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_ReplyChannelRangeDecodeErrorZ* arg_conv = (LDKCResult_ReplyChannelRangeDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1ReplyChannelRangeDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22860,8 +22921,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFil
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFilterDecodeErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_GossipTimestampFilterDecodeErrorZ* o_conv = (LDKCResult_GossipTimestampFilterDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_GossipTimestampFilterDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_GossipTimestampFilterDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFilterDecodeErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22880,8 +22941,8 @@ static inline uintptr_t CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(LDKC
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFilterDecodeErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_GossipTimestampFilterDecodeErrorZ* arg_conv = (LDKCResult_GossipTimestampFilterDecodeErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1GossipTimestampFilterDecodeErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -22934,8 +22995,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreat
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreationErrorZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_InvoiceSignOrCreationErrorZ* o_conv = (LDKCResult_InvoiceSignOrCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceSignOrCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceSignOrCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreationErrorZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -22954,8 +23015,8 @@ static inline uintptr_t CResult_InvoiceSignOrCreationErrorZ_clone_ptr(LDKCResult
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreationErrorZ_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKCResult_InvoiceSignOrCreationErrorZ* arg_conv = (LDKCResult_InvoiceSignOrCreationErrorZ*)(arg & ~1);
-	int64_t ret_val = CResult_InvoiceSignOrCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = CResult_InvoiceSignOrCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1InvoiceSignOrCreationErrorZ_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23014,8 +23075,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CResult_1LockedChannelMonit
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CResult_1LockedChannelMonitorNoneZ_1is_1ok(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCResult_LockedChannelMonitorNoneZ* o_conv = (LDKCResult_LockedChannelMonitorNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_LockedChannelMonitorNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_LockedChannelMonitorNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CResult_1LockedChannelMonitorNoneZ_1free(JNIEnv *env, jclass clz, int64_t _res) {
@@ -23064,8 +23125,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentPurpose_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKPaymentPurpose* arg_conv = (LDKPaymentPurpose*)arg;
-	int64_t ret_val = PaymentPurpose_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentPurpose_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentPurpose_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23116,8 +23177,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosureReason_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKClosureReason* arg_conv = (LDKClosureReason*)arg;
-	int64_t ret_val = ClosureReason_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosureReason_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosureReason_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23222,8 +23283,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Event_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKEvent* arg_conv = (LDKEvent*)arg;
-	int64_t ret_val = Event_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Event_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Event_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23492,8 +23553,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MessageSendEvent_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKMessageSendEvent* arg_conv = (LDKMessageSendEvent*)arg;
-	int64_t ret_val = MessageSendEvent_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = MessageSendEvent_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MessageSendEvent_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23843,8 +23904,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_APIError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKAPIError* arg_conv = (LDKAPIError*)arg;
-	int64_t ret_val = APIError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = APIError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_APIError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -23939,9 +24000,9 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_verify(JNIEnv *env, jclass
 	LDKPublicKey pk_ref;
 	CHECK((*env)->GetArrayLength(env, pk) == 33);
 	(*env)->GetByteArrayRegion(env, pk, 0, 33, pk_ref.compressed_form);
-	jboolean ret_val = verify(msg_ref, sig_conv, pk_ref);
+	jboolean ret_conv = verify(msg_ref, sig_conv, pk_ref);
 	(*env)->ReleaseByteArrayElements(env, msg, (int8_t*)msg_ref.data, 0);
-	return ret_val;
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_construct_1invoice_1preimage(JNIEnv *env, jclass clz, int8_tArray hrp_bytes, jobjectArray data_without_signature) {
@@ -24008,14 +24069,14 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_Level_1error(JNIEnv *env, jc
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Level_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKLevel* a_conv = (LDKLevel*)(a & ~1);
 	LDKLevel* b_conv = (LDKLevel*)(b & ~1);
-	jboolean ret_val = Level_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Level_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Level_1hash(JNIEnv *env, jclass clz, int64_t o) {
 	LDKLevel* o_conv = (LDKLevel*)(o & ~1);
-	int64_t ret_val = Level_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Level_hash(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_Level_1max(JNIEnv *env, jclass clz) {
@@ -24114,8 +24175,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_Record_1get_1line(JNIEnv *e
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = Record_get_line(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = Record_get_line(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Record_1set_1line(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24143,8 +24204,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Record_1clone_1ptr(JNIEnv *
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Record_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Record_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Record_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24186,8 +24247,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelHandshakeConfig_get_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelHandshakeConfig_get_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1set_1minimum_1depth(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24203,8 +24264,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeConfig_get_our_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeConfig_get_our_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1set_1our_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -24220,8 +24281,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeConfig_get_our_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeConfig_get_our_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1set_1our_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24237,8 +24298,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelHandshakeConfig_get_negotiate_scid_privacy(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelHandshakeConfig_get_negotiate_scid_privacy(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1set_1negotiate_1scid_1privacy(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24279,8 +24340,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelHandshakeConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeConfig_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24326,8 +24387,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_min_funding_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_min_funding_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1min_1funding_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24343,8 +24404,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_max_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_max_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1max_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24360,8 +24421,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_min_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_min_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1min_1max_1htlc_1value_1in_1flight_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24377,8 +24438,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_max_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_max_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1max_1channel_1reserve_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24394,8 +24455,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeLimits_get_min_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeLimits_get_min_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1min_1max_1accepted_1htlcs(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -24411,8 +24472,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelHandshakeLimits_get_max_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelHandshakeLimits_get_max_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1max_1minimum_1depth(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24428,8 +24489,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelHandshakeLimits_get_force_announced_channel_preference(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelHandshakeLimits_get_force_announced_channel_preference(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1force_1announced_1channel_1preference(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24445,8 +24506,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeLimits_get_their_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeLimits_get_their_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1set_1their_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -24487,8 +24548,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelHandshakeLimits_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelHandshakeLimits_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24534,8 +24595,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1forward
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelConfig_get_forwarding_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelConfig_get_forwarding_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1forwarding_1fee_1proportional_1millionths(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24551,8 +24612,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1forward
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelConfig_get_forwarding_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelConfig_get_forwarding_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1forwarding_1fee_1base_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -24568,8 +24629,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1cltv_1e
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelConfig_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelConfig_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -24585,8 +24646,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1announ
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelConfig_get_announced_channel(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelConfig_get_announced_channel(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1announced_1channel(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24602,8 +24663,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1commit
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelConfig_get_commit_upfront_shutdown_pubkey(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelConfig_get_commit_upfront_shutdown_pubkey(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1commit_1upfront_1shutdown_1pubkey(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24619,8 +24680,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1max_1du
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelConfig_get_max_dust_htlc_exposure_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_get_max_dust_htlc_exposure_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1max_1dust_1htlc_1exposure_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24636,8 +24697,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1get_1force_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelConfig_get_force_close_avoidance_max_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_get_force_close_avoidance_max_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1set_1force_1close_1avoidance_1max_1fee_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -24678,8 +24739,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelConfig_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24837,8 +24898,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_UserConfig_1get_1accept_1f
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_accept_forwards_to_priv_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_accept_forwards_to_priv_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UserConfig_1set_1accept_1forwards_1to_1priv_1channels(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24854,8 +24915,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_UserConfig_1get_1accept_1i
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_accept_inbound_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_accept_inbound_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UserConfig_1set_1accept_1inbound_1channels(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24871,8 +24932,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_UserConfig_1get_1manually_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_manually_accept_inbound_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_manually_accept_inbound_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UserConfig_1set_1manually_1accept_1inbound_1channels(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -24928,8 +24989,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UserConfig_1clone_1ptr(JNIE
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UserConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UserConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UserConfig_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -24987,8 +25048,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_BestBlock_1clone_1ptr(JNIEn
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = BestBlock_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = BestBlock_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_BestBlock_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25053,8 +25114,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_BestBlock_1height(JNIEnv *e
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = BestBlock_height(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = BestBlock_height(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_AccessError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25258,8 +25319,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WatchedOutput_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = WatchedOutput_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = WatchedOutput_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WatchedOutput_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25284,8 +25345,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WatchedOutput_1hash(JNIEnv 
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = WatchedOutput_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = WatchedOutput_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_BroadcasterInterface_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -25321,8 +25382,8 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_ConfirmationTarget_1high_1pr
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ConfirmationTarget_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKConfirmationTarget* a_conv = (LDKConfirmationTarget*)(a & ~1);
 	LDKConfirmationTarget* b_conv = (LDKConfirmationTarget*)(b & ~1);
-	jboolean ret_val = ConfirmationTarget_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = ConfirmationTarget_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_FeeEstimator_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -25359,8 +25420,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = MonitorUpdateId_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = MonitorUpdateId_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25385,8 +25446,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1hash(JNIEn
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = MonitorUpdateId_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = MonitorUpdateId_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -25398,8 +25459,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_MonitorUpdateId_1eq(JNIEnv
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = MonitorUpdateId_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = MonitorUpdateId_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Persist_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -25630,8 +25691,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitorUpdate_1get_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelMonitorUpdate_get_update_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitorUpdate_get_update_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelMonitorUpdate_1set_1update_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -25659,8 +25720,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitorUpdate_1clone
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelMonitorUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitorUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitorUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25719,8 +25780,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorEvent_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKMonitorEvent* arg_conv = (LDKMonitorEvent*)arg;
-	int64_t ret_val = MonitorEvent_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = MonitorEvent_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MonitorEvent_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25823,8 +25884,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCUpdate_1clone_1ptr(JNIE
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = HTLCUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = HTLCUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25883,8 +25944,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Balance_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKBalance* arg_conv = (LDKBalance*)arg;
-	int64_t ret_val = Balance_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Balance_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Balance_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -25926,8 +25987,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Balance_1maybe_1claimable_1
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Balance_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKBalance* a_conv = (LDKBalance*)a;
 	LDKBalance* b_conv = (LDKBalance*)b;
-	jboolean ret_val = Balance_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Balance_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -25955,8 +26016,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelMonitor_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -26016,8 +26077,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1get_1latest
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ChannelMonitor_get_latest_update_id(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitor_get_latest_update_id(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelMonitor_1get_1funding_1txo(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -26457,8 +26518,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1get_1index(JNIEnv
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OutPoint_get_index(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OutPoint_get_index(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OutPoint_1set_1index(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -26502,8 +26563,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1clone_1ptr(JNIEnv
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = OutPoint_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = OutPoint_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -26532,8 +26593,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_OutPoint_1eq(JNIEnv *env, 
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = OutPoint_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = OutPoint_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1hash(JNIEnv *env, jclass clz, int64_t o) {
@@ -26541,8 +26602,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OutPoint_1hash(JNIEnv *env,
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = OutPoint_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = OutPoint_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_OutPoint_1to_1channel_1id(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -26641,8 +26702,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescrip
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = DelayedPaymentOutputDescriptor_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = DelayedPaymentOutputDescriptor_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescriptor_1set_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -26712,8 +26773,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescrip
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = DelayedPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = DelayedPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescriptor_1set_1channel_1value_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -26772,8 +26833,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescrip
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = DelayedPaymentOutputDescriptor_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = DelayedPaymentOutputDescriptor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DelayedPaymentOutputDescriptor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -26891,8 +26952,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_StaticPaymentOutputDescript
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = StaticPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = StaticPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_StaticPaymentOutputDescriptor_1set_1channel_1value_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -26945,8 +27006,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_StaticPaymentOutputDescript
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = StaticPaymentOutputDescriptor_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = StaticPaymentOutputDescriptor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_StaticPaymentOutputDescriptor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27005,8 +27066,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SpendableOutputDescriptor_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKSpendableOutputDescriptor* arg_conv = (LDKSpendableOutputDescriptor*)arg;
-	int64_t ret_val = SpendableOutputDescriptor_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = SpendableOutputDescriptor_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SpendableOutputDescriptor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27094,8 +27155,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sign_1clone_1ptr(JNIEnv *en
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKSign* arg_conv = (LDKSign*)arg_ptr;
-	int64_t ret_val = Sign_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Sign_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sign_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27292,8 +27353,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InMemorySigner_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InMemorySigner_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27372,8 +27433,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1counterpart
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = InMemorySigner_counterparty_selected_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = InMemorySigner_counterparty_selected_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1holder_1selected_1contest_1delay(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -27381,8 +27442,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1holder_1sel
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = InMemorySigner_holder_selected_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = InMemorySigner_holder_selected_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1is_1outbound(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -27390,8 +27451,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1is_1outbou
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InMemorySigner_is_outbound(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InMemorySigner_is_outbound(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1funding_1outpoint(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -27433,8 +27494,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1opt_1ancho
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InMemorySigner_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InMemorySigner_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InMemorySigner_1sign_1counterparty_1payment_1input(JNIEnv *env, jclass clz, int64_t this_arg, int8_tArray spend_tx, int64_t input_idx, int64_t descriptor) {
@@ -27828,8 +27889,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChainParameters_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChainParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChainParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChainParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -27862,8 +27923,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = CounterpartyForwardingInfo_get_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = CounterpartyForwardingInfo_get_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_1set_1fee_1base_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -27879,8 +27940,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = CounterpartyForwardingInfo_get_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = CounterpartyForwardingInfo_get_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_1set_1fee_1proportional_1millionths(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -27896,8 +27957,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = CounterpartyForwardingInfo_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = CounterpartyForwardingInfo_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -27938,8 +27999,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CounterpartyForwardingInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyForwardingInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyForwardingInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -28023,8 +28084,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelCounterparty_1get_1u
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelCounterparty_get_unspendable_punishment_reserve(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelCounterparty_get_unspendable_punishment_reserve(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelCounterparty_1set_1unspendable_1punishment_1reserve(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28110,8 +28171,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelCounterparty_1clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelCounterparty_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelCounterparty_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelCounterparty_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -28305,8 +28366,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1channe
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1channel_1value_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28345,8 +28406,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1user_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_user_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_user_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1user_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28362,8 +28423,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1balanc
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_balance_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_balance_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1balance_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28379,8 +28440,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1outbou
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_outbound_capacity_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_outbound_capacity_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1outbound_1capacity_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28396,8 +28457,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1inboun
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_inbound_capacity_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_inbound_capacity_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1inbound_1capacity_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28459,8 +28520,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1is_1o
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_outbound(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_outbound(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1is_1outbound(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -28476,8 +28537,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1is_1f
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_funding_locked(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_funding_locked(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1is_1funding_1locked(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -28493,8 +28554,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1is_1u
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_usable(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_usable(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1is_1usable(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -28510,8 +28571,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1get_1is_1p
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_public(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_public(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1set_1is_1public(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -28589,8 +28650,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelDetails_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelDetails_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -28638,8 +28699,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentSendFailure_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKPaymentSendFailure* arg_conv = (LDKPaymentSendFailure*)arg;
-	int64_t ret_val = PaymentSendFailure_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentSendFailure_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentSendFailure_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -28801,8 +28862,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PhantomRouteHints_1get_1pha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = PhantomRouteHints_get_phantom_scid(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = PhantomRouteHints_get_phantom_scid(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PhantomRouteHints_1set_1phantom_1scid(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -28884,8 +28945,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PhantomRouteHints_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PhantomRouteHints_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PhantomRouteHints_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PhantomRouteHints_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -29238,8 +29299,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelManager_1fail_1htlc
 	CHECK((*env)->GetArrayLength(env, payment_hash) == 32);
 	(*env)->GetByteArrayRegion(env, payment_hash, 0, 32, payment_hash_arr);
 	unsigned char (*payment_hash_ref)[32] = &payment_hash_arr;
-	jboolean ret_val = ChannelManager_fail_htlc_backwards(&this_arg_conv, payment_hash_ref);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_fail_htlc_backwards(&this_arg_conv, payment_hash_ref);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelManager_1claim_1funds(JNIEnv *env, jclass clz, int64_t this_arg, int8_tArray payment_preimage) {
@@ -29250,8 +29311,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelManager_1claim_1fun
 	LDKThirtyTwoBytes payment_preimage_ref;
 	CHECK((*env)->GetArrayLength(env, payment_preimage) == 32);
 	(*env)->GetByteArrayRegion(env, payment_preimage, 0, 32, payment_preimage_ref.data);
-	jboolean ret_val = ChannelManager_claim_funds(&this_arg_conv, payment_preimage_ref);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_claim_funds(&this_arg_conv, payment_preimage_ref);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_ChannelManager_1get_1our_1node_1id(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -29361,8 +29422,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelManager_1get_1phanto
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ChannelManager_get_phantom_scid(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelManager_get_phantom_scid(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelManager_1get_1phantom_1route_1hints(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -29427,8 +29488,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelManager_1await_1per
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelManager_await_persistable_update_timeout(&this_arg_conv, max_wait);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_await_persistable_update_timeout(&this_arg_conv, max_wait);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelManager_1await_1persistable_1update(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -29838,8 +29899,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DecodeError_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = DecodeError_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = DecodeError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DecodeError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -29958,8 +30019,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Init_1clone_1ptr(JNIEnv *en
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Init_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Init_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Init_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30062,8 +30123,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ErrorMessage_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ErrorMessage_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ErrorMessage_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ErrorMessage_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30166,8 +30227,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WarningMessage_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = WarningMessage_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = WarningMessage_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_WarningMessage_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30200,8 +30261,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_Ping_1get_1ponglen(JNIEnv *
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Ping_get_ponglen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Ping_get_ponglen(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Ping_1set_1ponglen(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30217,8 +30278,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_Ping_1get_1byteslen(JNIEnv 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Ping_get_byteslen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Ping_get_byteslen(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Ping_1set_1byteslen(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30259,8 +30320,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Ping_1clone_1ptr(JNIEnv *en
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Ping_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Ping_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Ping_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30293,8 +30354,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_Pong_1get_1byteslen(JNIEnv 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Pong_get_byteslen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Pong_get_byteslen(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Pong_1set_1byteslen(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30335,8 +30396,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Pong_1clone_1ptr(JNIEnv *en
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Pong_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Pong_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Pong_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30411,8 +30472,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1funding_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_funding_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_funding_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1funding_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30428,8 +30489,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1push_1msa
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_push_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_push_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1push_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30445,8 +30506,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1dust_1lim
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_dust_limit_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_dust_limit_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1dust_1limit_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30462,8 +30523,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1max_1htlc
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1max_1htlc_1value_1in_1flight_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30479,8 +30540,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1channel_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1channel_1reserve_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30496,8 +30557,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1htlc_1min
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30513,8 +30574,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1feerate_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = OpenChannel_get_feerate_per_kw(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = OpenChannel_get_feerate_per_kw(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1feerate_1per_1kw(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -30530,8 +30591,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1to_1self_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OpenChannel_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OpenChannel_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30547,8 +30608,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1max_1acce
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OpenChannel_get_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OpenChannel_get_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1max_1accepted_1htlcs(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30690,8 +30751,8 @@ JNIEXPORT int8_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1get_1channel_1f
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int8_t ret_val = OpenChannel_get_channel_flags(&this_ptr_conv);
-	return ret_val;
+	int8_t ret_conv = OpenChannel_get_channel_flags(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_OpenChannel_1set_1channel_1flags(JNIEnv *env, jclass clz, int64_t this_ptr, int8_t val) {
@@ -30751,8 +30812,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = OpenChannel_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_OpenChannel_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -30806,8 +30867,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1dust_1l
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_dust_limit_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_dust_limit_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1dust_1limit_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30823,8 +30884,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1max_1ht
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1max_1htlc_1value_1in_1flight_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30840,8 +30901,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1channel
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1channel_1reserve_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30857,8 +30918,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1htlc_1m
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -30874,8 +30935,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1minimum
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = AcceptChannel_get_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = AcceptChannel_get_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1minimum_1depth(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -30891,8 +30952,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1to_1sel
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = AcceptChannel_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = AcceptChannel_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1to_1self_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -30908,8 +30969,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1get_1max_1ac
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = AcceptChannel_get_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = AcceptChannel_get_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1set_1max_1accepted_1htlcs(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -31095,8 +31156,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = AcceptChannel_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AcceptChannel_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31171,8 +31232,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_FundingCreated_1get_1fundin
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = FundingCreated_get_funding_output_index(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = FundingCreated_get_funding_output_index(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_FundingCreated_1set_1funding_1output_1index(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -31243,8 +31304,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingCreated_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = FundingCreated_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = FundingCreated_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingCreated_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31350,8 +31411,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingSigned_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = FundingSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = FundingSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingSigned_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31484,8 +31545,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingLocked_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = FundingLocked_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = FundingLocked_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FundingLocked_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31594,8 +31655,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Shutdown_1clone_1ptr(JNIEnv
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Shutdown_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Shutdown_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Shutdown_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31628,8 +31689,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSignedFeeRange_get_min_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_get_min_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1set_1min_1fee_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31645,8 +31706,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSignedFeeRange_get_max_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_get_max_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1set_1max_1fee_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31687,8 +31748,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ClosingSignedFeeRange_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSignedFeeRange_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31742,8 +31803,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSigned_1get_1fee_1sa
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSigned_get_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSigned_get_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ClosingSigned_1set_1fee_1satoshis(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31848,8 +31909,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSigned_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ClosingSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingSigned_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -31903,8 +31964,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1get_1htlc_1i
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateAddHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1set_1htlc_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31920,8 +31981,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1get_1amount_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateAddHTLC_get_amount_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_get_amount_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1set_1amount_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -31958,8 +32019,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1get_1cltv_1e
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UpdateAddHTLC_get_cltv_expiry(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UpdateAddHTLC_get_cltv_expiry(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1set_1cltv_1expiry(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -31987,8 +32048,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateAddHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateAddHTLC_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32042,8 +32103,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFulfillHTLC_1get_1htl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFulfillHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFulfillHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFulfillHTLC_1set_1htlc_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32111,8 +32172,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFulfillHTLC_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateFulfillHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFulfillHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFulfillHTLC_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32166,8 +32227,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailHTLC_1get_1htlc_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFailHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFailHTLC_1set_1htlc_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32195,8 +32256,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailHTLC_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateFailHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailHTLC_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32250,8 +32311,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFailMalformedHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailMalformedHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1set_1htlc_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32267,8 +32328,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = UpdateFailMalformedHTLC_get_failure_code(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = UpdateFailMalformedHTLC_get_failure_code(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1set_1failure_1code(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -32296,8 +32357,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateFailMalformedHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailMalformedHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFailMalformedHTLC_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32437,8 +32498,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentSigned_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CommitmentSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentSigned_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32568,8 +32629,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RevokeAndACK_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RevokeAndACK_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RevokeAndACK_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RevokeAndACK_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32623,8 +32684,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UpdateFee_1get_1feerate_1pe
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UpdateFee_get_feerate_per_kw(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UpdateFee_get_feerate_per_kw(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UpdateFee_1set_1feerate_1per_1kw(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -32668,8 +32729,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFee_1clone_1ptr(JNIEn
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UpdateFee_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFee_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UpdateFee_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32775,8 +32836,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DataLossProtect_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = DataLossProtect_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = DataLossProtect_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DataLossProtect_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32830,8 +32891,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1get_1ne
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelReestablish_get_next_local_commitment_number(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_get_next_local_commitment_number(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1set_1next_1local_1commitment_1number(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32847,8 +32908,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1get_1ne
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelReestablish_get_next_remote_commitment_number(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_get_next_remote_commitment_number(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1set_1next_1remote_1commitment_1number(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -32876,8 +32937,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1clone_1
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelReestablish_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelReestablish_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -32931,8 +32992,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AnnouncementSignatures_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AnnouncementSignatures_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AnnouncementSignatures_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_AnnouncementSignatures_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -33024,8 +33085,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AnnouncementSignatures_1clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = AnnouncementSignatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = AnnouncementSignatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_AnnouncementSignatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33062,8 +33123,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetAddress_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKNetAddress* arg_conv = (LDKNetAddress*)arg;
-	int64_t ret_val = NetAddress_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = NetAddress_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetAddress_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33176,8 +33237,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UnsignedNodeAnnouncement_1g
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedNodeAnnouncement_get_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedNodeAnnouncement_get_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedNodeAnnouncement_1set_1timestamp(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -33292,8 +33353,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedNodeAnnouncement_1c
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UnsignedNodeAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedNodeAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedNodeAnnouncement_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33410,8 +33471,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncement_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncement_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33495,8 +33556,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelAnnouncement
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelAnnouncement_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelAnnouncement_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelAnnouncement_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -33608,8 +33669,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelAnnouncement
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UnsignedChannelAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelAnnouncement_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33798,8 +33859,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelAnnouncement_1clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelAnnouncement_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -33853,8 +33914,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelUpdate_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -33870,8 +33931,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1timestamp(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -33887,8 +33948,8 @@ JNIEXPORT int8_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int8_t ret_val = UnsignedChannelUpdate_get_flags(&this_ptr_conv);
-	return ret_val;
+	int8_t ret_conv = UnsignedChannelUpdate_get_flags(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1flags(JNIEnv *env, jclass clz, int64_t this_ptr, int8_t val) {
@@ -33904,8 +33965,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = UnsignedChannelUpdate_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = UnsignedChannelUpdate_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -33921,8 +33982,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelUpdate_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -33938,8 +33999,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1fee_1base_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -33955,8 +34016,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1set_1fee_1proportional_1millionths(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -33984,8 +34045,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = UnsignedChannelUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_UnsignedChannelUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34102,8 +34163,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdate_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34157,8 +34218,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1get_1fir
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = QueryChannelRange_get_first_blocknum(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_get_first_blocknum(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1set_1first_1blocknum(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34174,8 +34235,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1get_1num
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = QueryChannelRange_get_number_of_blocks(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_get_number_of_blocks(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1set_1number_1of_1blocks(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34219,8 +34280,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = QueryChannelRange_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = QueryChannelRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34274,8 +34335,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1get_1fir
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ReplyChannelRange_get_first_blocknum(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ReplyChannelRange_get_first_blocknum(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1set_1first_1blocknum(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34291,8 +34352,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1get_1num
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ReplyChannelRange_get_number_of_blocks(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ReplyChannelRange_get_number_of_blocks(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1set_1number_1of_1blocks(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34308,8 +34369,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1get_1sy
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ReplyChannelRange_get_sync_complete(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ReplyChannelRange_get_sync_complete(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1set_1sync_1complete(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -34385,8 +34446,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ReplyChannelRange_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ReplyChannelRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ReplyChannelRange_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34500,8 +34561,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_QueryShortChannelIds_1clone
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = QueryShortChannelIds_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = QueryShortChannelIds_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_QueryShortChannelIds_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34555,8 +34616,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ReplyShortChannelIdsEnd_1g
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ReplyShortChannelIdsEnd_get_full_information(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ReplyShortChannelIdsEnd_get_full_information(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ReplyShortChannelIdsEnd_1set_1full_1information(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -34600,8 +34661,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ReplyShortChannelIdsEnd_1cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ReplyShortChannelIdsEnd_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ReplyShortChannelIdsEnd_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ReplyShortChannelIdsEnd_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34655,8 +34716,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = GossipTimestampFilter_get_first_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = GossipTimestampFilter_get_first_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1set_1first_1timestamp(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34672,8 +34733,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1get_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = GossipTimestampFilter_get_timestamp_range(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = GossipTimestampFilter_get_timestamp_range(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1set_1timestamp_1range(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -34717,8 +34778,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = GossipTimestampFilter_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = GossipTimestampFilter_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_GossipTimestampFilter_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34755,8 +34816,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ErrorAction_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKErrorAction* arg_conv = (LDKErrorAction*)arg;
-	int64_t ret_val = ErrorAction_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = ErrorAction_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ErrorAction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -34912,8 +34973,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_LightningError_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = LightningError_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = LightningError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_LightningError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -35315,8 +35376,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentUpdate_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CommitmentUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -36019,8 +36080,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1end_1blo
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = QueryChannelRange_end_blocknum(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_end_blocknum(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_QueryChannelRange_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -36294,8 +36355,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1clone_1pt
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKSocketDescriptor* arg_conv = (LDKSocketDescriptor*)arg_ptr;
-	int64_t ret_val = SocketDescriptor_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = SocketDescriptor_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SocketDescriptor_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -36329,8 +36390,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PeerHandleError_1get_1no_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = PeerHandleError_get_no_connection_possible(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = PeerHandleError_get_no_connection_possible(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PeerHandleError_1set_1no_1connection_1possible(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -36371,8 +36432,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PeerHandleError_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PeerHandleError_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PeerHandleError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PeerHandleError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -36578,13 +36639,13 @@ JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PeerManager_1timer_1tick_1occu
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_htlc_1success_1tx_1weight(JNIEnv *env, jclass clz, jboolean opt_anchors) {
-	int64_t ret_val = htlc_success_tx_weight(opt_anchors);
-	return ret_val;
+	int64_t ret_conv = htlc_success_tx_weight(opt_anchors);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_htlc_1timeout_1tx_1weight(JNIEnv *env, jclass clz, jboolean opt_anchors) {
-	int64_t ret_val = htlc_timeout_tx_weight(opt_anchors);
-	return ret_val;
+	int64_t ret_conv = htlc_timeout_tx_weight(opt_anchors);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_build_1commitment_1secret(JNIEnv *env, jclass clz, int8_tArray commitment_seed, int64_t idx) {
@@ -36643,8 +36704,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyCommitmentSecre
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CounterpartyCommitmentSecrets_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyCommitmentSecrets_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyCommitmentSecrets_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -36682,8 +36743,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyCommitmentSecre
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CounterpartyCommitmentSecrets_get_min_seen_secret(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyCommitmentSecrets_get_min_seen_secret(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyCommitmentSecrets_1provide_1secret(JNIEnv *env, jclass clz, int64_t this_arg, int64_t idx, int8_tArray secret) {
@@ -36940,8 +37001,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxCreationKeys_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = TxCreationKeys_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = TxCreationKeys_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TxCreationKeys_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37141,8 +37202,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelPublicKeys_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelPublicKeys_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelPublicKeys_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelPublicKeys_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37249,8 +37310,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = HTLCOutputInCommitment_get_offered(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = HTLCOutputInCommitment_get_offered(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1set_1offered(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -37266,8 +37327,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = HTLCOutputInCommitment_get_amount_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = HTLCOutputInCommitment_get_amount_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1set_1amount_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -37283,8 +37344,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1get
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = HTLCOutputInCommitment_get_cltv_expiry(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = HTLCOutputInCommitment_get_cltv_expiry(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1set_1cltv_1expiry(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -37376,8 +37437,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = HTLCOutputInCommitment_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = HTLCOutputInCommitment_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HTLCOutputInCommitment_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37525,8 +37586,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameter
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelTransactionParameters_get_holder_selected_contest_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelTransactionParameters_get_holder_selected_contest_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameters_1set_1holder_1selected_1contest_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -37542,8 +37603,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParamete
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelTransactionParameters_get_is_outbound_from_holder(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTransactionParameters_get_is_outbound_from_holder(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameters_1set_1is_1outbound_1from_1holder(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -37682,8 +37743,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameter
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelTransactionParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelTransactionParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37746,8 +37807,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_CounterpartyChannelTransact
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = CounterpartyChannelTransactionParameters_get_selected_contest_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = CounterpartyChannelTransactionParameters_get_selected_contest_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CounterpartyChannelTransactionParameters_1set_1selected_1contest_1delay(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -37793,8 +37854,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyChannelTransact
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CounterpartyChannelTransactionParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyChannelTransactionParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CounterpartyChannelTransactionParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -37819,8 +37880,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParamete
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelTransactionParameters_is_populated(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTransactionParameters_is_populated(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTransactionParameters_1as_1holder_1broadcastable(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -37948,8 +38009,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransactionP
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = DirectedChannelTransactionParameters_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = DirectedChannelTransactionParameters_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransactionParameters_1is_1outbound(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -37957,8 +38018,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransaction
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = DirectedChannelTransactionParameters_is_outbound(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = DirectedChannelTransactionParameters_is_outbound(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransactionParameters_1funding_1outpoint(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -37983,8 +38044,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_DirectedChannelTransaction
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = DirectedChannelTransactionParameters_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = DirectedChannelTransactionParameters_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_HolderCommitmentTransaction_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -38054,8 +38115,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HolderCommitmentTransaction
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = HolderCommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = HolderCommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_HolderCommitmentTransaction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38229,8 +38290,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_BuiltCommitmentTransaction_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = BuiltCommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = BuiltCommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_BuiltCommitmentTransaction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38329,8 +38390,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1clone_1
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ClosingTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38355,8 +38416,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1hash(JN
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = ClosingTransaction_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1new(JNIEnv *env, jclass clz, int64_t to_holder_value_sat, int64_t to_counterparty_value_sat, int8_tArray to_holder_script, int8_tArray to_counterparty_script, int64_t funding_outpoint) {
@@ -38422,8 +38483,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1to_1hol
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ClosingTransaction_to_holder_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_to_holder_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1to_1counterparty_1value_1sat(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38431,8 +38492,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1to_1cou
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ClosingTransaction_to_counterparty_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_to_counterparty_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_ClosingTransaction_1to_1holder_1script(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38534,8 +38595,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = CommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38582,8 +38643,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1comm
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_commitment_number(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_commitment_number(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1to_1broadcaster_1value_1sat(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38591,8 +38652,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1to_1
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_to_broadcaster_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_to_broadcaster_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1to_1countersignatory_1value_1sat(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38600,8 +38661,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1to_1
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_to_countersignatory_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_to_countersignatory_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1feerate_1per_1kw(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38609,8 +38670,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1feer
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = CommitmentTransaction_feerate_per_kw(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = CommitmentTransaction_feerate_per_kw(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_CommitmentTransaction_1trust(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -38709,8 +38770,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_TrustedCommitmentTransacti
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = TrustedCommitmentTransaction_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = TrustedCommitmentTransaction_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_TrustedCommitmentTransaction_1get_1htlc_1sigs(JNIEnv *env, jclass clz, int64_t this_arg, int8_tArray htlc_base_key, int64_t channel_parameters) {
@@ -38738,8 +38799,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_get_1commitment_1transactio
 	LDKPublicKey countersignatory_payment_basepoint_ref;
 	CHECK((*env)->GetArrayLength(env, countersignatory_payment_basepoint) == 33);
 	(*env)->GetByteArrayRegion(env, countersignatory_payment_basepoint, 0, 33, countersignatory_payment_basepoint_ref.compressed_form);
-	int64_t ret_val = get_commitment_transaction_number_obscure_factor(broadcaster_payment_basepoint_ref, countersignatory_payment_basepoint_ref, outbound_from_broadcaster);
-	return ret_val;
+	int64_t ret_conv = get_commitment_transaction_number_obscure_factor(broadcaster_payment_basepoint_ref, countersignatory_payment_basepoint_ref, outbound_from_broadcaster);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InitFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38751,8 +38812,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InitFeatures_1eq(JNIEnv *e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InitFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InitFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38764,8 +38825,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1eq(JNIEnv *e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = NodeFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = NodeFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38777,8 +38838,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1eq(JNIEnv
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ChannelFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38790,8 +38851,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1eq(JNIEnv
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InvoiceFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -38803,8 +38864,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1eq(JN
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ChannelTypeFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTypeFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t InitFeatures_clone_ptr(LDKInitFeatures *NONNULL_PTR arg) {
@@ -38824,8 +38885,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InitFeatures_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InitFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InitFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InitFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38862,8 +38923,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38900,8 +38961,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38938,8 +38999,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InvoiceFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InvoiceFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -38976,8 +39037,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelTypeFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelTypeFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39068,8 +39129,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InitFeatures_1requires_1un
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InitFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InitFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1empty(JNIEnv *env, jclass clz) {
@@ -39103,8 +39164,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_NodeFeatures_1requires_1un
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = NodeFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = NodeFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1empty(JNIEnv *env, jclass clz) {
@@ -39138,8 +39199,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelFeatures_1requires_
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1empty(JNIEnv *env, jclass clz) {
@@ -39173,8 +39234,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InvoiceFeatures_1requires_
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InvoiceFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1empty(JNIEnv *env, jclass clz) {
@@ -39208,8 +39269,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelTypeFeatures_1requi
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelTypeFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTypeFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_InitFeatures_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -39347,8 +39408,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ShutdownScript_1clone_1ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ShutdownScript_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ShutdownScript_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ShutdownScript_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39433,8 +39494,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvalidShutdownScript_1clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InvalidShutdownScript_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InvalidShutdownScript_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvalidShutdownScript_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39552,8 +39613,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ShutdownScript_1is_1compat
 	features_conv.inner = (void*)(features & (~1));
 	features_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(features_conv);
-	jboolean ret_val = ShutdownScript_is_compatible(&this_arg_conv, &features_conv);
-	return ret_val;
+	jboolean ret_conv = ShutdownScript_is_compatible(&this_arg_conv, &features_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_CustomMessageReader_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -39574,8 +39635,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Type_1clone_1ptr(JNIEnv *en
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKType* arg_conv = (LDKType*)arg_ptr;
-	int64_t ret_val = Type_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Type_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Type_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39621,8 +39682,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeId_1clone_1ptr(JNIEnv *
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeId_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeId_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeId_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39674,8 +39735,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeId_1hash(JNIEnv *env, j
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = NodeId_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = NodeId_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_NodeId_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -39725,8 +39786,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetworkGraph_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NetworkGraph_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NetworkGraph_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetworkGraph_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39771,8 +39832,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetworkUpdate_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKNetworkUpdate* arg_conv = (LDKNetworkUpdate*)arg;
-	int64_t ret_val = NetworkUpdate_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = NetworkUpdate_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NetworkUpdate_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -39936,8 +39997,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1get_1las
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelUpdateInfo_get_last_update(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelUpdateInfo_get_last_update(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1set_1last_1update(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -39953,8 +40014,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1get_1en
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelUpdateInfo_get_enabled(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelUpdateInfo_get_enabled(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1set_1enabled(JNIEnv *env, jclass clz, int64_t this_ptr, jboolean val) {
@@ -39970,8 +40031,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1get_1clt
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelUpdateInfo_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelUpdateInfo_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -39987,8 +40048,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1get_1htl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelUpdateInfo_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelUpdateInfo_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1set_1htlc_1minimum_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -40128,8 +40189,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelUpdateInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelUpdateInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelUpdateInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40405,8 +40466,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelInfo_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ChannelInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ChannelInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40473,8 +40534,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DirectedChannelInfo_1clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = DirectedChannelInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = DirectedChannelInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_DirectedChannelInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40558,8 +40619,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_EffectiveCapacity_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKEffectiveCapacity* arg_conv = (LDKEffectiveCapacity*)arg;
-	int64_t ret_val = EffectiveCapacity_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = EffectiveCapacity_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_EffectiveCapacity_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40607,8 +40668,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_EffectiveCapacity_1unknown(
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_EffectiveCapacity_1as_1msat(JNIEnv *env, jclass clz, int64_t this_arg) {
 	LDKEffectiveCapacity* this_arg_conv = (LDKEffectiveCapacity*)this_arg;
-	int64_t ret_val = EffectiveCapacity_as_msat(this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = EffectiveCapacity_as_msat(this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RoutingFees_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -40624,8 +40685,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1get_1base_1msa
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RoutingFees_get_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RoutingFees_get_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RoutingFees_1set_1base_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -40641,8 +40702,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1get_1proportio
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RoutingFees_get_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RoutingFees_get_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RoutingFees_1set_1proportional_1millionths(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -40675,8 +40736,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RoutingFees_1eq(JNIEnv *en
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RoutingFees_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RoutingFees_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RoutingFees_clone_ptr(LDKRoutingFees *NONNULL_PTR arg) {
@@ -40696,8 +40757,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RoutingFees_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RoutingFees_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -40722,8 +40783,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RoutingFees_1hash(JNIEnv *e
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RoutingFees_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RoutingFees_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RoutingFees_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -40791,8 +40852,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncementInfo_1get_1
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = NodeAnnouncementInfo_get_last_update(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = NodeAnnouncementInfo_get_last_update(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_NodeAnnouncementInfo_1set_1last_1update(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -40962,8 +41023,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncementInfo_1clone
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeAnnouncementInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeAnnouncementInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeAnnouncementInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -41149,8 +41210,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeInfo_1clone_1ptr(JNIEnv
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = NodeInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = NodeInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_NodeInfo_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -41466,8 +41527,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1get_1short_1chann
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHop_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHop_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -41513,8 +41574,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1get_1fee_1msat(JN
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHop_get_fee_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_get_fee_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHop_1set_1fee_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -41530,8 +41591,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1get_1cltv_1expiry
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RouteHop_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RouteHop_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHop_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -41585,8 +41646,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1clone_1ptr(JNIEnv
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RouteHop_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -41611,8 +41672,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHop_1hash(JNIEnv *env,
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHop_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHop_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -41624,8 +41685,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHop_1eq(JNIEnv *env, 
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHop_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHop_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RouteHop_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -41822,8 +41883,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1clone_1ptr(JNIEnv *e
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Route_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -41848,8 +41909,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1hash(JNIEnv *env, jc
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Route_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Route_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Route_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -41861,8 +41922,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Route_1eq(JNIEnv *env, jcl
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Route_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Route_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1get_1total_1fees(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -41870,8 +41931,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1get_1total_1fees(JNI
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Route_get_total_fees(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_get_total_fees(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1get_1total_1amount(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -41879,8 +41940,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Route_1get_1total_1amount(J
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Route_get_total_amount(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_get_total_amount(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_Route_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -41948,8 +42009,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteParameters_1get_1final
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteParameters_get_final_value_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteParameters_get_final_value_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteParameters_1set_1final_1value_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -41965,8 +42026,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_RouteParameters_1get_1final
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RouteParameters_get_final_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RouteParameters_get_final_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteParameters_1set_1final_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -42012,8 +42073,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteParameters_1clone_1ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RouteParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RouteParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42195,8 +42256,8 @@ JNIEXPORT int32_t JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1get_1max
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = PaymentParameters_get_max_total_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = PaymentParameters_get_max_total_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1set_1max_1total_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int32_t val) {
@@ -42266,8 +42327,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PaymentParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42292,8 +42353,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1hash(JNI
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PaymentParameters_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentParameters_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -42305,8 +42366,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1eq(JNIE
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PaymentParameters_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PaymentParameters_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_PaymentParameters_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -42469,8 +42530,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHint_1clone_1ptr(JNIEn
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RouteHint_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHint_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHint_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42495,8 +42556,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHint_1hash(JNIEnv *env
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHint_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHint_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHint_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -42508,8 +42569,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHint_1eq(JNIEnv *env,
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHint_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHint_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RouteHint_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -42568,8 +42629,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1get_1short_1c
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHintHop_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1set_1short_1channel_1id(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -42615,8 +42676,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1get_1cltv_1ex
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = RouteHintHop_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = RouteHintHop_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1set_1cltv_1expiry_1delta(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -42719,8 +42780,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RouteHintHop_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42745,8 +42806,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1hash(JNIEnv *
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHintHop_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -42758,8 +42819,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1eq(JNIEnv *e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHintHop_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHintHop_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RouteHintHop_1write(JNIEnv *env, jclass clz, int64_t obj) {
@@ -42907,8 +42968,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FixedPenaltyScorer_1clone_1
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = FixedPenaltyScorer_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = FixedPenaltyScorer_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_FixedPenaltyScorer_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -42994,8 +43055,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1bas
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_base_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_base_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1base_1penalty_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43011,8 +43072,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1fai
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_failure_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_failure_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1failure_1penalty_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43028,8 +43089,8 @@ JNIEXPORT int16_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1ove
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ScoringParameters_get_overuse_penalty_start_1024th(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ScoringParameters_get_overuse_penalty_start_1024th(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1overuse_1penalty_1start_11024th(JNIEnv *env, jclass clz, int64_t this_ptr, int16_t val) {
@@ -43045,8 +43106,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1ove
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_overuse_penalty_msat_per_1024th(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_overuse_penalty_msat_per_1024th(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1overuse_1penalty_1msat_1per_11024th(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43062,8 +43123,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1get_1fai
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_failure_penalty_half_life(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_failure_penalty_half_life(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1set_1failure_1penalty_1half_1life(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43104,8 +43165,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ScoringParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ScoringParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43244,8 +43305,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_base_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_base_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1set_1base_1penalty_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43261,8 +43322,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_liquidity_penalty_multiplier_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_liquidity_penalty_multiplier_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1set_1liquidity_1penalty_1multiplier_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43278,8 +43339,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_liquidity_offset_half_life(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_liquidity_offset_half_life(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1set_1liquidity_1offset_1half_1life(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43295,8 +43356,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_amount_penalty_multiplier_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_amount_penalty_multiplier_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1set_1amount_1penalty_1multiplier_1msat(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -43337,8 +43398,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParamet
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ProbabilisticScoringParameters_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43622,8 +43683,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ParseError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKParseError* arg_conv = (LDKParseError*)arg;
-	int64_t ret_val = ParseError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = ParseError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ParseError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43785,8 +43846,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ParseOrSemanticError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKParseOrSemanticError* arg_conv = (LDKParseOrSemanticError*)arg;
-	int64_t ret_val = ParseOrSemanticError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = ParseOrSemanticError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ParseOrSemanticError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43833,8 +43894,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1eq(JNIEnv *env, j
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Invoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Invoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t Invoice_clone_ptr(LDKInvoice *NONNULL_PTR arg) {
@@ -43854,8 +43915,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1clone_1ptr(JNIEnv 
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Invoice_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43892,8 +43953,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1eq(JNIEn
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = SignedRawInvoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = SignedRawInvoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t SignedRawInvoice_clone_ptr(LDKSignedRawInvoice *NONNULL_PTR arg) {
@@ -43913,8 +43974,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = SignedRawInvoice_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = SignedRawInvoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -43981,8 +44042,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RawInvoice_1eq(JNIEnv *env
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RawInvoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RawInvoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RawInvoice_clone_ptr(LDKRawInvoice *NONNULL_PTR arg) {
@@ -44002,8 +44063,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RawInvoice_1clone_1ptr(JNIE
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RawInvoice_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RawInvoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RawInvoice_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44070,8 +44131,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RawDataPart_1eq(JNIEnv *en
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RawDataPart_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RawDataPart_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RawDataPart_clone_ptr(LDKRawDataPart *NONNULL_PTR arg) {
@@ -44091,8 +44152,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RawDataPart_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RawDataPart_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RawDataPart_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RawDataPart_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44129,8 +44190,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1eq(JNIE
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PositiveTimestamp_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PositiveTimestamp_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t PositiveTimestamp_clone_ptr(LDKPositiveTimestamp *NONNULL_PTR arg) {
@@ -44150,8 +44211,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1clone_1p
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PositiveTimestamp_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44200,14 +44261,14 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_SiPrefix_1pico(JNIEnv *env, 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SiPrefix_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKSiPrefix* a_conv = (LDKSiPrefix*)(a & ~1);
 	LDKSiPrefix* b_conv = (LDKSiPrefix*)(b & ~1);
-	jboolean ret_val = SiPrefix_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SiPrefix_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SiPrefix_1multiplier(JNIEnv *env, jclass clz, int64_t this_arg) {
 	LDKSiPrefix* this_arg_conv = (LDKSiPrefix*)(this_arg & ~1);
-	int64_t ret_val = SiPrefix_multiplier(this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = SiPrefix_multiplier(this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_Currency_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44243,15 +44304,15 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_Currency_1signet(JNIEnv *env
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Currency_1hash(JNIEnv *env, jclass clz, int64_t o) {
 	LDKCurrency* o_conv = (LDKCurrency*)(o & ~1);
-	int64_t ret_val = Currency_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Currency_hash(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Currency_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKCurrency* a_conv = (LDKCurrency*)(a & ~1);
 	LDKCurrency* b_conv = (LDKCurrency*)(b & ~1);
-	jboolean ret_val = Currency_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Currency_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Sha256_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44279,8 +44340,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sha256_1clone_1ptr(JNIEnv *
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Sha256_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Sha256_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sha256_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44305,8 +44366,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Sha256_1hash(JNIEnv *env, j
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Sha256_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Sha256_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Sha256_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44318,8 +44379,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Sha256_1eq(JNIEnv *env, jc
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Sha256_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Sha256_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Description_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44347,8 +44408,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Description_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = Description_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = Description_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Description_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44373,8 +44434,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Description_1hash(JNIEnv *e
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Description_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Description_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Description_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44386,8 +44447,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Description_1eq(JNIEnv *en
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Description_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Description_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44452,8 +44513,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1clone_1ptr(JNI
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PayeePubKey_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PayeePubKey_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44478,8 +44539,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1hash(JNIEnv *e
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PayeePubKey_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PayeePubKey_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44491,8 +44552,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PayeePubKey_1eq(JNIEnv *en
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PayeePubKey_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PayeePubKey_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44520,8 +44581,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1clone_1ptr(JNIE
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = ExpiryTime_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44546,8 +44607,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1hash(JNIEnv *en
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = ExpiryTime_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44559,8 +44620,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1eq(JNIEnv *env
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ExpiryTime_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ExpiryTime_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44576,8 +44637,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1get_1a(
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = MinFinalCltvExpiry_get_a(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_get_a(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1set_1a(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -44618,8 +44679,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1clone_1
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = MinFinalCltvExpiry_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44644,8 +44705,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1hash(JN
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = MinFinalCltvExpiry_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44657,8 +44718,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_MinFinalCltvExpiry_1eq(JNI
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = MinFinalCltvExpiry_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = MinFinalCltvExpiry_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_Fallback_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -44678,8 +44739,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Fallback_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKFallback* arg_conv = (LDKFallback*)arg;
-	int64_t ret_val = Fallback_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = Fallback_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Fallback_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44724,15 +44785,15 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Fallback_1script_1hash(JNIE
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Fallback_1hash(JNIEnv *env, jclass clz, int64_t o) {
 	LDKFallback* o_conv = (LDKFallback*)o;
-	int64_t ret_val = Fallback_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Fallback_hash(o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Fallback_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKFallback* a_conv = (LDKFallback*)a;
 	LDKFallback* b_conv = (LDKFallback*)b;
-	jboolean ret_val = Fallback_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Fallback_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_InvoiceSignature_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44760,8 +44821,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceSignature_1clone_1pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = InvoiceSignature_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = InvoiceSignature_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_InvoiceSignature_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44790,8 +44851,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_InvoiceSignature_1eq(JNIEn
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InvoiceSignature_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceSignature_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1free(JNIEnv *env, jclass clz, int64_t this_obj) {
@@ -44819,8 +44880,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1clone_1ptr(JN
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = PrivateRoute_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = PrivateRoute_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -44845,8 +44906,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1hash(JNIEnv *
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PrivateRoute_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PrivateRoute_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
@@ -44858,8 +44919,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1eq(JNIEnv *e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PrivateRoute_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PrivateRoute_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1into_1parts(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -44932,8 +44993,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SignedRawInvoice_1check_1s
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = SignedRawInvoice_check_signature(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = SignedRawInvoice_check_signature(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_RawInvoice_1hash(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45158,8 +45219,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1unix
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_unix_timestamp(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_unix_timestamp(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1duration_1since_1epoch(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45167,8 +45228,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1dura
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_duration_since_epoch(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_duration_since_epoch(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1time(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45176,8 +45237,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PositiveTimestamp_1as_1time
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_time(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_time(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1into_1signed_1raw(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45224,8 +45285,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1timestamp(JNIEnv *
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_timestamp(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_timestamp(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1duration_1since_1epoch(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45233,8 +45294,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1duration_1since_1e
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_duration_since_epoch(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_duration_since_epoch(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int8_tArray JNICALL Java_org_ldk_impl_bindings_Invoice_1payment_1hash(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45301,8 +45362,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1expiry_1time(JNIEn
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_expiry_time(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_expiry_time(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1is_1expired(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45310,8 +45371,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1is_1expired(JNIEn
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = Invoice_is_expired(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = Invoice_is_expired(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1would_1expire(JNIEnv *env, jclass clz, int64_t this_arg, int64_t at_time) {
@@ -45319,8 +45380,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_Invoice_1would_1expire(JNI
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = Invoice_would_expire(&this_arg_conv, at_time);
-	return ret_val;
+	jboolean ret_conv = Invoice_would_expire(&this_arg_conv, at_time);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1min_1final_1cltv_1expiry(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45328,8 +45389,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_Invoice_1min_1final_1cltv_1
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_min_final_cltv_expiry(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_min_final_cltv_expiry(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_tArray JNICALL Java_org_ldk_impl_bindings_Invoice_1private_1routes(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45454,8 +45515,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1as_1seconds(JNI
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ExpiryTime_as_seconds(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_as_seconds(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1as_1duration(JNIEnv *env, jclass clz, int64_t this_arg) {
@@ -45463,8 +45524,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_ExpiryTime_1as_1duration(JN
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ExpiryTime_as_duration(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_as_duration(&this_arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PrivateRoute_1new(JNIEnv *env, jclass clz, int64_t hops) {
@@ -45530,8 +45591,8 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_CreationError_1missing_1rout
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_CreationError_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKCreationError* a_conv = (LDKCreationError*)(a & ~1);
 	LDKCreationError* b_conv = (LDKCreationError*)(b & ~1);
-	jboolean ret_val = CreationError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = CreationError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jstring JNICALL Java_org_ldk_impl_bindings_CreationError_1to_1str(JNIEnv *env, jclass clz, int64_t o) {
@@ -45601,8 +45662,8 @@ JNIEXPORT jclass JNICALL Java_org_ldk_impl_bindings_SemanticError_1imprecise_1am
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SemanticError_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKSemanticError* a_conv = (LDKSemanticError*)(a & ~1);
 	LDKSemanticError* b_conv = (LDKSemanticError*)(b & ~1);
-	jboolean ret_val = SemanticError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SemanticError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jstring JNICALL Java_org_ldk_impl_bindings_SemanticError_1to_1str(JNIEnv *env, jclass clz, int64_t o) {
@@ -45630,8 +45691,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKSignOrCreationError* arg_conv = (LDKSignOrCreationError*)arg;
-	int64_t ret_val = SignOrCreationError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = SignOrCreationError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -45660,8 +45721,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1creati
 JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1eq(JNIEnv *env, jclass clz, int64_t a, int64_t b) {
 	LDKSignOrCreationError* a_conv = (LDKSignOrCreationError*)a;
 	LDKSignOrCreationError* b_conv = (LDKSignOrCreationError*)b;
-	jboolean ret_val = SignOrCreationError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SignOrCreationError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT jstring JNICALL Java_org_ldk_impl_bindings_SignOrCreationError_1to_1str(JNIEnv *env, jclass clz, int64_t o) {
@@ -45711,8 +45772,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1get_1a(JNIEn
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RetryAttempts_get_a(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RetryAttempts_get_a(&this_ptr_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1set_1a(JNIEnv *env, jclass clz, int64_t this_ptr, int64_t val) {
@@ -45753,8 +45814,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1clone_1ptr(J
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	int64_t ret_val = RetryAttempts_clone_ptr(&arg_conv);
-	return ret_val;
+	int64_t ret_conv = RetryAttempts_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1clone(JNIEnv *env, jclass clz, int64_t orig) {
@@ -45783,8 +45844,8 @@ JNIEXPORT jboolean JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1eq(JNIEnv *
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RetryAttempts_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RetryAttempts_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1hash(JNIEnv *env, jclass clz, int64_t o) {
@@ -45792,8 +45853,8 @@ JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_RetryAttempts_1hash(JNIEnv 
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RetryAttempts_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RetryAttempts_hash(&o_conv);
+	return ret_conv;
 }
 
 JNIEXPORT void JNICALL Java_org_ldk_impl_bindings_PaymentError_1free(JNIEnv *env, jclass clz, int64_t this_ptr) {
@@ -45813,8 +45874,8 @@ int64_t ret_ref = (uintptr_t)ret_copy;
 }
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentError_1clone_1ptr(JNIEnv *env, jclass clz, int64_t arg) {
 	LDKPaymentError* arg_conv = (LDKPaymentError*)arg;
-	int64_t ret_val = PaymentError_clone_ptr(arg_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 JNIEXPORT int64_t JNICALL Java_org_ldk_impl_bindings_PaymentError_1clone(JNIEnv *env, jclass clz, int64_t orig) {

--- a/ts/bindings.c
+++ b/ts/bindings.c
@@ -338,12 +338,14 @@ uint32_t __attribute__((export_name("TS_LDKBech32Error_ty_from_ptr"))) TS_LDKBec
 int32_t __attribute__((export_name("TS_LDKBech32Error_InvalidChar_get_invalid_char"))) TS_LDKBech32Error_InvalidChar_get_invalid_char(uint32_t ptr) {
 	LDKBech32Error *obj = (LDKBech32Error*)(ptr & ~1);
 	assert(obj->tag == LDKBech32Error_InvalidChar);
-	return obj->invalid_char;
+			int32_t invalid_char_conv = obj->invalid_char;
+	return invalid_char_conv;
 }
 int8_t __attribute__((export_name("TS_LDKBech32Error_InvalidData_get_invalid_data"))) TS_LDKBech32Error_InvalidData_get_invalid_data(uint32_t ptr) {
 	LDKBech32Error *obj = (LDKBech32Error*)(ptr & ~1);
 	assert(obj->tag == LDKBech32Error_InvalidData);
-	return obj->invalid_data;
+			int8_t invalid_data_conv = obj->invalid_data;
+	return invalid_data_conv;
 }
 static inline LDKCVec_u8Z CVec_u8Z_clone(const LDKCVec_u8Z *orig) {
 	LDKCVec_u8Z ret = { .data = MALLOC(sizeof(int8_t) * orig->datalen, "LDKCVec_u8Z clone bytes"), .datalen = orig->datalen };
@@ -361,8 +363,8 @@ struct LDKCVec_u8Z TxOut_get_script_pubkey (struct LDKTxOut* thing) {	return CVe
 
 uint64_t TxOut_get_value (struct LDKTxOut* thing) {	return thing->value;}int64_t  __attribute__((export_name("TS_TxOut_get_value"))) TS_TxOut_get_value(uint32_t thing) {
 	LDKTxOut* thing_conv = (LDKTxOut*)(thing & ~1);
-	int64_t ret_val = TxOut_get_value(thing_conv);
-	return ret_val;
+	int64_t ret_conv = TxOut_get_value(thing_conv);
+	return ret_conv;
 }
 
 static inline void CResult_NoneNoneZ_get_ok(LDKCResult_NoneNoneZ *NONNULL_PTR owner){
@@ -572,7 +574,8 @@ uint32_t __attribute__((export_name("TS_LDKCOption_u32Z_ty_from_ptr"))) TS_LDKCO
 int32_t __attribute__((export_name("TS_LDKCOption_u32Z_Some_get_some"))) TS_LDKCOption_u32Z_Some_get_some(uint32_t ptr) {
 	LDKCOption_u32Z *obj = (LDKCOption_u32Z*)(ptr & ~1);
 	assert(obj->tag == LDKCOption_u32Z_Some);
-	return obj->some;
+			int32_t some_conv = obj->some;
+	return some_conv;
 }
 static inline struct LDKHTLCOutputInCommitment CResult_HTLCOutputInCommitmentDecodeErrorZ_get_ok(LDKCResult_HTLCOutputInCommitmentDecodeErrorZ *NONNULL_PTR owner){
 CHECK(owner->result_ok);
@@ -1078,7 +1081,8 @@ uint32_t __attribute__((export_name("TS_LDKCOption_u64Z_ty_from_ptr"))) TS_LDKCO
 int64_t __attribute__((export_name("TS_LDKCOption_u64Z_Some_get_some"))) TS_LDKCOption_u64Z_Some_get_some(uint32_t ptr) {
 	LDKCOption_u64Z *obj = (LDKCOption_u64Z*)(ptr & ~1);
 	assert(obj->tag == LDKCOption_u64Z_Some);
-	return obj->some;
+			int64_t some_conv = obj->some;
+	return some_conv;
 }
 static inline struct LDKPaymentParameters CResult_PaymentParametersDecodeErrorZ_get_ok(LDKCResult_PaymentParametersDecodeErrorZ *NONNULL_PTR owner){
 CHECK(owner->result_ok);
@@ -1264,8 +1268,8 @@ static inline uintptr_t C2Tuple_usizeTransactionZ_get_a(LDKC2Tuple_usizeTransact
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_usizeTransactionZ_get_a"))) TS_C2Tuple_usizeTransactionZ_get_a(uint32_t owner) {
 	LDKC2Tuple_usizeTransactionZ* owner_conv = (LDKC2Tuple_usizeTransactionZ*)(owner & ~1);
-	uint32_t ret_val = C2Tuple_usizeTransactionZ_get_a(owner_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_usizeTransactionZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKTransaction C2Tuple_usizeTransactionZ_get_b(LDKC2Tuple_usizeTransactionZ *NONNULL_PTR owner){
@@ -1358,7 +1362,8 @@ uint32_t __attribute__((export_name("TS_LDKMonitorEvent_UpdateCompleted_get_fund
 int64_t __attribute__((export_name("TS_LDKMonitorEvent_UpdateCompleted_get_monitor_update_id"))) TS_LDKMonitorEvent_UpdateCompleted_get_monitor_update_id(uint32_t ptr) {
 	LDKMonitorEvent *obj = (LDKMonitorEvent*)(ptr & ~1);
 	assert(obj->tag == LDKMonitorEvent_UpdateCompleted);
-	return obj->update_completed.monitor_update_id;
+			int64_t monitor_update_id_conv = obj->update_completed.monitor_update_id;
+	return monitor_update_id_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKMonitorEvent_UpdateFailed_get_update_failed"))) TS_LDKMonitorEvent_UpdateFailed_get_update_failed(uint32_t ptr) {
 	LDKMonitorEvent *obj = (LDKMonitorEvent*)(ptr & ~1);
@@ -1489,12 +1494,14 @@ uint32_t __attribute__((export_name("TS_LDKNetworkUpdate_ChannelUpdateMessage_ge
 int64_t __attribute__((export_name("TS_LDKNetworkUpdate_ChannelClosed_get_short_channel_id"))) TS_LDKNetworkUpdate_ChannelClosed_get_short_channel_id(uint32_t ptr) {
 	LDKNetworkUpdate *obj = (LDKNetworkUpdate*)(ptr & ~1);
 	assert(obj->tag == LDKNetworkUpdate_ChannelClosed);
-	return obj->channel_closed.short_channel_id;
+			int64_t short_channel_id_conv = obj->channel_closed.short_channel_id;
+	return short_channel_id_conv;
 }
 jboolean __attribute__((export_name("TS_LDKNetworkUpdate_ChannelClosed_get_is_permanent"))) TS_LDKNetworkUpdate_ChannelClosed_get_is_permanent(uint32_t ptr) {
 	LDKNetworkUpdate *obj = (LDKNetworkUpdate*)(ptr & ~1);
 	assert(obj->tag == LDKNetworkUpdate_ChannelClosed);
-	return obj->channel_closed.is_permanent;
+			jboolean is_permanent_conv = obj->channel_closed.is_permanent;
+	return is_permanent_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKNetworkUpdate_NodeFailure_get_node_id"))) TS_LDKNetworkUpdate_NodeFailure_get_node_id(uint32_t ptr) {
 	LDKNetworkUpdate *obj = (LDKNetworkUpdate*)(ptr & ~1);
@@ -1506,7 +1513,8 @@ int8_tArray __attribute__((export_name("TS_LDKNetworkUpdate_NodeFailure_get_node
 jboolean __attribute__((export_name("TS_LDKNetworkUpdate_NodeFailure_get_is_permanent"))) TS_LDKNetworkUpdate_NodeFailure_get_is_permanent(uint32_t ptr) {
 	LDKNetworkUpdate *obj = (LDKNetworkUpdate*)(ptr & ~1);
 	assert(obj->tag == LDKNetworkUpdate_NodeFailure);
-	return obj->node_failure.is_permanent;
+			jboolean is_permanent_conv = obj->node_failure.is_permanent;
+	return is_permanent_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKCOption_NetworkUpdateZ_ty_from_ptr"))) TS_LDKCOption_NetworkUpdateZ_ty_from_ptr(uint32_t ptr) {
 	LDKCOption_NetworkUpdateZ *obj = (LDKCOption_NetworkUpdateZ*)(ptr & ~1);
@@ -1634,7 +1642,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_t
 int64_t __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_channel_value_satoshis"))) TS_LDKEvent_FundingGenerationReady_get_channel_value_satoshis(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_FundingGenerationReady);
-	return obj->funding_generation_ready.channel_value_satoshis;
+			int64_t channel_value_satoshis_conv = obj->funding_generation_ready.channel_value_satoshis;
+	return channel_value_satoshis_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_output_script"))) TS_LDKEvent_FundingGenerationReady_get_output_script(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1647,7 +1656,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_o
 int64_t __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_user_channel_id"))) TS_LDKEvent_FundingGenerationReady_get_user_channel_id(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_FundingGenerationReady);
-	return obj->funding_generation_ready.user_channel_id;
+			int64_t user_channel_id_conv = obj->funding_generation_ready.user_channel_id;
+	return user_channel_id_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKEvent_PaymentReceived_get_payment_hash"))) TS_LDKEvent_PaymentReceived_get_payment_hash(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1659,7 +1669,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_PaymentReceived_get_payment_
 int64_t __attribute__((export_name("TS_LDKEvent_PaymentReceived_get_amt"))) TS_LDKEvent_PaymentReceived_get_amt(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PaymentReceived);
-	return obj->payment_received.amt;
+			int64_t amt_conv = obj->payment_received.amt;
+	return amt_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKEvent_PaymentReceived_get_purpose"))) TS_LDKEvent_PaymentReceived_get_purpose(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1711,7 +1722,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_paymen
 jboolean __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_rejected_by_dest"))) TS_LDKEvent_PaymentPathFailed_get_rejected_by_dest(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PaymentPathFailed);
-	return obj->payment_path_failed.rejected_by_dest;
+			jboolean rejected_by_dest_conv = obj->payment_path_failed.rejected_by_dest;
+	return rejected_by_dest_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_network_update"))) TS_LDKEvent_PaymentPathFailed_get_network_update(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1722,7 +1734,8 @@ uint32_t __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_network_u
 jboolean __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_all_paths_failed"))) TS_LDKEvent_PaymentPathFailed_get_all_paths_failed(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PaymentPathFailed);
-	return obj->payment_path_failed.all_paths_failed;
+			jboolean all_paths_failed_conv = obj->payment_path_failed.all_paths_failed;
+	return all_paths_failed_conv;
 }
 uint32_tArray __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_path"))) TS_LDKEvent_PaymentPathFailed_get_path(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1779,7 +1792,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_PaymentFailed_get_payment_ha
 int64_t __attribute__((export_name("TS_LDKEvent_PendingHTLCsForwardable_get_time_forwardable"))) TS_LDKEvent_PendingHTLCsForwardable_get_time_forwardable(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PendingHTLCsForwardable);
-	return obj->pending_htl_cs_forwardable.time_forwardable;
+			int64_t time_forwardable_conv = obj->pending_htl_cs_forwardable.time_forwardable;
+	return time_forwardable_conv;
 }
 uint32_tArray __attribute__((export_name("TS_LDKEvent_SpendableOutputs_get_outputs"))) TS_LDKEvent_SpendableOutputs_get_outputs(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1804,7 +1818,8 @@ uint32_t __attribute__((export_name("TS_LDKEvent_PaymentForwarded_get_fee_earned
 jboolean __attribute__((export_name("TS_LDKEvent_PaymentForwarded_get_claim_from_onchain_tx"))) TS_LDKEvent_PaymentForwarded_get_claim_from_onchain_tx(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PaymentForwarded);
-	return obj->payment_forwarded.claim_from_onchain_tx;
+			jboolean claim_from_onchain_tx_conv = obj->payment_forwarded.claim_from_onchain_tx;
+	return claim_from_onchain_tx_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKEvent_ChannelClosed_get_channel_id"))) TS_LDKEvent_ChannelClosed_get_channel_id(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1816,7 +1831,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_ChannelClosed_get_channel_id
 int64_t __attribute__((export_name("TS_LDKEvent_ChannelClosed_get_user_channel_id"))) TS_LDKEvent_ChannelClosed_get_user_channel_id(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_ChannelClosed);
-	return obj->channel_closed.user_channel_id;
+			int64_t user_channel_id_conv = obj->channel_closed.user_channel_id;
+	return user_channel_id_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKEvent_ChannelClosed_get_reason"))) TS_LDKEvent_ChannelClosed_get_reason(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1889,12 +1905,14 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_OpenChannelRequest_get_count
 int64_t __attribute__((export_name("TS_LDKEvent_OpenChannelRequest_get_funding_satoshis"))) TS_LDKEvent_OpenChannelRequest_get_funding_satoshis(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_OpenChannelRequest);
-	return obj->open_channel_request.funding_satoshis;
+			int64_t funding_satoshis_conv = obj->open_channel_request.funding_satoshis;
+	return funding_satoshis_conv;
 }
 int64_t __attribute__((export_name("TS_LDKEvent_OpenChannelRequest_get_push_msat"))) TS_LDKEvent_OpenChannelRequest_get_push_msat(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_OpenChannelRequest);
-	return obj->open_channel_request.push_msat;
+			int64_t push_msat_conv = obj->open_channel_request.push_msat;
+	return push_msat_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKEvent_OpenChannelRequest_get_channel_type"))) TS_LDKEvent_OpenChannelRequest_get_channel_type(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -2955,7 +2973,8 @@ static void LDKBaseSign_JCalls_free(void* this_arg) {
 }
 LDKPublicKey get_per_commitment_point_LDKBaseSign_jcall(const void* this_arg, uint64_t idx) {
 	LDKBaseSign_JCalls *j_calls = (LDKBaseSign_JCalls*) this_arg;
-	int8_tArray ret = (int8_tArray)js_invoke_function_1(j_calls->instance_ptr, 0, (uint32_t)idx);
+	int64_t idx_conv = idx;
+	int8_tArray ret = (int8_tArray)js_invoke_function_1(j_calls->instance_ptr, 0, (uint32_t)idx_conv);
 	LDKPublicKey ret_ref;
 	CHECK(ret->arr_len == 33);
 	memcpy(ret_ref.compressed_form, ret->elems, 33); FREE(ret);
@@ -2963,7 +2982,8 @@ LDKPublicKey get_per_commitment_point_LDKBaseSign_jcall(const void* this_arg, ui
 }
 LDKThirtyTwoBytes release_commitment_secret_LDKBaseSign_jcall(const void* this_arg, uint64_t idx) {
 	LDKBaseSign_JCalls *j_calls = (LDKBaseSign_JCalls*) this_arg;
-	int8_tArray ret = (int8_tArray)js_invoke_function_1(j_calls->instance_ptr, 1, (uint32_t)idx);
+	int64_t idx_conv = idx;
+	int8_tArray ret = (int8_tArray)js_invoke_function_1(j_calls->instance_ptr, 1, (uint32_t)idx_conv);
 	LDKThirtyTwoBytes ret_ref;
 	CHECK(ret->arr_len == 32);
 	memcpy(ret_ref.data, ret->elems, 32); FREE(ret);
@@ -3039,9 +3059,10 @@ LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ sign_counterparty_commitment_L
 }
 LDKCResult_NoneNoneZ validate_counterparty_revocation_LDKBaseSign_jcall(const void* this_arg, uint64_t idx, const uint8_t (* secret)[32]) {
 	LDKBaseSign_JCalls *j_calls = (LDKBaseSign_JCalls*) this_arg;
+	int64_t idx_conv = idx;
 	int8_tArray secret_arr = init_int8_tArray(32, __LINE__);
 	memcpy(secret_arr->elems, *secret, 32);
-	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 5, (uint32_t)idx, (uint32_t)secret_arr);
+	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 5, (uint32_t)idx_conv, (uint32_t)secret_arr);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_NoneNoneZ ret_conv = *(LDKCResult_NoneNoneZ*)(ret_ptr);
@@ -3073,9 +3094,11 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_output_LDKBaseSign_jcall(const vo
 	int8_tArray justice_tx_arr = init_int8_tArray(justice_tx_var.datalen, __LINE__);
 	memcpy(justice_tx_arr->elems, justice_tx_var.data, justice_tx_var.datalen);
 	Transaction_free(justice_tx_var);
+	uint32_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_key_arr = init_int8_tArray(32, __LINE__);
 	memcpy(per_commitment_key_arr->elems, *per_commitment_key, 32);
-	uint32_t ret = js_invoke_function_4(j_calls->instance_ptr, 7, (uint32_t)justice_tx_arr, (uint32_t)input, (uint32_t)amount, (uint32_t)per_commitment_key_arr);
+	uint32_t ret = js_invoke_function_4(j_calls->instance_ptr, 7, (uint32_t)justice_tx_arr, (uint32_t)input_conv, (uint32_t)amount_conv, (uint32_t)per_commitment_key_arr);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_SignatureNoneZ ret_conv = *(LDKCResult_SignatureNoneZ*)(ret_ptr);
@@ -3088,6 +3111,8 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_htlc_LDKBaseSign_jcall(const void
 	int8_tArray justice_tx_arr = init_int8_tArray(justice_tx_var.datalen, __LINE__);
 	memcpy(justice_tx_arr->elems, justice_tx_var.data, justice_tx_var.datalen);
 	Transaction_free(justice_tx_var);
+	uint32_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_key_arr = init_int8_tArray(32, __LINE__);
 	memcpy(per_commitment_key_arr->elems, *per_commitment_key, 32);
 	LDKHTLCOutputInCommitment htlc_var = *htlc;
@@ -3100,7 +3125,7 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_htlc_LDKBaseSign_jcall(const void
 	if (htlc_var.is_owned) {
 		htlc_ref |= 1;
 	}
-	uint32_t ret = js_invoke_function_5(j_calls->instance_ptr, 8, (uint32_t)justice_tx_arr, (uint32_t)input, (uint32_t)amount, (uint32_t)per_commitment_key_arr, (uint32_t)htlc_ref);
+	uint32_t ret = js_invoke_function_5(j_calls->instance_ptr, 8, (uint32_t)justice_tx_arr, (uint32_t)input_conv, (uint32_t)amount_conv, (uint32_t)per_commitment_key_arr, (uint32_t)htlc_ref);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_SignatureNoneZ ret_conv = *(LDKCResult_SignatureNoneZ*)(ret_ptr);
@@ -3113,6 +3138,8 @@ LDKCResult_SignatureNoneZ sign_counterparty_htlc_transaction_LDKBaseSign_jcall(c
 	int8_tArray htlc_tx_arr = init_int8_tArray(htlc_tx_var.datalen, __LINE__);
 	memcpy(htlc_tx_arr->elems, htlc_tx_var.data, htlc_tx_var.datalen);
 	Transaction_free(htlc_tx_var);
+	uint32_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_point_arr = init_int8_tArray(33, __LINE__);
 	memcpy(per_commitment_point_arr->elems, per_commitment_point.compressed_form, 33);
 	LDKHTLCOutputInCommitment htlc_var = *htlc;
@@ -3125,7 +3152,7 @@ LDKCResult_SignatureNoneZ sign_counterparty_htlc_transaction_LDKBaseSign_jcall(c
 	if (htlc_var.is_owned) {
 		htlc_ref |= 1;
 	}
-	uint32_t ret = js_invoke_function_5(j_calls->instance_ptr, 9, (uint32_t)htlc_tx_arr, (uint32_t)input, (uint32_t)amount, (uint32_t)per_commitment_point_arr, (uint32_t)htlc_ref);
+	uint32_t ret = js_invoke_function_5(j_calls->instance_ptr, 9, (uint32_t)htlc_tx_arr, (uint32_t)input_conv, (uint32_t)amount_conv, (uint32_t)per_commitment_point_arr, (uint32_t)htlc_ref);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_SignatureNoneZ ret_conv = *(LDKCResult_SignatureNoneZ*)(ret_ptr);
@@ -3673,7 +3700,8 @@ uint32_t __attribute__((export_name("TS_LDKCOption_u16Z_ty_from_ptr"))) TS_LDKCO
 int16_t __attribute__((export_name("TS_LDKCOption_u16Z_Some_get_some"))) TS_LDKCOption_u16Z_Some_get_some(uint32_t ptr) {
 	LDKCOption_u16Z *obj = (LDKCOption_u16Z*)(ptr & ~1);
 	assert(obj->tag == LDKCOption_u16Z_Some);
-	return obj->some;
+			int16_t some_conv = obj->some;
+	return some_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKAPIError_ty_from_ptr"))) TS_LDKAPIError_ty_from_ptr(uint32_t ptr) {
 	LDKAPIError *obj = (LDKAPIError*)(ptr & ~1);
@@ -3704,7 +3732,8 @@ jstring __attribute__((export_name("TS_LDKAPIError_FeeRateTooHigh_get_err"))) TS
 int32_t __attribute__((export_name("TS_LDKAPIError_FeeRateTooHigh_get_feerate"))) TS_LDKAPIError_FeeRateTooHigh_get_feerate(uint32_t ptr) {
 	LDKAPIError *obj = (LDKAPIError*)(ptr & ~1);
 	assert(obj->tag == LDKAPIError_FeeRateTooHigh);
-	return obj->fee_rate_too_high.feerate;
+			int32_t feerate_conv = obj->fee_rate_too_high.feerate;
+	return feerate_conv;
 }
 jstring __attribute__((export_name("TS_LDKAPIError_RouteError_get_err"))) TS_LDKAPIError_RouteError_get_err(uint32_t ptr) {
 	LDKAPIError *obj = (LDKAPIError*)(ptr & ~1);
@@ -3978,7 +4007,8 @@ int8_tArray __attribute__((export_name("TS_LDKNetAddress_IPv4_get_addr"))) TS_LD
 int16_t __attribute__((export_name("TS_LDKNetAddress_IPv4_get_port"))) TS_LDKNetAddress_IPv4_get_port(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_IPv4);
-	return obj->i_pv4.port;
+			int16_t port_conv = obj->i_pv4.port;
+	return port_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKNetAddress_IPv6_get_addr"))) TS_LDKNetAddress_IPv6_get_addr(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
@@ -3990,7 +4020,8 @@ int8_tArray __attribute__((export_name("TS_LDKNetAddress_IPv6_get_addr"))) TS_LD
 int16_t __attribute__((export_name("TS_LDKNetAddress_IPv6_get_port"))) TS_LDKNetAddress_IPv6_get_port(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_IPv6);
-	return obj->i_pv6.port;
+			int16_t port_conv = obj->i_pv6.port;
+	return port_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKNetAddress_OnionV2_get_onion_v2"))) TS_LDKNetAddress_OnionV2_get_onion_v2(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
@@ -4009,17 +4040,20 @@ int8_tArray __attribute__((export_name("TS_LDKNetAddress_OnionV3_get_ed25519_pub
 int16_t __attribute__((export_name("TS_LDKNetAddress_OnionV3_get_checksum"))) TS_LDKNetAddress_OnionV3_get_checksum(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_OnionV3);
-	return obj->onion_v3.checksum;
+			int16_t checksum_conv = obj->onion_v3.checksum;
+	return checksum_conv;
 }
 int8_t __attribute__((export_name("TS_LDKNetAddress_OnionV3_get_version"))) TS_LDKNetAddress_OnionV3_get_version(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_OnionV3);
-	return obj->onion_v3.version;
+			int8_t version_conv = obj->onion_v3.version;
+	return version_conv;
 }
 int16_t __attribute__((export_name("TS_LDKNetAddress_OnionV3_get_port"))) TS_LDKNetAddress_OnionV3_get_port(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_OnionV3);
-	return obj->onion_v3.port;
+			int16_t port_conv = obj->onion_v3.port;
+	return port_conv;
 }
 static inline LDKCVec_NetAddressZ CVec_NetAddressZ_clone(const LDKCVec_NetAddressZ *orig) {
 	LDKCVec_NetAddressZ ret = { .data = MALLOC(sizeof(LDKNetAddress) * orig->datalen, "LDKCVec_NetAddressZ clone bytes"), .datalen = orig->datalen };
@@ -4563,7 +4597,9 @@ LDKShutdownScript get_shutdown_scriptpubkey_LDKKeysInterface_jcall(const void* t
 }
 LDKSign get_channel_signer_LDKKeysInterface_jcall(const void* this_arg, bool inbound, uint64_t channel_value_satoshis) {
 	LDKKeysInterface_JCalls *j_calls = (LDKKeysInterface_JCalls*) this_arg;
-	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 21, (uint32_t)inbound, (uint32_t)channel_value_satoshis);
+	jboolean inbound_conv = inbound;
+	int64_t channel_value_satoshis_conv = channel_value_satoshis;
+	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 21, (uint32_t)inbound_conv, (uint32_t)channel_value_satoshis_conv);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKSign ret_conv = *(LDKSign*)(ret_ptr);
@@ -4791,8 +4827,8 @@ int32_t  __attribute__((export_name("TS_FeeEstimator_get_est_sat_per_1000_weight
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKFeeEstimator* this_arg_conv = (LDKFeeEstimator*)this_arg_ptr;
 	LDKConfirmationTarget confirmation_target_conv = LDKConfirmationTarget_from_js(confirmation_target);
-	int32_t ret_val = (this_arg_conv->get_est_sat_per_1000_weight)(this_arg_conv->this_arg, confirmation_target_conv);
-	return ret_val;
+	int32_t ret_conv = (this_arg_conv->get_est_sat_per_1000_weight)(this_arg_conv->this_arg, confirmation_target_conv);
+	return ret_conv;
 }
 
 typedef struct LDKLogger_JCalls {
@@ -5021,8 +5057,8 @@ int16_t  __attribute__((export_name("TS_Type_type_id"))) TS_Type_type_id(uint32_
 	void* this_arg_ptr = (void*)(((uintptr_t)this_arg) & ~1);
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKType* this_arg_conv = (LDKType*)this_arg_ptr;
-	int16_t ret_val = (this_arg_conv->type_id)(this_arg_conv->this_arg);
-	return ret_val;
+	int16_t ret_conv = (this_arg_conv->type_id)(this_arg_conv->this_arg);
+	return ret_conv;
 }
 
 jstring  __attribute__((export_name("TS_Type_debug_str"))) TS_Type_debug_str(uint32_t this_arg) {
@@ -5685,8 +5721,8 @@ static inline uint32_t C2Tuple_u32ScriptZ_get_a(LDKC2Tuple_u32ScriptZ *NONNULL_P
 }
 int32_t  __attribute__((export_name("TS_C2Tuple_u32ScriptZ_get_a"))) TS_C2Tuple_u32ScriptZ_get_a(uint32_t owner) {
 	LDKC2Tuple_u32ScriptZ* owner_conv = (LDKC2Tuple_u32ScriptZ*)(owner & ~1);
-	int32_t ret_val = C2Tuple_u32ScriptZ_get_a(owner_conv);
-	return ret_val;
+	int32_t ret_conv = C2Tuple_u32ScriptZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKCVec_u8Z C2Tuple_u32ScriptZ_get_b(LDKC2Tuple_u32ScriptZ *NONNULL_PTR owner){
@@ -5756,8 +5792,8 @@ static inline uint32_t C2Tuple_u32TxOutZ_get_a(LDKC2Tuple_u32TxOutZ *NONNULL_PTR
 }
 int32_t  __attribute__((export_name("TS_C2Tuple_u32TxOutZ_get_a"))) TS_C2Tuple_u32TxOutZ_get_a(uint32_t owner) {
 	LDKC2Tuple_u32TxOutZ* owner_conv = (LDKC2Tuple_u32TxOutZ*)(owner & ~1);
-	int32_t ret_val = C2Tuple_u32TxOutZ_get_a(owner_conv);
-	return ret_val;
+	int32_t ret_conv = C2Tuple_u32TxOutZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKTxOut C2Tuple_u32TxOutZ_get_b(LDKC2Tuple_u32TxOutZ *NONNULL_PTR owner){
@@ -5826,37 +5862,44 @@ uint32_t __attribute__((export_name("TS_LDKBalance_ty_from_ptr"))) TS_LDKBalance
 int64_t __attribute__((export_name("TS_LDKBalance_ClaimableOnChannelClose_get_claimable_amount_satoshis"))) TS_LDKBalance_ClaimableOnChannelClose_get_claimable_amount_satoshis(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ClaimableOnChannelClose);
-	return obj->claimable_on_channel_close.claimable_amount_satoshis;
+			int64_t claimable_amount_satoshis_conv = obj->claimable_on_channel_close.claimable_amount_satoshis;
+	return claimable_amount_satoshis_conv;
 }
 int64_t __attribute__((export_name("TS_LDKBalance_ClaimableAwaitingConfirmations_get_claimable_amount_satoshis"))) TS_LDKBalance_ClaimableAwaitingConfirmations_get_claimable_amount_satoshis(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ClaimableAwaitingConfirmations);
-	return obj->claimable_awaiting_confirmations.claimable_amount_satoshis;
+			int64_t claimable_amount_satoshis_conv = obj->claimable_awaiting_confirmations.claimable_amount_satoshis;
+	return claimable_amount_satoshis_conv;
 }
 int32_t __attribute__((export_name("TS_LDKBalance_ClaimableAwaitingConfirmations_get_confirmation_height"))) TS_LDKBalance_ClaimableAwaitingConfirmations_get_confirmation_height(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ClaimableAwaitingConfirmations);
-	return obj->claimable_awaiting_confirmations.confirmation_height;
+			int32_t confirmation_height_conv = obj->claimable_awaiting_confirmations.confirmation_height;
+	return confirmation_height_conv;
 }
 int64_t __attribute__((export_name("TS_LDKBalance_ContentiousClaimable_get_claimable_amount_satoshis"))) TS_LDKBalance_ContentiousClaimable_get_claimable_amount_satoshis(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ContentiousClaimable);
-	return obj->contentious_claimable.claimable_amount_satoshis;
+			int64_t claimable_amount_satoshis_conv = obj->contentious_claimable.claimable_amount_satoshis;
+	return claimable_amount_satoshis_conv;
 }
 int32_t __attribute__((export_name("TS_LDKBalance_ContentiousClaimable_get_timeout_height"))) TS_LDKBalance_ContentiousClaimable_get_timeout_height(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ContentiousClaimable);
-	return obj->contentious_claimable.timeout_height;
+			int32_t timeout_height_conv = obj->contentious_claimable.timeout_height;
+	return timeout_height_conv;
 }
 int64_t __attribute__((export_name("TS_LDKBalance_MaybeClaimableHTLCAwaitingTimeout_get_claimable_amount_satoshis"))) TS_LDKBalance_MaybeClaimableHTLCAwaitingTimeout_get_claimable_amount_satoshis(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_MaybeClaimableHTLCAwaitingTimeout);
-	return obj->maybe_claimable_htlc_awaiting_timeout.claimable_amount_satoshis;
+			int64_t claimable_amount_satoshis_conv = obj->maybe_claimable_htlc_awaiting_timeout.claimable_amount_satoshis;
+	return claimable_amount_satoshis_conv;
 }
 int32_t __attribute__((export_name("TS_LDKBalance_MaybeClaimableHTLCAwaitingTimeout_get_claimable_height"))) TS_LDKBalance_MaybeClaimableHTLCAwaitingTimeout_get_claimable_height(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_MaybeClaimableHTLCAwaitingTimeout);
-	return obj->maybe_claimable_htlc_awaiting_timeout.claimable_height;
+			int32_t claimable_height_conv = obj->maybe_claimable_htlc_awaiting_timeout.claimable_height;
+	return claimable_height_conv;
 }
 static inline LDKCVec_BalanceZ CVec_BalanceZ_clone(const LDKCVec_BalanceZ *orig) {
 	LDKCVec_BalanceZ ret = { .data = MALLOC(sizeof(LDKBalance) * orig->datalen, "LDKCVec_BalanceZ clone bytes"), .datalen = orig->datalen };
@@ -5981,8 +6024,8 @@ CHECK(owner->result_ok);
 }
 jboolean  __attribute__((export_name("TS_CResult_boolLightningErrorZ_get_ok"))) TS_CResult_boolLightningErrorZ_get_ok(uint32_t owner) {
 	LDKCResult_boolLightningErrorZ* owner_conv = (LDKCResult_boolLightningErrorZ*)(owner & ~1);
-	jboolean ret_val = CResult_boolLightningErrorZ_get_ok(owner_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolLightningErrorZ_get_ok(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKLightningError CResult_boolLightningErrorZ_get_err(LDKCResult_boolLightningErrorZ *NONNULL_PTR owner){
@@ -6146,8 +6189,8 @@ CHECK(owner->result_ok);
 }
 jboolean  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_get_ok"))) TS_CResult_boolPeerHandleErrorZ_get_ok(uint32_t owner) {
 	LDKCResult_boolPeerHandleErrorZ* owner_conv = (LDKCResult_boolPeerHandleErrorZ*)(owner & ~1);
-	jboolean ret_val = CResult_boolPeerHandleErrorZ_get_ok(owner_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolPeerHandleErrorZ_get_ok(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKPeerHandleError CResult_boolPeerHandleErrorZ_get_err(LDKCResult_boolPeerHandleErrorZ *NONNULL_PTR owner){
@@ -6248,7 +6291,8 @@ LDKCResult_TxOutAccessErrorZ get_utxo_LDKAccess_jcall(const void* this_arg, cons
 	LDKAccess_JCalls *j_calls = (LDKAccess_JCalls*) this_arg;
 	int8_tArray genesis_hash_arr = init_int8_tArray(32, __LINE__);
 	memcpy(genesis_hash_arr->elems, *genesis_hash, 32);
-	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 31, (uint32_t)genesis_hash_arr, (uint32_t)short_channel_id);
+	int64_t short_channel_id_conv = short_channel_id;
+	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 31, (uint32_t)genesis_hash_arr, (uint32_t)short_channel_id_conv);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_TxOutAccessErrorZ ret_conv = *(LDKCResult_TxOutAccessErrorZ*)(ret_ptr);
@@ -8162,13 +8206,15 @@ void block_connected_LDKListen_jcall(const void* this_arg, LDKu8slice block, uin
 	LDKu8slice block_var = block;
 	int8_tArray block_arr = init_int8_tArray(block_var.datalen, __LINE__);
 	memcpy(block_arr->elems, block_var.data, block_var.datalen);
-	js_invoke_function_2(j_calls->instance_ptr, 37, (uint32_t)block_arr, (uint32_t)height);
+	int32_t height_conv = height;
+	js_invoke_function_2(j_calls->instance_ptr, 37, (uint32_t)block_arr, (uint32_t)height_conv);
 }
 void block_disconnected_LDKListen_jcall(const void* this_arg, const uint8_t (* header)[80], uint32_t height) {
 	LDKListen_JCalls *j_calls = (LDKListen_JCalls*) this_arg;
 	int8_tArray header_arr = init_int8_tArray(80, __LINE__);
 	memcpy(header_arr->elems, *header, 80);
-	js_invoke_function_2(j_calls->instance_ptr, 38, (uint32_t)header_arr, (uint32_t)height);
+	int32_t height_conv = height;
+	js_invoke_function_2(j_calls->instance_ptr, 38, (uint32_t)header_arr, (uint32_t)height_conv);
 }
 static void LDKListen_JCalls_cloned(LDKListen* new_obj) {
 	LDKListen_JCalls *j_calls = (LDKListen_JCalls*) new_obj->this_arg;
@@ -8238,7 +8284,8 @@ void transactions_confirmed_LDKConfirm_jcall(const void* this_arg, const uint8_t
 	}
 	
 	FREE(txdata_var.data);
-	js_invoke_function_3(j_calls->instance_ptr, 39, (uint32_t)header_arr, (uint32_t)txdata_arr, (uint32_t)height);
+	int32_t height_conv = height;
+	js_invoke_function_3(j_calls->instance_ptr, 39, (uint32_t)header_arr, (uint32_t)txdata_arr, (uint32_t)height_conv);
 }
 void transaction_unconfirmed_LDKConfirm_jcall(const void* this_arg, const uint8_t (* txid)[32]) {
 	LDKConfirm_JCalls *j_calls = (LDKConfirm_JCalls*) this_arg;
@@ -8250,7 +8297,8 @@ void best_block_updated_LDKConfirm_jcall(const void* this_arg, const uint8_t (* 
 	LDKConfirm_JCalls *j_calls = (LDKConfirm_JCalls*) this_arg;
 	int8_tArray header_arr = init_int8_tArray(80, __LINE__);
 	memcpy(header_arr->elems, *header, 80);
-	js_invoke_function_2(j_calls->instance_ptr, 41, (uint32_t)header_arr, (uint32_t)height);
+	int32_t height_conv = height;
+	js_invoke_function_2(j_calls->instance_ptr, 41, (uint32_t)header_arr, (uint32_t)height_conv);
 }
 LDKCVec_TxidZ get_relevant_txids_LDKConfirm_jcall(const void* this_arg) {
 	LDKConfirm_JCalls *j_calls = (LDKConfirm_JCalls*) this_arg;
@@ -8812,7 +8860,8 @@ void peer_disconnected_LDKChannelMessageHandler_jcall(const void* this_arg, LDKP
 	LDKChannelMessageHandler_JCalls *j_calls = (LDKChannelMessageHandler_JCalls*) this_arg;
 	int8_tArray their_node_id_arr = init_int8_tArray(33, __LINE__);
 	memcpy(their_node_id_arr->elems, their_node_id.compressed_form, 33);
-	js_invoke_function_2(j_calls->instance_ptr, 60, (uint32_t)their_node_id_arr, (uint32_t)no_connection_possible);
+	jboolean no_connection_possible_conv = no_connection_possible;
+	js_invoke_function_2(j_calls->instance_ptr, 60, (uint32_t)their_node_id_arr, (uint32_t)no_connection_possible_conv);
 }
 void peer_connected_LDKChannelMessageHandler_jcall(const void* this_arg, LDKPublicKey their_node_id, const LDKInit * msg) {
 	LDKChannelMessageHandler_JCalls *j_calls = (LDKChannelMessageHandler_JCalls*) this_arg;
@@ -9281,7 +9330,9 @@ LDKCResult_boolLightningErrorZ handle_channel_update_LDKRoutingMessageHandler_jc
 }
 LDKCVec_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZZ get_next_channel_announcements_LDKRoutingMessageHandler_jcall(const void* this_arg, uint64_t starting_point, uint8_t batch_amount) {
 	LDKRoutingMessageHandler_JCalls *j_calls = (LDKRoutingMessageHandler_JCalls*) this_arg;
-	uint32_tArray ret = (uint32_tArray)js_invoke_function_2(j_calls->instance_ptr, 68, (uint32_t)starting_point, (uint32_t)batch_amount);
+	int64_t starting_point_conv = starting_point;
+	int8_t batch_amount_conv = batch_amount;
+	uint32_tArray ret = (uint32_tArray)js_invoke_function_2(j_calls->instance_ptr, 68, (uint32_t)starting_point_conv, (uint32_t)batch_amount_conv);
 	LDKCVec_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZZ ret_constr;
 	ret_constr.datalen = ret->arr_len;
 	if (ret_constr.datalen > 0)
@@ -9303,7 +9354,8 @@ LDKCVec_NodeAnnouncementZ get_next_node_announcements_LDKRoutingMessageHandler_j
 	LDKRoutingMessageHandler_JCalls *j_calls = (LDKRoutingMessageHandler_JCalls*) this_arg;
 	int8_tArray starting_point_arr = init_int8_tArray(33, __LINE__);
 	memcpy(starting_point_arr->elems, starting_point.compressed_form, 33);
-	uint32_tArray ret = (uint32_tArray)js_invoke_function_2(j_calls->instance_ptr, 69, (uint32_t)starting_point_arr, (uint32_t)batch_amount);
+	int8_t batch_amount_conv = batch_amount;
+	uint32_tArray ret = (uint32_tArray)js_invoke_function_2(j_calls->instance_ptr, 69, (uint32_t)starting_point_arr, (uint32_t)batch_amount_conv);
 	LDKCVec_NodeAnnouncementZ ret_constr;
 	ret_constr.datalen = ret->arr_len;
 	if (ret_constr.datalen > 0)
@@ -9629,10 +9681,11 @@ static void LDKCustomMessageReader_JCalls_free(void* this_arg) {
 }
 LDKCResult_COption_TypeZDecodeErrorZ read_LDKCustomMessageReader_jcall(const void* this_arg, uint16_t message_type, LDKu8slice buffer) {
 	LDKCustomMessageReader_JCalls *j_calls = (LDKCustomMessageReader_JCalls*) this_arg;
+	int16_t message_type_conv = message_type;
 	LDKu8slice buffer_var = buffer;
 	int8_tArray buffer_arr = init_int8_tArray(buffer_var.datalen, __LINE__);
 	memcpy(buffer_arr->elems, buffer_var.data, buffer_var.datalen);
-	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 75, (uint32_t)message_type, (uint32_t)buffer_arr);
+	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 75, (uint32_t)message_type_conv, (uint32_t)buffer_arr);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_COption_TypeZDecodeErrorZ ret_conv = *(LDKCResult_COption_TypeZDecodeErrorZ*)(ret_ptr);
@@ -9793,7 +9846,8 @@ uintptr_t send_data_LDKSocketDescriptor_jcall(void* this_arg, LDKu8slice data, b
 	LDKu8slice data_var = data;
 	int8_tArray data_arr = init_int8_tArray(data_var.datalen, __LINE__);
 	memcpy(data_arr->elems, data_var.data, data_var.datalen);
-	return js_invoke_function_2(j_calls->instance_ptr, 78, (uint32_t)data_arr, (uint32_t)resume_read);
+	jboolean resume_read_conv = resume_read;
+	return js_invoke_function_2(j_calls->instance_ptr, 78, (uint32_t)data_arr, (uint32_t)resume_read_conv);
 }
 void disconnect_socket_LDKSocketDescriptor_jcall(void* this_arg) {
 	LDKSocketDescriptor_JCalls *j_calls = (LDKSocketDescriptor_JCalls*) this_arg;
@@ -9841,8 +9895,8 @@ uint32_t  __attribute__((export_name("TS_SocketDescriptor_send_data"))) TS_Socke
 	LDKu8slice data_ref;
 	data_ref.datalen = data->arr_len;
 	data_ref.data = data->elems /* XXX data leaks */;
-	uint32_t ret_val = (this_arg_conv->send_data)(this_arg_conv->this_arg, data_ref, resume_read);
-	return ret_val;
+	uint32_t ret_conv = (this_arg_conv->send_data)(this_arg_conv->this_arg, data_ref, resume_read);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_SocketDescriptor_disconnect_socket"))) TS_SocketDescriptor_disconnect_socket(uint32_t this_arg) {
@@ -9856,8 +9910,8 @@ int64_t  __attribute__((export_name("TS_SocketDescriptor_hash"))) TS_SocketDescr
 	void* this_arg_ptr = (void*)(((uintptr_t)this_arg) & ~1);
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKSocketDescriptor* this_arg_conv = (LDKSocketDescriptor*)this_arg_ptr;
-	int64_t ret_val = (this_arg_conv->hash)(this_arg_conv->this_arg);
-	return ret_val;
+	int64_t ret_conv = (this_arg_conv->hash)(this_arg_conv->this_arg);
+	return ret_conv;
 }
 
 uint32_t __attribute__((export_name("TS_LDKEffectiveCapacity_ty_from_ptr"))) TS_LDKEffectiveCapacity_ty_from_ptr(uint32_t ptr) {
@@ -9874,17 +9928,20 @@ uint32_t __attribute__((export_name("TS_LDKEffectiveCapacity_ty_from_ptr"))) TS_
 int64_t __attribute__((export_name("TS_LDKEffectiveCapacity_ExactLiquidity_get_liquidity_msat"))) TS_LDKEffectiveCapacity_ExactLiquidity_get_liquidity_msat(uint32_t ptr) {
 	LDKEffectiveCapacity *obj = (LDKEffectiveCapacity*)(ptr & ~1);
 	assert(obj->tag == LDKEffectiveCapacity_ExactLiquidity);
-	return obj->exact_liquidity.liquidity_msat;
+			int64_t liquidity_msat_conv = obj->exact_liquidity.liquidity_msat;
+	return liquidity_msat_conv;
 }
 int64_t __attribute__((export_name("TS_LDKEffectiveCapacity_MaximumHTLC_get_amount_msat"))) TS_LDKEffectiveCapacity_MaximumHTLC_get_amount_msat(uint32_t ptr) {
 	LDKEffectiveCapacity *obj = (LDKEffectiveCapacity*)(ptr & ~1);
 	assert(obj->tag == LDKEffectiveCapacity_MaximumHTLC);
-	return obj->maximum_htlc.amount_msat;
+			int64_t amount_msat_conv = obj->maximum_htlc.amount_msat;
+	return amount_msat_conv;
 }
 int64_t __attribute__((export_name("TS_LDKEffectiveCapacity_Total_get_capacity_msat"))) TS_LDKEffectiveCapacity_Total_get_capacity_msat(uint32_t ptr) {
 	LDKEffectiveCapacity *obj = (LDKEffectiveCapacity*)(ptr & ~1);
 	assert(obj->tag == LDKEffectiveCapacity_Total);
-	return obj->total.capacity_msat;
+			int64_t capacity_msat_conv = obj->total.capacity_msat;
+	return capacity_msat_conv;
 }
 typedef struct LDKScore_JCalls {
 	atomic_size_t refcnt;
@@ -9898,6 +9955,9 @@ static void LDKScore_JCalls_free(void* this_arg) {
 }
 uint64_t channel_penalty_msat_LDKScore_jcall(const void* this_arg, uint64_t short_channel_id, uint64_t send_amt_msat, uint64_t capacity_msat, const LDKNodeId * source, const LDKNodeId * target) {
 	LDKScore_JCalls *j_calls = (LDKScore_JCalls*) this_arg;
+	int64_t short_channel_id_conv = short_channel_id;
+	int64_t send_amt_msat_conv = send_amt_msat;
+	int64_t capacity_msat_conv = capacity_msat;
 	LDKNodeId source_var = *source;
 	uint32_t source_ref = 0;
 	source_var = NodeId_clone(&source_var);
@@ -9918,7 +9978,7 @@ uint64_t channel_penalty_msat_LDKScore_jcall(const void* this_arg, uint64_t shor
 	if (target_var.is_owned) {
 		target_ref |= 1;
 	}
-	return js_invoke_function_5(j_calls->instance_ptr, 82, (uint32_t)short_channel_id, (uint32_t)send_amt_msat, (uint32_t)capacity_msat, (uint32_t)source_ref, (uint32_t)target_ref);
+	return js_invoke_function_5(j_calls->instance_ptr, 82, (uint32_t)short_channel_id_conv, (uint32_t)send_amt_msat_conv, (uint32_t)capacity_msat_conv, (uint32_t)source_ref, (uint32_t)target_ref);
 }
 void payment_path_failed_LDKScore_jcall(void* this_arg, LDKCVec_RouteHopZ path, uint64_t short_channel_id) {
 	LDKScore_JCalls *j_calls = (LDKScore_JCalls*) this_arg;
@@ -9940,7 +10000,8 @@ void payment_path_failed_LDKScore_jcall(void* this_arg, LDKCVec_RouteHopZ path, 
 	}
 	
 	FREE(path_var.data);
-	js_invoke_function_2(j_calls->instance_ptr, 83, (uint32_t)path_arr, (uint32_t)short_channel_id);
+	int64_t short_channel_id_conv = short_channel_id;
+	js_invoke_function_2(j_calls->instance_ptr, 83, (uint32_t)path_arr, (uint32_t)short_channel_id_conv);
 }
 void payment_path_successful_LDKScore_jcall(void* this_arg, LDKCVec_RouteHopZ path) {
 	LDKScore_JCalls *j_calls = (LDKScore_JCalls*) this_arg;
@@ -10009,8 +10070,8 @@ int64_t  __attribute__((export_name("TS_Score_channel_penalty_msat"))) TS_Score_
 	target_conv.inner = (void*)(target & (~1));
 	target_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(target_conv);
-	int64_t ret_val = (this_arg_conv->channel_penalty_msat)(this_arg_conv->this_arg, short_channel_id, send_amt_msat, capacity_msat, &source_conv, &target_conv);
-	return ret_val;
+	int64_t ret_conv = (this_arg_conv->channel_penalty_msat)(this_arg_conv->this_arg, short_channel_id, send_amt_msat, capacity_msat, &source_conv, &target_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Score_payment_path_failed"))) TS_Score_payment_path_failed(uint32_t this_arg, uint32_tArray path, int64_t short_channel_id) {
@@ -10531,8 +10592,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_Bech32Error_clone_ptr"))) TS_Bech32Error_clone_ptr(uint32_t arg) {
 	LDKBech32Error* arg_conv = (LDKBech32Error*)arg;
-	uint32_t ret_val = Bech32Error_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Bech32Error_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Bech32Error_clone"))) TS_Bech32Error_clone(uint32_t orig) {
@@ -10587,8 +10648,8 @@ static inline uintptr_t TxOut_clone_ptr(LDKTxOut *NONNULL_PTR arg) {
 }
 uint32_t  __attribute__((export_name("TS_TxOut_clone_ptr"))) TS_TxOut_clone_ptr(uint32_t arg) {
 	LDKTxOut* arg_conv = (LDKTxOut*)(arg & ~1);
-	uint32_t ret_val = TxOut_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = TxOut_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_TxOut_clone"))) TS_TxOut_clone(uint32_t orig) {
@@ -10617,8 +10678,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneNoneZ_err"))) TS_CResult_No
 
 jboolean  __attribute__((export_name("TS_CResult_NoneNoneZ_is_ok"))) TS_CResult_NoneNoneZ_is_ok(uint32_t o) {
 	LDKCResult_NoneNoneZ* o_conv = (LDKCResult_NoneNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneNoneZ_free"))) TS_CResult_NoneNoneZ_free(uint32_t _res) {
@@ -10637,8 +10698,8 @@ static inline uintptr_t CResult_NoneNoneZ_clone_ptr(LDKCResult_NoneNoneZ *NONNUL
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneNoneZ_clone_ptr"))) TS_CResult_NoneNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneNoneZ* arg_conv = (LDKCResult_NoneNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneNoneZ_clone"))) TS_CResult_NoneNoneZ_clone(uint32_t orig) {
@@ -10672,8 +10733,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDe
 
 jboolean  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok"))) TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ* o_conv = (LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_free"))) TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_free(uint32_t _res) {
@@ -10692,8 +10753,8 @@ static inline uintptr_t CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_
 }
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr"))) TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone"))) TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone(uint32_t orig) {
@@ -10721,8 +10782,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_err"))) TS_CRes
 
 jboolean  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_is_ok"))) TS_CResult_SecretKeyErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SecretKeyErrorZ* o_conv = (LDKCResult_SecretKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SecretKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SecretKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_free"))) TS_CResult_SecretKeyErrorZ_free(uint32_t _res) {
@@ -10741,8 +10802,8 @@ static inline uintptr_t CResult_SecretKeyErrorZ_clone_ptr(LDKCResult_SecretKeyEr
 }
 uint32_t  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_clone_ptr"))) TS_CResult_SecretKeyErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SecretKeyErrorZ* arg_conv = (LDKCResult_SecretKeyErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SecretKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SecretKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_clone"))) TS_CResult_SecretKeyErrorZ_clone(uint32_t orig) {
@@ -10770,8 +10831,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_err"))) TS_CRes
 
 jboolean  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_is_ok"))) TS_CResult_PublicKeyErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PublicKeyErrorZ* o_conv = (LDKCResult_PublicKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PublicKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PublicKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_free"))) TS_CResult_PublicKeyErrorZ_free(uint32_t _res) {
@@ -10790,8 +10851,8 @@ static inline uintptr_t CResult_PublicKeyErrorZ_clone_ptr(LDKCResult_PublicKeyEr
 }
 uint32_t  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_clone_ptr"))) TS_CResult_PublicKeyErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PublicKeyErrorZ* arg_conv = (LDKCResult_PublicKeyErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PublicKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PublicKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_clone"))) TS_CResult_PublicKeyErrorZ_clone(uint32_t orig) {
@@ -10825,8 +10886,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_is_ok"))) TS_CResult_TxCreationKeysDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_TxCreationKeysDecodeErrorZ* o_conv = (LDKCResult_TxCreationKeysDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxCreationKeysDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxCreationKeysDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_free"))) TS_CResult_TxCreationKeysDecodeErrorZ_free(uint32_t _res) {
@@ -10845,8 +10906,8 @@ static inline uintptr_t CResult_TxCreationKeysDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_clone_ptr"))) TS_CResult_TxCreationKeysDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_TxCreationKeysDecodeErrorZ* arg_conv = (LDKCResult_TxCreationKeysDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_TxCreationKeysDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_TxCreationKeysDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_clone"))) TS_CResult_TxCreationKeysDecodeErrorZ_clone(uint32_t orig) {
@@ -10880,8 +10941,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_is_ok"))) TS_CResult_ChannelPublicKeysDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelPublicKeysDecodeErrorZ* o_conv = (LDKCResult_ChannelPublicKeysDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelPublicKeysDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelPublicKeysDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_free"))) TS_CResult_ChannelPublicKeysDecodeErrorZ_free(uint32_t _res) {
@@ -10900,8 +10961,8 @@ static inline uintptr_t CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelPublicKeysDecodeErrorZ* arg_conv = (LDKCResult_ChannelPublicKeysDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_clone"))) TS_CResult_ChannelPublicKeysDecodeErrorZ_clone(uint32_t orig) {
@@ -10931,8 +10992,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_is_ok"))) TS_CResult_TxCreationKeysErrorZ_is_ok(uint32_t o) {
 	LDKCResult_TxCreationKeysErrorZ* o_conv = (LDKCResult_TxCreationKeysErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxCreationKeysErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxCreationKeysErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_free"))) TS_CResult_TxCreationKeysErrorZ_free(uint32_t _res) {
@@ -10951,8 +11012,8 @@ static inline uintptr_t CResult_TxCreationKeysErrorZ_clone_ptr(LDKCResult_TxCrea
 }
 uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_clone_ptr"))) TS_CResult_TxCreationKeysErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_TxCreationKeysErrorZ* arg_conv = (LDKCResult_TxCreationKeysErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_TxCreationKeysErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_TxCreationKeysErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_clone"))) TS_CResult_TxCreationKeysErrorZ_clone(uint32_t orig) {
@@ -10993,8 +11054,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_u32Z_clone_ptr"))) TS_COption_u32Z_clone_ptr(uint32_t arg) {
 	LDKCOption_u32Z* arg_conv = (LDKCOption_u32Z*)arg;
-	uint32_t ret_val = COption_u32Z_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_u32Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_u32Z_clone"))) TS_COption_u32Z_clone(uint32_t orig) {
@@ -11029,8 +11090,8 @@ uint32_t  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErr
 
 jboolean  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok"))) TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_HTLCOutputInCommitmentDecodeErrorZ* o_conv = (LDKCResult_HTLCOutputInCommitmentDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_free"))) TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_free(uint32_t _res) {
@@ -11049,8 +11110,8 @@ static inline uintptr_t CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(LDK
 }
 uint32_t  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr"))) TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_HTLCOutputInCommitmentDecodeErrorZ* arg_conv = (LDKCResult_HTLCOutputInCommitmentDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_clone"))) TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_clone(uint32_t orig) {
@@ -11099,8 +11160,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionP
 
 jboolean  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok"))) TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ* o_conv = (LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_free"))) TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_free(uint32_t _res) {
@@ -11119,8 +11180,8 @@ static inline uintptr_t CResult_CounterpartyChannelTransactionParametersDecodeEr
 }
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr"))) TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone"))) TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -11154,8 +11215,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDec
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDecodeErrorZ_is_ok"))) TS_CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelTransactionParametersDecodeErrorZ* o_conv = (LDKCResult_ChannelTransactionParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDecodeErrorZ_free"))) TS_CResult_ChannelTransactionParametersDecodeErrorZ_free(uint32_t _res) {
@@ -11174,8 +11235,8 @@ static inline uintptr_t CResult_ChannelTransactionParametersDecodeErrorZ_clone_p
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelTransactionParametersDecodeErrorZ* arg_conv = (LDKCResult_ChannelTransactionParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDecodeErrorZ_clone"))) TS_CResult_ChannelTransactionParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -11227,8 +11288,8 @@ uint32_t  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDeco
 
 jboolean  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok"))) TS_CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_HolderCommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_HolderCommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDecodeErrorZ_free"))) TS_CResult_HolderCommitmentTransactionDecodeErrorZ_free(uint32_t _res) {
@@ -11247,8 +11308,8 @@ static inline uintptr_t CResult_HolderCommitmentTransactionDecodeErrorZ_clone_pt
 }
 uint32_t  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr"))) TS_CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_HolderCommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_HolderCommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDecodeErrorZ_clone"))) TS_CResult_HolderCommitmentTransactionDecodeErrorZ_clone(uint32_t orig) {
@@ -11282,8 +11343,8 @@ uint32_t  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecod
 
 jboolean  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok"))) TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_BuiltCommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_BuiltCommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_free"))) TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_free(uint32_t _res) {
@@ -11302,8 +11363,8 @@ static inline uintptr_t CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr
 }
 uint32_t  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr"))) TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_BuiltCommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_BuiltCommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_clone"))) TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_clone(uint32_t orig) {
@@ -11332,8 +11393,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TrustedClosingTransactionNoneZ_
 
 jboolean  __attribute__((export_name("TS_CResult_TrustedClosingTransactionNoneZ_is_ok"))) TS_CResult_TrustedClosingTransactionNoneZ_is_ok(uint32_t o) {
 	LDKCResult_TrustedClosingTransactionNoneZ* o_conv = (LDKCResult_TrustedClosingTransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TrustedClosingTransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TrustedClosingTransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TrustedClosingTransactionNoneZ_free"))) TS_CResult_TrustedClosingTransactionNoneZ_free(uint32_t _res) {
@@ -11369,8 +11430,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErrorZ_is_ok"))) TS_CResult_CommitmentTransactionDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_CommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErrorZ_free"))) TS_CResult_CommitmentTransactionDecodeErrorZ_free(uint32_t _res) {
@@ -11389,8 +11450,8 @@ static inline uintptr_t CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErrorZ_clone_ptr"))) TS_CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_CommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErrorZ_clone"))) TS_CResult_CommitmentTransactionDecodeErrorZ_clone(uint32_t orig) {
@@ -11419,8 +11480,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TrustedCommitmentTransactionNon
 
 jboolean  __attribute__((export_name("TS_CResult_TrustedCommitmentTransactionNoneZ_is_ok"))) TS_CResult_TrustedCommitmentTransactionNoneZ_is_ok(uint32_t o) {
 	LDKCResult_TrustedCommitmentTransactionNoneZ* o_conv = (LDKCResult_TrustedCommitmentTransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TrustedCommitmentTransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TrustedCommitmentTransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TrustedCommitmentTransactionNoneZ_free"))) TS_CResult_TrustedCommitmentTransactionNoneZ_free(uint32_t _res) {
@@ -11460,8 +11521,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_is_ok"))) TS_CResult_CVec_SignatureZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_CVec_SignatureZNoneZ* o_conv = (LDKCResult_CVec_SignatureZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_SignatureZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_SignatureZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_free"))) TS_CResult_CVec_SignatureZNoneZ_free(uint32_t _res) {
@@ -11480,8 +11541,8 @@ static inline uintptr_t CResult_CVec_SignatureZNoneZ_clone_ptr(LDKCResult_CVec_S
 }
 uint32_t  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_clone_ptr"))) TS_CResult_CVec_SignatureZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CVec_SignatureZNoneZ* arg_conv = (LDKCResult_CVec_SignatureZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CVec_SignatureZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CVec_SignatureZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_clone"))) TS_CResult_CVec_SignatureZNoneZ_clone(uint32_t orig) {
@@ -11515,8 +11576,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_is_ok"))) TS_CResult_ShutdownScriptDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ShutdownScriptDecodeErrorZ* o_conv = (LDKCResult_ShutdownScriptDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownScriptDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownScriptDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_free"))) TS_CResult_ShutdownScriptDecodeErrorZ_free(uint32_t _res) {
@@ -11535,8 +11596,8 @@ static inline uintptr_t CResult_ShutdownScriptDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_clone_ptr"))) TS_CResult_ShutdownScriptDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ShutdownScriptDecodeErrorZ* arg_conv = (LDKCResult_ShutdownScriptDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ShutdownScriptDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ShutdownScriptDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_clone"))) TS_CResult_ShutdownScriptDecodeErrorZ_clone(uint32_t orig) {
@@ -11570,8 +11631,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownSc
 
 jboolean  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok"))) TS_CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(uint32_t o) {
 	LDKCResult_ShutdownScriptInvalidShutdownScriptZ* o_conv = (LDKCResult_ShutdownScriptInvalidShutdownScriptZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownScriptZ_free"))) TS_CResult_ShutdownScriptInvalidShutdownScriptZ_free(uint32_t _res) {
@@ -11590,8 +11651,8 @@ static inline uintptr_t CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(L
 }
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr"))) TS_CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ShutdownScriptInvalidShutdownScriptZ* arg_conv = (LDKCResult_ShutdownScriptInvalidShutdownScriptZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownScriptZ_clone"))) TS_CResult_ShutdownScriptInvalidShutdownScriptZ_clone(uint32_t orig) {
@@ -11625,8 +11686,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_is_ok"))) TS_CResult_RouteHopDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteHopDecodeErrorZ* o_conv = (LDKCResult_RouteHopDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHopDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHopDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_free"))) TS_CResult_RouteHopDecodeErrorZ_free(uint32_t _res) {
@@ -11645,8 +11706,8 @@ static inline uintptr_t CResult_RouteHopDecodeErrorZ_clone_ptr(LDKCResult_RouteH
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_clone_ptr"))) TS_CResult_RouteHopDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteHopDecodeErrorZ* arg_conv = (LDKCResult_RouteHopDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteHopDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteHopDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_clone"))) TS_CResult_RouteHopDecodeErrorZ_clone(uint32_t orig) {
@@ -11729,8 +11790,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_err"))) TS_CR
 
 jboolean  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_is_ok"))) TS_CResult_RouteDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteDecodeErrorZ* o_conv = (LDKCResult_RouteDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_free"))) TS_CResult_RouteDecodeErrorZ_free(uint32_t _res) {
@@ -11749,8 +11810,8 @@ static inline uintptr_t CResult_RouteDecodeErrorZ_clone_ptr(LDKCResult_RouteDeco
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_clone_ptr"))) TS_CResult_RouteDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteDecodeErrorZ* arg_conv = (LDKCResult_RouteDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_clone"))) TS_CResult_RouteDecodeErrorZ_clone(uint32_t orig) {
@@ -11784,8 +11845,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_is_ok"))) TS_CResult_RouteParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteParametersDecodeErrorZ* o_conv = (LDKCResult_RouteParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_free"))) TS_CResult_RouteParametersDecodeErrorZ_free(uint32_t _res) {
@@ -11804,8 +11865,8 @@ static inline uintptr_t CResult_RouteParametersDecodeErrorZ_clone_ptr(LDKCResult
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_clone_ptr"))) TS_CResult_RouteParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteParametersDecodeErrorZ* arg_conv = (LDKCResult_RouteParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_clone"))) TS_CResult_RouteParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -11865,8 +11926,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_u64Z_clone_ptr"))) TS_COption_u64Z_clone_ptr(uint32_t arg) {
 	LDKCOption_u64Z* arg_conv = (LDKCOption_u64Z*)arg;
-	uint32_t ret_val = COption_u64Z_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_u64Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_u64Z_clone"))) TS_COption_u64Z_clone(uint32_t orig) {
@@ -11901,8 +11962,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_is_ok"))) TS_CResult_PaymentParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentParametersDecodeErrorZ* o_conv = (LDKCResult_PaymentParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_free"))) TS_CResult_PaymentParametersDecodeErrorZ_free(uint32_t _res) {
@@ -11921,8 +11982,8 @@ static inline uintptr_t CResult_PaymentParametersDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_clone_ptr"))) TS_CResult_PaymentParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentParametersDecodeErrorZ* arg_conv = (LDKCResult_PaymentParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_clone"))) TS_CResult_PaymentParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -11975,8 +12036,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_err"))) T
 
 jboolean  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_is_ok"))) TS_CResult_RouteHintDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteHintDecodeErrorZ* o_conv = (LDKCResult_RouteHintDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHintDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHintDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_free"))) TS_CResult_RouteHintDecodeErrorZ_free(uint32_t _res) {
@@ -11995,8 +12056,8 @@ static inline uintptr_t CResult_RouteHintDecodeErrorZ_clone_ptr(LDKCResult_Route
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_clone_ptr"))) TS_CResult_RouteHintDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteHintDecodeErrorZ* arg_conv = (LDKCResult_RouteHintDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteHintDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteHintDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_clone"))) TS_CResult_RouteHintDecodeErrorZ_clone(uint32_t orig) {
@@ -12030,8 +12091,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_is_ok"))) TS_CResult_RouteHintHopDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteHintHopDecodeErrorZ* o_conv = (LDKCResult_RouteHintHopDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHintHopDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHintHopDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_free"))) TS_CResult_RouteHintHopDecodeErrorZ_free(uint32_t _res) {
@@ -12050,8 +12111,8 @@ static inline uintptr_t CResult_RouteHintHopDecodeErrorZ_clone_ptr(LDKCResult_Ro
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_clone_ptr"))) TS_CResult_RouteHintHopDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteHintHopDecodeErrorZ* arg_conv = (LDKCResult_RouteHintHopDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteHintHopDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteHintHopDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_clone"))) TS_CResult_RouteHintHopDecodeErrorZ_clone(uint32_t orig) {
@@ -12104,8 +12165,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_is_ok"))) TS_CResult_RouteLightningErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteLightningErrorZ* o_conv = (LDKCResult_RouteLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_free"))) TS_CResult_RouteLightningErrorZ_free(uint32_t _res) {
@@ -12124,8 +12185,8 @@ static inline uintptr_t CResult_RouteLightningErrorZ_clone_ptr(LDKCResult_RouteL
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_clone_ptr"))) TS_CResult_RouteLightningErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteLightningErrorZ* arg_conv = (LDKCResult_RouteLightningErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_clone"))) TS_CResult_RouteLightningErrorZ_clone(uint32_t orig) {
@@ -12154,8 +12215,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_err"))) TS_CR
 
 jboolean  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_is_ok"))) TS_CResult_TxOutAccessErrorZ_is_ok(uint32_t o) {
 	LDKCResult_TxOutAccessErrorZ* o_conv = (LDKCResult_TxOutAccessErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxOutAccessErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxOutAccessErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_free"))) TS_CResult_TxOutAccessErrorZ_free(uint32_t _res) {
@@ -12174,8 +12235,8 @@ static inline uintptr_t CResult_TxOutAccessErrorZ_clone_ptr(LDKCResult_TxOutAcce
 }
 uint32_t  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_clone_ptr"))) TS_CResult_TxOutAccessErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_TxOutAccessErrorZ* arg_conv = (LDKCResult_TxOutAccessErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_TxOutAccessErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_TxOutAccessErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_clone"))) TS_CResult_TxOutAccessErrorZ_clone(uint32_t orig) {
@@ -12192,8 +12253,8 @@ static inline uintptr_t C2Tuple_usizeTransactionZ_clone_ptr(LDKC2Tuple_usizeTran
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_usizeTransactionZ_clone_ptr"))) TS_C2Tuple_usizeTransactionZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_usizeTransactionZ* arg_conv = (LDKC2Tuple_usizeTransactionZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_usizeTransactionZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_usizeTransactionZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_usizeTransactionZ_clone"))) TS_C2Tuple_usizeTransactionZ_clone(uint32_t orig) {
@@ -12275,8 +12336,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_is_ok"))) TS_CResult_NoneChannelMonitorUpdateErrZ_is_ok(uint32_t o) {
 	LDKCResult_NoneChannelMonitorUpdateErrZ* o_conv = (LDKCResult_NoneChannelMonitorUpdateErrZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneChannelMonitorUpdateErrZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneChannelMonitorUpdateErrZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_free"))) TS_CResult_NoneChannelMonitorUpdateErrZ_free(uint32_t _res) {
@@ -12295,8 +12356,8 @@ static inline uintptr_t CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_clone_ptr"))) TS_CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneChannelMonitorUpdateErrZ* arg_conv = (LDKCResult_NoneChannelMonitorUpdateErrZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_clone"))) TS_CResult_NoneChannelMonitorUpdateErrZ_clone(uint32_t orig) {
@@ -12360,8 +12421,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_C2Tuple_usizeTransactionZZ_clone_ptr"))) TS_COption_C2Tuple_usizeTransactionZZ_clone_ptr(uint32_t arg) {
 	LDKCOption_C2Tuple_usizeTransactionZZ* arg_conv = (LDKCOption_C2Tuple_usizeTransactionZZ*)arg;
-	uint32_t ret_val = COption_C2Tuple_usizeTransactionZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_C2Tuple_usizeTransactionZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_C2Tuple_usizeTransactionZZ_clone"))) TS_COption_C2Tuple_usizeTransactionZZ_clone(uint32_t orig) {
@@ -12407,8 +12468,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_ClosureReasonZ_clone_ptr"))) TS_COption_ClosureReasonZ_clone_ptr(uint32_t arg) {
 	LDKCOption_ClosureReasonZ* arg_conv = (LDKCOption_ClosureReasonZ*)arg;
-	uint32_t ret_val = COption_ClosureReasonZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_ClosureReasonZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_ClosureReasonZ_clone"))) TS_COption_ClosureReasonZ_clone(uint32_t orig) {
@@ -12442,8 +12503,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErr
 
 jboolean  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErrorZ_is_ok"))) TS_CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_ClosureReasonZDecodeErrorZ* o_conv = (LDKCResult_COption_ClosureReasonZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErrorZ_free"))) TS_CResult_COption_ClosureReasonZDecodeErrorZ_free(uint32_t _res) {
@@ -12462,8 +12523,8 @@ static inline uintptr_t CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(LDK
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_ClosureReasonZDecodeErrorZ* arg_conv = (LDKCResult_COption_ClosureReasonZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErrorZ_clone"))) TS_CResult_COption_ClosureReasonZDecodeErrorZ_clone(uint32_t orig) {
@@ -12508,8 +12569,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_NetworkUpdateZ_clone_ptr"))) TS_COption_NetworkUpdateZ_clone_ptr(uint32_t arg) {
 	LDKCOption_NetworkUpdateZ* arg_conv = (LDKCOption_NetworkUpdateZ*)arg;
-	uint32_t ret_val = COption_NetworkUpdateZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_NetworkUpdateZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_NetworkUpdateZ_clone"))) TS_COption_NetworkUpdateZ_clone(uint32_t orig) {
@@ -12574,8 +12635,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_EventZ_clone_ptr"))) TS_COption_EventZ_clone_ptr(uint32_t arg) {
 	LDKCOption_EventZ* arg_conv = (LDKCOption_EventZ*)arg;
-	uint32_t ret_val = COption_EventZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_EventZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_EventZ_clone"))) TS_COption_EventZ_clone(uint32_t orig) {
@@ -12609,8 +12670,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_is_ok"))) TS_CResult_COption_EventZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_EventZDecodeErrorZ* o_conv = (LDKCResult_COption_EventZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_EventZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_EventZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_free"))) TS_CResult_COption_EventZDecodeErrorZ_free(uint32_t _res) {
@@ -12629,8 +12690,8 @@ static inline uintptr_t CResult_COption_EventZDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_EventZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_EventZDecodeErrorZ* arg_conv = (LDKCResult_COption_EventZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_EventZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_EventZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_clone"))) TS_CResult_COption_EventZDecodeErrorZ_clone(uint32_t orig) {
@@ -12683,8 +12744,8 @@ uint32_t  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_
 
 jboolean  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_is_ok"))) TS_CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_FixedPenaltyScorerDecodeErrorZ* o_conv = (LDKCResult_FixedPenaltyScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_free"))) TS_CResult_FixedPenaltyScorerDecodeErrorZ_free(uint32_t _res) {
@@ -12703,8 +12764,8 @@ static inline uintptr_t CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(LDKCRes
 }
 uint32_t  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr"))) TS_CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_FixedPenaltyScorerDecodeErrorZ* arg_conv = (LDKCResult_FixedPenaltyScorerDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_clone"))) TS_CResult_FixedPenaltyScorerDecodeErrorZ_clone(uint32_t orig) {
@@ -12738,8 +12799,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_is_ok"))) TS_CResult_ScoringParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ScoringParametersDecodeErrorZ* o_conv = (LDKCResult_ScoringParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ScoringParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ScoringParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_free"))) TS_CResult_ScoringParametersDecodeErrorZ_free(uint32_t _res) {
@@ -12758,8 +12819,8 @@ static inline uintptr_t CResult_ScoringParametersDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_clone_ptr"))) TS_CResult_ScoringParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ScoringParametersDecodeErrorZ* arg_conv = (LDKCResult_ScoringParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ScoringParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ScoringParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_clone"))) TS_CResult_ScoringParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -12793,8 +12854,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ScorerDecodeErrorZ_err"))) TS_C
 
 jboolean  __attribute__((export_name("TS_CResult_ScorerDecodeErrorZ_is_ok"))) TS_CResult_ScorerDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ScorerDecodeErrorZ* o_conv = (LDKCResult_ScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ScorerDecodeErrorZ_free"))) TS_CResult_ScorerDecodeErrorZ_free(uint32_t _res) {
@@ -12830,8 +12891,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ProbabilisticScorerDecodeErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_ProbabilisticScorerDecodeErrorZ_is_ok"))) TS_CResult_ProbabilisticScorerDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ProbabilisticScorerDecodeErrorZ* o_conv = (LDKCResult_ProbabilisticScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ProbabilisticScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ProbabilisticScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ProbabilisticScorerDecodeErrorZ_free"))) TS_CResult_ProbabilisticScorerDecodeErrorZ_free(uint32_t _res) {
@@ -12867,8 +12928,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InitFeaturesDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_InitFeaturesDecodeErrorZ_is_ok"))) TS_CResult_InitFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InitFeaturesDecodeErrorZ* o_conv = (LDKCResult_InitFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InitFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InitFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InitFeaturesDecodeErrorZ_free"))) TS_CResult_InitFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -12904,8 +12965,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelFeaturesDecodeErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelFeaturesDecodeErrorZ_is_ok"))) TS_CResult_ChannelFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelFeaturesDecodeErrorZ* o_conv = (LDKCResult_ChannelFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelFeaturesDecodeErrorZ_free"))) TS_CResult_ChannelFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -12941,8 +13002,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeFeaturesDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_NodeFeaturesDecodeErrorZ_is_ok"))) TS_CResult_NodeFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeFeaturesDecodeErrorZ* o_conv = (LDKCResult_NodeFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeFeaturesDecodeErrorZ_free"))) TS_CResult_NodeFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -12978,8 +13039,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InvoiceFeaturesDecodeErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_InvoiceFeaturesDecodeErrorZ_is_ok"))) TS_CResult_InvoiceFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InvoiceFeaturesDecodeErrorZ* o_conv = (LDKCResult_InvoiceFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InvoiceFeaturesDecodeErrorZ_free"))) TS_CResult_InvoiceFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -13015,8 +13076,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelTypeFeaturesDecodeErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok"))) TS_CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelTypeFeaturesDecodeErrorZ* o_conv = (LDKCResult_ChannelTypeFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelTypeFeaturesDecodeErrorZ_free"))) TS_CResult_ChannelTypeFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -13052,8 +13113,8 @@ uint32_t  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorD
 
 jboolean  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok"))) TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_free"))) TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_free(uint32_t _res) {
@@ -13072,8 +13133,8 @@ static inline uintptr_t CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone
 }
 uint32_t  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr"))) TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone"))) TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone(uint32_t orig) {
@@ -13107,8 +13168,8 @@ uint32_t  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDe
 
 jboolean  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok"))) TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_free"))) TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_free(uint32_t _res) {
@@ -13127,8 +13188,8 @@ static inline uintptr_t CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_
 }
 uint32_t  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr"))) TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone"))) TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone(uint32_t orig) {
@@ -13161,8 +13222,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecode
 
 jboolean  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok"))) TS_CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SpendableOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_SpendableOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecodeErrorZ_free"))) TS_CResult_SpendableOutputDescriptorDecodeErrorZ_free(uint32_t _res) {
@@ -13181,8 +13242,8 @@ static inline uintptr_t CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(
 }
 uint32_t  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr"))) TS_CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SpendableOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_SpendableOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecodeErrorZ_clone"))) TS_CResult_SpendableOutputDescriptorDecodeErrorZ_clone(uint32_t orig) {
@@ -13217,8 +13278,8 @@ static inline uintptr_t C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(LDKC2Tuple_S
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_SignatureCVec_SignatureZZ_clone_ptr"))) TS_C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_SignatureCVec_SignatureZZ* arg_conv = (LDKC2Tuple_SignatureCVec_SignatureZZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_SignatureCVec_SignatureZZ_clone"))) TS_C2Tuple_SignatureCVec_SignatureZZ_clone(uint32_t orig) {
@@ -13278,8 +13339,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_Signature
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok"))) TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ* o_conv = (LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_free"))) TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_free(uint32_t _res) {
@@ -13298,8 +13359,8 @@ static inline uintptr_t CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr"))) TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ* arg_conv = (LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone"))) TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone(uint32_t orig) {
@@ -13326,8 +13387,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SignatureNoneZ_err"))) TS_CResu
 
 jboolean  __attribute__((export_name("TS_CResult_SignatureNoneZ_is_ok"))) TS_CResult_SignatureNoneZ_is_ok(uint32_t o) {
 	LDKCResult_SignatureNoneZ* o_conv = (LDKCResult_SignatureNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_SignatureNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignatureNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SignatureNoneZ_free"))) TS_CResult_SignatureNoneZ_free(uint32_t _res) {
@@ -13346,8 +13407,8 @@ static inline uintptr_t CResult_SignatureNoneZ_clone_ptr(LDKCResult_SignatureNon
 }
 uint32_t  __attribute__((export_name("TS_CResult_SignatureNoneZ_clone_ptr"))) TS_CResult_SignatureNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SignatureNoneZ* arg_conv = (LDKCResult_SignatureNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SignatureNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SignatureNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SignatureNoneZ_clone"))) TS_CResult_SignatureNoneZ_clone(uint32_t orig) {
@@ -13364,8 +13425,8 @@ static inline uintptr_t C2Tuple_SignatureSignatureZ_clone_ptr(LDKC2Tuple_Signatu
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_SignatureSignatureZ_clone_ptr"))) TS_C2Tuple_SignatureSignatureZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_SignatureSignatureZ* arg_conv = (LDKC2Tuple_SignatureSignatureZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_SignatureSignatureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_SignatureSignatureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_SignatureSignatureZ_clone"))) TS_C2Tuple_SignatureSignatureZ_clone(uint32_t orig) {
@@ -13414,8 +13475,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNone
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok"))) TS_CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_SignatureSignatureZNoneZ* o_conv = (LDKCResult_C2Tuple_SignatureSignatureZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNoneZ_free"))) TS_CResult_C2Tuple_SignatureSignatureZNoneZ_free(uint32_t _res) {
@@ -13434,8 +13495,8 @@ static inline uintptr_t CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(LDKCR
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr"))) TS_CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_SignatureSignatureZNoneZ* arg_conv = (LDKCResult_C2Tuple_SignatureSignatureZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNoneZ_clone"))) TS_CResult_C2Tuple_SignatureSignatureZNoneZ_clone(uint32_t orig) {
@@ -13462,8 +13523,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_err"))) TS_CResu
 
 jboolean  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_is_ok"))) TS_CResult_SecretKeyNoneZ_is_ok(uint32_t o) {
 	LDKCResult_SecretKeyNoneZ* o_conv = (LDKCResult_SecretKeyNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_SecretKeyNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SecretKeyNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_free"))) TS_CResult_SecretKeyNoneZ_free(uint32_t _res) {
@@ -13482,8 +13543,8 @@ static inline uintptr_t CResult_SecretKeyNoneZ_clone_ptr(LDKCResult_SecretKeyNon
 }
 uint32_t  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_clone_ptr"))) TS_CResult_SecretKeyNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SecretKeyNoneZ* arg_conv = (LDKCResult_SecretKeyNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SecretKeyNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SecretKeyNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_clone"))) TS_CResult_SecretKeyNoneZ_clone(uint32_t orig) {
@@ -13519,8 +13580,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_is_ok"))) TS_CResult_SignDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SignDecodeErrorZ* o_conv = (LDKCResult_SignDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SignDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_free"))) TS_CResult_SignDecodeErrorZ_free(uint32_t _res) {
@@ -13539,8 +13600,8 @@ static inline uintptr_t CResult_SignDecodeErrorZ_clone_ptr(LDKCResult_SignDecode
 }
 uint32_t  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_clone_ptr"))) TS_CResult_SignDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SignDecodeErrorZ* arg_conv = (LDKCResult_SignDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SignDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SignDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_clone"))) TS_CResult_SignDecodeErrorZ_clone(uint32_t orig) {
@@ -13583,8 +13644,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_is_ok"))) TS_CResult_RecoverableSignatureNoneZ_is_ok(uint32_t o) {
 	LDKCResult_RecoverableSignatureNoneZ* o_conv = (LDKCResult_RecoverableSignatureNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_RecoverableSignatureNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RecoverableSignatureNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_free"))) TS_CResult_RecoverableSignatureNoneZ_free(uint32_t _res) {
@@ -13603,8 +13664,8 @@ static inline uintptr_t CResult_RecoverableSignatureNoneZ_clone_ptr(LDKCResult_R
 }
 uint32_t  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_clone_ptr"))) TS_CResult_RecoverableSignatureNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RecoverableSignatureNoneZ* arg_conv = (LDKCResult_RecoverableSignatureNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RecoverableSignatureNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RecoverableSignatureNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_clone"))) TS_CResult_RecoverableSignatureNoneZ_clone(uint32_t orig) {
@@ -13670,8 +13731,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_err"))) TS_
 
 jboolean  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_is_ok"))) TS_CResult_CVec_CVec_u8ZZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_CVec_CVec_u8ZZNoneZ* o_conv = (LDKCResult_CVec_CVec_u8ZZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_CVec_u8ZZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_CVec_u8ZZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_free"))) TS_CResult_CVec_CVec_u8ZZNoneZ_free(uint32_t _res) {
@@ -13690,8 +13751,8 @@ static inline uintptr_t CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(LDKCResult_CVec_CV
 }
 uint32_t  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_clone_ptr"))) TS_CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CVec_CVec_u8ZZNoneZ* arg_conv = (LDKCResult_CVec_CVec_u8ZZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_clone"))) TS_CResult_CVec_CVec_u8ZZNoneZ_clone(uint32_t orig) {
@@ -13725,8 +13786,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_is_ok"))) TS_CResult_InMemorySignerDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InMemorySignerDecodeErrorZ* o_conv = (LDKCResult_InMemorySignerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InMemorySignerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InMemorySignerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_free"))) TS_CResult_InMemorySignerDecodeErrorZ_free(uint32_t _res) {
@@ -13745,8 +13806,8 @@ static inline uintptr_t CResult_InMemorySignerDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_clone_ptr"))) TS_CResult_InMemorySignerDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InMemorySignerDecodeErrorZ* arg_conv = (LDKCResult_InMemorySignerDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InMemorySignerDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InMemorySignerDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_clone"))) TS_CResult_InMemorySignerDecodeErrorZ_clone(uint32_t orig) {
@@ -13794,8 +13855,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TransactionNoneZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_TransactionNoneZ_is_ok"))) TS_CResult_TransactionNoneZ_is_ok(uint32_t o) {
 	LDKCResult_TransactionNoneZ* o_conv = (LDKCResult_TransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TransactionNoneZ_free"))) TS_CResult_TransactionNoneZ_free(uint32_t _res) {
@@ -13814,8 +13875,8 @@ static inline uintptr_t CResult_TransactionNoneZ_clone_ptr(LDKCResult_Transactio
 }
 uint32_t  __attribute__((export_name("TS_CResult_TransactionNoneZ_clone_ptr"))) TS_CResult_TransactionNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_TransactionNoneZ* arg_conv = (LDKCResult_TransactionNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_TransactionNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_TransactionNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_TransactionNoneZ_clone"))) TS_CResult_TransactionNoneZ_clone(uint32_t orig) {
@@ -13856,8 +13917,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_u16Z_clone_ptr"))) TS_COption_u16Z_clone_ptr(uint32_t arg) {
 	LDKCOption_u16Z* arg_conv = (LDKCOption_u16Z*)arg;
-	uint32_t ret_val = COption_u16Z_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_u16Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_u16Z_clone"))) TS_COption_u16Z_clone(uint32_t orig) {
@@ -13886,8 +13947,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_err"))) TS_CResul
 
 jboolean  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_is_ok"))) TS_CResult_NoneAPIErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NoneAPIErrorZ* o_conv = (LDKCResult_NoneAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_free"))) TS_CResult_NoneAPIErrorZ_free(uint32_t _res) {
@@ -13906,8 +13967,8 @@ static inline uintptr_t CResult_NoneAPIErrorZ_clone_ptr(LDKCResult_NoneAPIErrorZ
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_clone_ptr"))) TS_CResult_NoneAPIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneAPIErrorZ* arg_conv = (LDKCResult_NoneAPIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_clone"))) TS_CResult_NoneAPIErrorZ_clone(uint32_t orig) {
@@ -13976,8 +14037,8 @@ uint32_t  __attribute__((export_name("TS_CResult__u832APIErrorZ_err"))) TS_CResu
 
 jboolean  __attribute__((export_name("TS_CResult__u832APIErrorZ_is_ok"))) TS_CResult__u832APIErrorZ_is_ok(uint32_t o) {
 	LDKCResult__u832APIErrorZ* o_conv = (LDKCResult__u832APIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult__u832APIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult__u832APIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult__u832APIErrorZ_free"))) TS_CResult__u832APIErrorZ_free(uint32_t _res) {
@@ -13996,8 +14057,8 @@ static inline uintptr_t CResult__u832APIErrorZ_clone_ptr(LDKCResult__u832APIErro
 }
 uint32_t  __attribute__((export_name("TS_CResult__u832APIErrorZ_clone_ptr"))) TS_CResult__u832APIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult__u832APIErrorZ* arg_conv = (LDKCResult__u832APIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult__u832APIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult__u832APIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult__u832APIErrorZ_clone"))) TS_CResult__u832APIErrorZ_clone(uint32_t orig) {
@@ -14028,8 +14089,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_is_ok"))) TS_CResult_PaymentIdPaymentSendFailureZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentIdPaymentSendFailureZ* o_conv = (LDKCResult_PaymentIdPaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentIdPaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentIdPaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_free"))) TS_CResult_PaymentIdPaymentSendFailureZ_free(uint32_t _res) {
@@ -14048,8 +14109,8 @@ static inline uintptr_t CResult_PaymentIdPaymentSendFailureZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_clone_ptr"))) TS_CResult_PaymentIdPaymentSendFailureZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentIdPaymentSendFailureZ* arg_conv = (LDKCResult_PaymentIdPaymentSendFailureZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentIdPaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentIdPaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_clone"))) TS_CResult_PaymentIdPaymentSendFailureZ_clone(uint32_t orig) {
@@ -14077,8 +14138,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_err")))
 
 jboolean  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_is_ok"))) TS_CResult_NonePaymentSendFailureZ_is_ok(uint32_t o) {
 	LDKCResult_NonePaymentSendFailureZ* o_conv = (LDKCResult_NonePaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_NonePaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NonePaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_free"))) TS_CResult_NonePaymentSendFailureZ_free(uint32_t _res) {
@@ -14097,8 +14158,8 @@ static inline uintptr_t CResult_NonePaymentSendFailureZ_clone_ptr(LDKCResult_Non
 }
 uint32_t  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_clone_ptr"))) TS_CResult_NonePaymentSendFailureZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NonePaymentSendFailureZ* arg_conv = (LDKCResult_NonePaymentSendFailureZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NonePaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NonePaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_clone"))) TS_CResult_NonePaymentSendFailureZ_clone(uint32_t orig) {
@@ -14115,8 +14176,8 @@ static inline uintptr_t C2Tuple_PaymentHashPaymentIdZ_clone_ptr(LDKC2Tuple_Payme
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_PaymentHashPaymentIdZ_clone_ptr"))) TS_C2Tuple_PaymentHashPaymentIdZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_PaymentHashPaymentIdZ* arg_conv = (LDKC2Tuple_PaymentHashPaymentIdZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_PaymentHashPaymentIdZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_PaymentHashPaymentIdZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_PaymentHashPaymentIdZ_clone"))) TS_C2Tuple_PaymentHashPaymentIdZ_clone(uint32_t orig) {
@@ -14169,8 +14230,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPa
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok"))) TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_free"))) TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_free(uint32_t _res) {
@@ -14189,8 +14250,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr"))) TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone"))) TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone(uint32_t orig) {
@@ -14226,8 +14287,8 @@ static inline uintptr_t C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(LDKC2Tuple_P
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_PaymentHashPaymentSecretZ_clone_ptr"))) TS_C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_PaymentHashPaymentSecretZ* arg_conv = (LDKC2Tuple_PaymentHashPaymentSecretZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_PaymentHashPaymentSecretZ_clone"))) TS_C2Tuple_PaymentHashPaymentSecretZ_clone(uint32_t orig) {
@@ -14276,8 +14337,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecre
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_free"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_free(uint32_t _res) {
@@ -14296,8 +14357,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone(uint32_t orig) {
@@ -14329,8 +14390,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecre
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_free"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_free(uint32_t _res) {
@@ -14349,8 +14410,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone(uint32_t orig) {
@@ -14377,8 +14438,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_err"))) TS_C
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_is_ok"))) TS_CResult_PaymentSecretNoneZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentSecretNoneZ* o_conv = (LDKCResult_PaymentSecretNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentSecretNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentSecretNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_free"))) TS_CResult_PaymentSecretNoneZ_free(uint32_t _res) {
@@ -14397,8 +14458,8 @@ static inline uintptr_t CResult_PaymentSecretNoneZ_clone_ptr(LDKCResult_PaymentS
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_clone_ptr"))) TS_CResult_PaymentSecretNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentSecretNoneZ* arg_conv = (LDKCResult_PaymentSecretNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentSecretNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentSecretNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_clone"))) TS_CResult_PaymentSecretNoneZ_clone(uint32_t orig) {
@@ -14429,8 +14490,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_err"))) 
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_is_ok"))) TS_CResult_PaymentSecretAPIErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentSecretAPIErrorZ* o_conv = (LDKCResult_PaymentSecretAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentSecretAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentSecretAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_free"))) TS_CResult_PaymentSecretAPIErrorZ_free(uint32_t _res) {
@@ -14449,8 +14510,8 @@ static inline uintptr_t CResult_PaymentSecretAPIErrorZ_clone_ptr(LDKCResult_Paym
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_clone_ptr"))) TS_CResult_PaymentSecretAPIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentSecretAPIErrorZ* arg_conv = (LDKCResult_PaymentSecretAPIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentSecretAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentSecretAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_clone"))) TS_CResult_PaymentSecretAPIErrorZ_clone(uint32_t orig) {
@@ -14481,8 +14542,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_is_ok"))) TS_CResult_PaymentPreimageAPIErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentPreimageAPIErrorZ* o_conv = (LDKCResult_PaymentPreimageAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentPreimageAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentPreimageAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_free"))) TS_CResult_PaymentPreimageAPIErrorZ_free(uint32_t _res) {
@@ -14501,8 +14562,8 @@ static inline uintptr_t CResult_PaymentPreimageAPIErrorZ_clone_ptr(LDKCResult_Pa
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_clone_ptr"))) TS_CResult_PaymentPreimageAPIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentPreimageAPIErrorZ* arg_conv = (LDKCResult_PaymentPreimageAPIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentPreimageAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentPreimageAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_clone"))) TS_CResult_PaymentPreimageAPIErrorZ_clone(uint32_t orig) {
@@ -14536,8 +14597,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecod
 
 jboolean  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok"))) TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CounterpartyForwardingInfoDecodeErrorZ* o_conv = (LDKCResult_CounterpartyForwardingInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_free"))) TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_free(uint32_t _res) {
@@ -14556,8 +14617,8 @@ static inline uintptr_t CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr
 }
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr"))) TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CounterpartyForwardingInfoDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyForwardingInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_clone"))) TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -14591,8 +14652,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ_is_ok"))) TS_CResult_ChannelCounterpartyDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelCounterpartyDecodeErrorZ* o_conv = (LDKCResult_ChannelCounterpartyDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelCounterpartyDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelCounterpartyDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ_free"))) TS_CResult_ChannelCounterpartyDecodeErrorZ_free(uint32_t _res) {
@@ -14611,8 +14672,8 @@ static inline uintptr_t CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(LDKCRe
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelCounterpartyDecodeErrorZ* arg_conv = (LDKCResult_ChannelCounterpartyDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ_clone"))) TS_CResult_ChannelCounterpartyDecodeErrorZ_clone(uint32_t orig) {
@@ -14646,8 +14707,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_is_ok"))) TS_CResult_ChannelDetailsDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelDetailsDecodeErrorZ* o_conv = (LDKCResult_ChannelDetailsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelDetailsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelDetailsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_free"))) TS_CResult_ChannelDetailsDecodeErrorZ_free(uint32_t _res) {
@@ -14666,8 +14727,8 @@ static inline uintptr_t CResult_ChannelDetailsDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelDetailsDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelDetailsDecodeErrorZ* arg_conv = (LDKCResult_ChannelDetailsDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelDetailsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelDetailsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_clone"))) TS_CResult_ChannelDetailsDecodeErrorZ_clone(uint32_t orig) {
@@ -14701,8 +14762,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_is_ok"))) TS_CResult_PhantomRouteHintsDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PhantomRouteHintsDecodeErrorZ* o_conv = (LDKCResult_PhantomRouteHintsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PhantomRouteHintsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PhantomRouteHintsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_free"))) TS_CResult_PhantomRouteHintsDecodeErrorZ_free(uint32_t _res) {
@@ -14721,8 +14782,8 @@ static inline uintptr_t CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr"))) TS_CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PhantomRouteHintsDecodeErrorZ* arg_conv = (LDKCResult_PhantomRouteHintsDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_clone"))) TS_CResult_PhantomRouteHintsDecodeErrorZ_clone(uint32_t orig) {
@@ -14797,8 +14858,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelManager
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok"))) TS_CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ* o_conv = (LDKCResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_free"))) TS_CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_free(uint32_t _res) {
@@ -14834,8 +14895,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_is_ok"))) TS_CResult_ChannelConfigDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelConfigDecodeErrorZ* o_conv = (LDKCResult_ChannelConfigDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelConfigDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelConfigDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_free"))) TS_CResult_ChannelConfigDecodeErrorZ_free(uint32_t _res) {
@@ -14854,8 +14915,8 @@ static inline uintptr_t CResult_ChannelConfigDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelConfigDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelConfigDecodeErrorZ* arg_conv = (LDKCResult_ChannelConfigDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelConfigDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelConfigDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_clone"))) TS_CResult_ChannelConfigDecodeErrorZ_clone(uint32_t orig) {
@@ -14889,8 +14950,8 @@ uint32_t  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_is_ok"))) TS_CResult_OutPointDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_OutPointDecodeErrorZ* o_conv = (LDKCResult_OutPointDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_OutPointDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_OutPointDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_free"))) TS_CResult_OutPointDecodeErrorZ_free(uint32_t _res) {
@@ -14909,8 +14970,8 @@ static inline uintptr_t CResult_OutPointDecodeErrorZ_clone_ptr(LDKCResult_OutPoi
 }
 uint32_t  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_clone_ptr"))) TS_CResult_OutPointDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_OutPointDecodeErrorZ* arg_conv = (LDKCResult_OutPointDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_OutPointDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_OutPointDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_clone"))) TS_CResult_OutPointDecodeErrorZ_clone(uint32_t orig) {
@@ -14958,8 +15019,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_TypeZ_clone_ptr"))) TS_COption_TypeZ_clone_ptr(uint32_t arg) {
 	LDKCOption_TypeZ* arg_conv = (LDKCOption_TypeZ*)arg;
-	uint32_t ret_val = COption_TypeZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_TypeZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_TypeZ_clone"))) TS_COption_TypeZ_clone(uint32_t orig) {
@@ -14993,8 +15054,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_is_ok"))) TS_CResult_COption_TypeZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_TypeZDecodeErrorZ* o_conv = (LDKCResult_COption_TypeZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_TypeZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_TypeZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_free"))) TS_CResult_COption_TypeZDecodeErrorZ_free(uint32_t _res) {
@@ -15013,8 +15074,8 @@ static inline uintptr_t CResult_COption_TypeZDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_TypeZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_TypeZDecodeErrorZ* arg_conv = (LDKCResult_COption_TypeZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_TypeZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_TypeZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_clone"))) TS_CResult_COption_TypeZDecodeErrorZ_clone(uint32_t orig) {
@@ -15045,8 +15106,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_err"))) 
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_is_ok"))) TS_CResult_PaymentIdPaymentErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentIdPaymentErrorZ* o_conv = (LDKCResult_PaymentIdPaymentErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentIdPaymentErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentIdPaymentErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_free"))) TS_CResult_PaymentIdPaymentErrorZ_free(uint32_t _res) {
@@ -15065,8 +15126,8 @@ static inline uintptr_t CResult_PaymentIdPaymentErrorZ_clone_ptr(LDKCResult_Paym
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_clone_ptr"))) TS_CResult_PaymentIdPaymentErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentIdPaymentErrorZ* arg_conv = (LDKCResult_PaymentIdPaymentErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentIdPaymentErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentIdPaymentErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_clone"))) TS_CResult_PaymentIdPaymentErrorZ_clone(uint32_t orig) {
@@ -15095,8 +15156,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_err"))) TS_
 
 jboolean  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_is_ok"))) TS_CResult_SiPrefixParseErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SiPrefixParseErrorZ* o_conv = (LDKCResult_SiPrefixParseErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SiPrefixParseErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SiPrefixParseErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_free"))) TS_CResult_SiPrefixParseErrorZ_free(uint32_t _res) {
@@ -15115,8 +15176,8 @@ static inline uintptr_t CResult_SiPrefixParseErrorZ_clone_ptr(LDKCResult_SiPrefi
 }
 uint32_t  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_clone_ptr"))) TS_CResult_SiPrefixParseErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SiPrefixParseErrorZ* arg_conv = (LDKCResult_SiPrefixParseErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SiPrefixParseErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SiPrefixParseErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_clone"))) TS_CResult_SiPrefixParseErrorZ_clone(uint32_t orig) {
@@ -15149,8 +15210,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_is_ok"))) TS_CResult_InvoiceParseOrSemanticErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InvoiceParseOrSemanticErrorZ* o_conv = (LDKCResult_InvoiceParseOrSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceParseOrSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceParseOrSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_free"))) TS_CResult_InvoiceParseOrSemanticErrorZ_free(uint32_t _res) {
@@ -15169,8 +15230,8 @@ static inline uintptr_t CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_clone_ptr"))) TS_CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InvoiceParseOrSemanticErrorZ* arg_conv = (LDKCResult_InvoiceParseOrSemanticErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_clone"))) TS_CResult_InvoiceParseOrSemanticErrorZ_clone(uint32_t orig) {
@@ -15203,8 +15264,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_is_ok"))) TS_CResult_SignedRawInvoiceParseErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SignedRawInvoiceParseErrorZ* o_conv = (LDKCResult_SignedRawInvoiceParseErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SignedRawInvoiceParseErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignedRawInvoiceParseErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_free"))) TS_CResult_SignedRawInvoiceParseErrorZ_free(uint32_t _res) {
@@ -15223,8 +15284,8 @@ static inline uintptr_t CResult_SignedRawInvoiceParseErrorZ_clone_ptr(LDKCResult
 }
 uint32_t  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_clone_ptr"))) TS_CResult_SignedRawInvoiceParseErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SignedRawInvoiceParseErrorZ* arg_conv = (LDKCResult_SignedRawInvoiceParseErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SignedRawInvoiceParseErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SignedRawInvoiceParseErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_clone"))) TS_CResult_SignedRawInvoiceParseErrorZ_clone(uint32_t orig) {
@@ -15241,8 +15302,8 @@ static inline uintptr_t C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(LDKC3
 }
 uint32_t  __attribute__((export_name("TS_C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr"))) TS_C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(uint32_t arg) {
 	LDKC3Tuple_RawInvoice_u832InvoiceSignatureZ* arg_conv = (LDKC3Tuple_RawInvoice_u832InvoiceSignatureZ*)(arg & ~1);
-	uint32_t ret_val = C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone"))) TS_C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone(uint32_t orig) {
@@ -15300,8 +15361,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_err"))) TS_CR
 
 jboolean  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_is_ok"))) TS_CResult_PayeePubKeyErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PayeePubKeyErrorZ* o_conv = (LDKCResult_PayeePubKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PayeePubKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PayeePubKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_free"))) TS_CResult_PayeePubKeyErrorZ_free(uint32_t _res) {
@@ -15320,8 +15381,8 @@ static inline uintptr_t CResult_PayeePubKeyErrorZ_clone_ptr(LDKCResult_PayeePubK
 }
 uint32_t  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_clone_ptr"))) TS_CResult_PayeePubKeyErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PayeePubKeyErrorZ* arg_conv = (LDKCResult_PayeePubKeyErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PayeePubKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PayeePubKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_clone"))) TS_CResult_PayeePubKeyErrorZ_clone(uint32_t orig) {
@@ -15370,8 +15431,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ_is_ok"))) TS_CResult_PositiveTimestampCreationErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PositiveTimestampCreationErrorZ* o_conv = (LDKCResult_PositiveTimestampCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PositiveTimestampCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PositiveTimestampCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ_free"))) TS_CResult_PositiveTimestampCreationErrorZ_free(uint32_t _res) {
@@ -15390,8 +15451,8 @@ static inline uintptr_t CResult_PositiveTimestampCreationErrorZ_clone_ptr(LDKCRe
 }
 uint32_t  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ_clone_ptr"))) TS_CResult_PositiveTimestampCreationErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PositiveTimestampCreationErrorZ* arg_conv = (LDKCResult_PositiveTimestampCreationErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PositiveTimestampCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PositiveTimestampCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ_clone"))) TS_CResult_PositiveTimestampCreationErrorZ_clone(uint32_t orig) {
@@ -15416,8 +15477,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_err"))) TS_C
 
 jboolean  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_is_ok"))) TS_CResult_NoneSemanticErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NoneSemanticErrorZ* o_conv = (LDKCResult_NoneSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_free"))) TS_CResult_NoneSemanticErrorZ_free(uint32_t _res) {
@@ -15436,8 +15497,8 @@ static inline uintptr_t CResult_NoneSemanticErrorZ_clone_ptr(LDKCResult_NoneSema
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_clone_ptr"))) TS_CResult_NoneSemanticErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneSemanticErrorZ* arg_conv = (LDKCResult_NoneSemanticErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_clone"))) TS_CResult_NoneSemanticErrorZ_clone(uint32_t orig) {
@@ -15467,8 +15528,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_err"))) T
 
 jboolean  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_is_ok"))) TS_CResult_InvoiceSemanticErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InvoiceSemanticErrorZ* o_conv = (LDKCResult_InvoiceSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_free"))) TS_CResult_InvoiceSemanticErrorZ_free(uint32_t _res) {
@@ -15487,8 +15548,8 @@ static inline uintptr_t CResult_InvoiceSemanticErrorZ_clone_ptr(LDKCResult_Invoi
 }
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_clone_ptr"))) TS_CResult_InvoiceSemanticErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InvoiceSemanticErrorZ* arg_conv = (LDKCResult_InvoiceSemanticErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InvoiceSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InvoiceSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_clone"))) TS_CResult_InvoiceSemanticErrorZ_clone(uint32_t orig) {
@@ -15518,8 +15579,8 @@ uint32_t  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_is_ok"))) TS_CResult_DescriptionCreationErrorZ_is_ok(uint32_t o) {
 	LDKCResult_DescriptionCreationErrorZ* o_conv = (LDKCResult_DescriptionCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_DescriptionCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_DescriptionCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_free"))) TS_CResult_DescriptionCreationErrorZ_free(uint32_t _res) {
@@ -15538,8 +15599,8 @@ static inline uintptr_t CResult_DescriptionCreationErrorZ_clone_ptr(LDKCResult_D
 }
 uint32_t  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_clone_ptr"))) TS_CResult_DescriptionCreationErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_DescriptionCreationErrorZ* arg_conv = (LDKCResult_DescriptionCreationErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_DescriptionCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_DescriptionCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_clone"))) TS_CResult_DescriptionCreationErrorZ_clone(uint32_t orig) {
@@ -15569,8 +15630,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_is_ok"))) TS_CResult_PrivateRouteCreationErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PrivateRouteCreationErrorZ* o_conv = (LDKCResult_PrivateRouteCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PrivateRouteCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PrivateRouteCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_free"))) TS_CResult_PrivateRouteCreationErrorZ_free(uint32_t _res) {
@@ -15589,8 +15650,8 @@ static inline uintptr_t CResult_PrivateRouteCreationErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_clone_ptr"))) TS_CResult_PrivateRouteCreationErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PrivateRouteCreationErrorZ* arg_conv = (LDKCResult_PrivateRouteCreationErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PrivateRouteCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PrivateRouteCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_clone"))) TS_CResult_PrivateRouteCreationErrorZ_clone(uint32_t orig) {
@@ -15616,8 +15677,8 @@ uint32_t  __attribute__((export_name("TS_CResult_StringErrorZ_err"))) TS_CResult
 
 jboolean  __attribute__((export_name("TS_CResult_StringErrorZ_is_ok"))) TS_CResult_StringErrorZ_is_ok(uint32_t o) {
 	LDKCResult_StringErrorZ* o_conv = (LDKCResult_StringErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_StringErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_StringErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_StringErrorZ_free"))) TS_CResult_StringErrorZ_free(uint32_t _res) {
@@ -15653,8 +15714,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeError
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok"))) TS_CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelMonitorUpdateDecodeErrorZ* o_conv = (LDKCResult_ChannelMonitorUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeErrorZ_free"))) TS_CResult_ChannelMonitorUpdateDecodeErrorZ_free(uint32_t _res) {
@@ -15673,8 +15734,8 @@ static inline uintptr_t CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(LDKCR
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelMonitorUpdateDecodeErrorZ* arg_conv = (LDKCResult_ChannelMonitorUpdateDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeErrorZ_clone"))) TS_CResult_ChannelMonitorUpdateDecodeErrorZ_clone(uint32_t orig) {
@@ -15719,8 +15780,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_MonitorEventZ_clone_ptr"))) TS_COption_MonitorEventZ_clone_ptr(uint32_t arg) {
 	LDKCOption_MonitorEventZ* arg_conv = (LDKCOption_MonitorEventZ*)arg;
-	uint32_t ret_val = COption_MonitorEventZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_MonitorEventZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_MonitorEventZ_clone"))) TS_COption_MonitorEventZ_clone(uint32_t orig) {
@@ -15754,8 +15815,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErrorZ_is_ok"))) TS_CResult_COption_MonitorEventZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* o_conv = (LDKCResult_COption_MonitorEventZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_MonitorEventZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_MonitorEventZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErrorZ_free"))) TS_CResult_COption_MonitorEventZDecodeErrorZ_free(uint32_t _res) {
@@ -15774,8 +15835,8 @@ static inline uintptr_t CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* arg_conv = (LDKCResult_COption_MonitorEventZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErrorZ_clone"))) TS_CResult_COption_MonitorEventZDecodeErrorZ_clone(uint32_t orig) {
@@ -15809,8 +15870,8 @@ uint32_t  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_err"))) 
 
 jboolean  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_is_ok"))) TS_CResult_HTLCUpdateDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_HTLCUpdateDecodeErrorZ* o_conv = (LDKCResult_HTLCUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HTLCUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HTLCUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_free"))) TS_CResult_HTLCUpdateDecodeErrorZ_free(uint32_t _res) {
@@ -15829,8 +15890,8 @@ static inline uintptr_t CResult_HTLCUpdateDecodeErrorZ_clone_ptr(LDKCResult_HTLC
 }
 uint32_t  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_clone_ptr"))) TS_CResult_HTLCUpdateDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_HTLCUpdateDecodeErrorZ* arg_conv = (LDKCResult_HTLCUpdateDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_HTLCUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_HTLCUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_clone"))) TS_CResult_HTLCUpdateDecodeErrorZ_clone(uint32_t orig) {
@@ -15847,8 +15908,8 @@ static inline uintptr_t C2Tuple_OutPointScriptZ_clone_ptr(LDKC2Tuple_OutPointScr
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_OutPointScriptZ_clone_ptr"))) TS_C2Tuple_OutPointScriptZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_OutPointScriptZ* arg_conv = (LDKC2Tuple_OutPointScriptZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_OutPointScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_OutPointScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_OutPointScriptZ_clone"))) TS_C2Tuple_OutPointScriptZ_clone(uint32_t orig) {
@@ -15889,8 +15950,8 @@ static inline uintptr_t C2Tuple_u32ScriptZ_clone_ptr(LDKC2Tuple_u32ScriptZ *NONN
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_u32ScriptZ_clone_ptr"))) TS_C2Tuple_u32ScriptZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_u32ScriptZ* arg_conv = (LDKC2Tuple_u32ScriptZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_u32ScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_u32ScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_u32ScriptZ_clone"))) TS_C2Tuple_u32ScriptZ_clone(uint32_t orig) {
@@ -15945,8 +16006,8 @@ static inline uintptr_t C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(LDKC2Tup
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr"))) TS_C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ* arg_conv = (LDKC2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone"))) TS_C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone(uint32_t orig) {
@@ -16054,8 +16115,8 @@ static inline uintptr_t C2Tuple_u32TxOutZ_clone_ptr(LDKC2Tuple_u32TxOutZ *NONNUL
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_u32TxOutZ_clone_ptr"))) TS_C2Tuple_u32TxOutZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_u32TxOutZ* arg_conv = (LDKC2Tuple_u32TxOutZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_u32TxOutZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_u32TxOutZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_u32TxOutZ_clone"))) TS_C2Tuple_u32TxOutZ_clone(uint32_t orig) {
@@ -16110,8 +16171,8 @@ static inline uintptr_t C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(LDKC2Tupl
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr"))) TS_C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ* arg_conv = (LDKC2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone"))) TS_C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone(uint32_t orig) {
@@ -16199,8 +16260,8 @@ static inline uintptr_t C2Tuple_BlockHashChannelMonitorZ_clone_ptr(LDKC2Tuple_Bl
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_BlockHashChannelMonitorZ_clone_ptr"))) TS_C2Tuple_BlockHashChannelMonitorZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_BlockHashChannelMonitorZ* arg_conv = (LDKC2Tuple_BlockHashChannelMonitorZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_BlockHashChannelMonitorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_BlockHashChannelMonitorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_BlockHashChannelMonitorZ_clone"))) TS_C2Tuple_BlockHashChannelMonitorZ_clone(uint32_t orig) {
@@ -16256,8 +16317,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitor
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok"))) TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ* o_conv = (LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_free"))) TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_free(uint32_t _res) {
@@ -16276,8 +16337,8 @@ static inline uintptr_t CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clo
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr"))) TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ* arg_conv = (LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone"))) TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone(uint32_t orig) {
@@ -16306,8 +16367,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_err"))) TS_
 
 jboolean  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_is_ok"))) TS_CResult_NoneLightningErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NoneLightningErrorZ* o_conv = (LDKCResult_NoneLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_free"))) TS_CResult_NoneLightningErrorZ_free(uint32_t _res) {
@@ -16326,8 +16387,8 @@ static inline uintptr_t CResult_NoneLightningErrorZ_clone_ptr(LDKCResult_NoneLig
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_clone_ptr"))) TS_CResult_NoneLightningErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneLightningErrorZ* arg_conv = (LDKCResult_NoneLightningErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_clone"))) TS_CResult_NoneLightningErrorZ_clone(uint32_t orig) {
@@ -16344,8 +16405,8 @@ static inline uintptr_t C2Tuple_PublicKeyTypeZ_clone_ptr(LDKC2Tuple_PublicKeyTyp
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_PublicKeyTypeZ_clone_ptr"))) TS_C2Tuple_PublicKeyTypeZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_PublicKeyTypeZ* arg_conv = (LDKC2Tuple_PublicKeyTypeZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_PublicKeyTypeZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_PublicKeyTypeZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_PublicKeyTypeZ_clone"))) TS_C2Tuple_PublicKeyTypeZ_clone(uint32_t orig) {
@@ -16418,8 +16479,8 @@ uint32_t  __attribute__((export_name("TS_CResult_boolLightningErrorZ_err"))) TS_
 
 jboolean  __attribute__((export_name("TS_CResult_boolLightningErrorZ_is_ok"))) TS_CResult_boolLightningErrorZ_is_ok(uint32_t o) {
 	LDKCResult_boolLightningErrorZ* o_conv = (LDKCResult_boolLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_boolLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_boolLightningErrorZ_free"))) TS_CResult_boolLightningErrorZ_free(uint32_t _res) {
@@ -16438,8 +16499,8 @@ static inline uintptr_t CResult_boolLightningErrorZ_clone_ptr(LDKCResult_boolLig
 }
 uint32_t  __attribute__((export_name("TS_CResult_boolLightningErrorZ_clone_ptr"))) TS_CResult_boolLightningErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_boolLightningErrorZ* arg_conv = (LDKCResult_boolLightningErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_boolLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_boolLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_boolLightningErrorZ_clone"))) TS_CResult_boolLightningErrorZ_clone(uint32_t orig) {
@@ -16456,8 +16517,8 @@ static inline uintptr_t C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_c
 }
 uint32_t  __attribute__((export_name("TS_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr"))) TS_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(uint32_t arg) {
 	LDKC3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ* arg_conv = (LDKC3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ*)(arg & ~1);
-	uint32_t ret_val = C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone"))) TS_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone(uint32_t orig) {
@@ -16588,8 +16649,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_NetAddressZ_clone_ptr"))) TS_COption_NetAddressZ_clone_ptr(uint32_t arg) {
 	LDKCOption_NetAddressZ* arg_conv = (LDKCOption_NetAddressZ*)arg;
-	uint32_t ret_val = COption_NetAddressZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_NetAddressZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_NetAddressZ_clone"))) TS_COption_NetAddressZ_clone(uint32_t orig) {
@@ -16623,8 +16684,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_is_ok"))) TS_CResult_CVec_u8ZPeerHandleErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CVec_u8ZPeerHandleErrorZ* o_conv = (LDKCResult_CVec_u8ZPeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_u8ZPeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_u8ZPeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_free"))) TS_CResult_CVec_u8ZPeerHandleErrorZ_free(uint32_t _res) {
@@ -16643,8 +16704,8 @@ static inline uintptr_t CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(LDKCResult_CV
 }
 uint32_t  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr"))) TS_CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CVec_u8ZPeerHandleErrorZ* arg_conv = (LDKCResult_CVec_u8ZPeerHandleErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_clone"))) TS_CResult_CVec_u8ZPeerHandleErrorZ_clone(uint32_t orig) {
@@ -16673,8 +16734,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_is_ok"))) TS_CResult_NonePeerHandleErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NonePeerHandleErrorZ* o_conv = (LDKCResult_NonePeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NonePeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NonePeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_free"))) TS_CResult_NonePeerHandleErrorZ_free(uint32_t _res) {
@@ -16693,8 +16754,8 @@ static inline uintptr_t CResult_NonePeerHandleErrorZ_clone_ptr(LDKCResult_NonePe
 }
 uint32_t  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_clone_ptr"))) TS_CResult_NonePeerHandleErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NonePeerHandleErrorZ* arg_conv = (LDKCResult_NonePeerHandleErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NonePeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NonePeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_clone"))) TS_CResult_NonePeerHandleErrorZ_clone(uint32_t orig) {
@@ -16723,8 +16784,8 @@ uint32_t  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_is_ok"))) TS_CResult_boolPeerHandleErrorZ_is_ok(uint32_t o) {
 	LDKCResult_boolPeerHandleErrorZ* o_conv = (LDKCResult_boolPeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_boolPeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolPeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_free"))) TS_CResult_boolPeerHandleErrorZ_free(uint32_t _res) {
@@ -16743,8 +16804,8 @@ static inline uintptr_t CResult_boolPeerHandleErrorZ_clone_ptr(LDKCResult_boolPe
 }
 uint32_t  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_clone_ptr"))) TS_CResult_boolPeerHandleErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_boolPeerHandleErrorZ* arg_conv = (LDKCResult_boolPeerHandleErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_boolPeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_boolPeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_clone"))) TS_CResult_boolPeerHandleErrorZ_clone(uint32_t orig) {
@@ -16778,8 +16839,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_err"))) TS_C
 
 jboolean  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_is_ok"))) TS_CResult_NodeIdDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeIdDecodeErrorZ* o_conv = (LDKCResult_NodeIdDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeIdDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeIdDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_free"))) TS_CResult_NodeIdDecodeErrorZ_free(uint32_t _res) {
@@ -16798,8 +16859,8 @@ static inline uintptr_t CResult_NodeIdDecodeErrorZ_clone_ptr(LDKCResult_NodeIdDe
 }
 uint32_t  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_clone_ptr"))) TS_CResult_NodeIdDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NodeIdDecodeErrorZ* arg_conv = (LDKCResult_NodeIdDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NodeIdDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NodeIdDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_clone"))) TS_CResult_NodeIdDecodeErrorZ_clone(uint32_t orig) {
@@ -16832,8 +16893,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErr
 
 jboolean  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok"))) TS_CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_NetworkUpdateZDecodeErrorZ* o_conv = (LDKCResult_COption_NetworkUpdateZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErrorZ_free"))) TS_CResult_COption_NetworkUpdateZDecodeErrorZ_free(uint32_t _res) {
@@ -16852,8 +16913,8 @@ static inline uintptr_t CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(LDK
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_NetworkUpdateZDecodeErrorZ* arg_conv = (LDKCResult_COption_NetworkUpdateZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErrorZ_clone"))) TS_CResult_COption_NetworkUpdateZDecodeErrorZ_clone(uint32_t orig) {
@@ -16917,8 +16978,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_is_ok"))) TS_CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelUpdateInfoDecodeErrorZ* o_conv = (LDKCResult_ChannelUpdateInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_free"))) TS_CResult_ChannelUpdateInfoDecodeErrorZ_free(uint32_t _res) {
@@ -16937,8 +16998,8 @@ static inline uintptr_t CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelUpdateInfoDecodeErrorZ* arg_conv = (LDKCResult_ChannelUpdateInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_clone"))) TS_CResult_ChannelUpdateInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -16972,8 +17033,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_err")))
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_is_ok"))) TS_CResult_ChannelInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelInfoDecodeErrorZ* o_conv = (LDKCResult_ChannelInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_free"))) TS_CResult_ChannelInfoDecodeErrorZ_free(uint32_t _res) {
@@ -16992,8 +17053,8 @@ static inline uintptr_t CResult_ChannelInfoDecodeErrorZ_clone_ptr(LDKCResult_Cha
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelInfoDecodeErrorZ* arg_conv = (LDKCResult_ChannelInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_clone"))) TS_CResult_ChannelInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -17027,8 +17088,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_err")))
 
 jboolean  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_is_ok"))) TS_CResult_RoutingFeesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RoutingFeesDecodeErrorZ* o_conv = (LDKCResult_RoutingFeesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RoutingFeesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RoutingFeesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_free"))) TS_CResult_RoutingFeesDecodeErrorZ_free(uint32_t _res) {
@@ -17047,8 +17108,8 @@ static inline uintptr_t CResult_RoutingFeesDecodeErrorZ_clone_ptr(LDKCResult_Rou
 }
 uint32_t  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_clone_ptr"))) TS_CResult_RoutingFeesDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RoutingFeesDecodeErrorZ* arg_conv = (LDKCResult_RoutingFeesDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RoutingFeesDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RoutingFeesDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_clone"))) TS_CResult_RoutingFeesDecodeErrorZ_clone(uint32_t orig) {
@@ -17082,8 +17143,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeError
 
 jboolean  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok"))) TS_CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeAnnouncementInfoDecodeErrorZ* o_conv = (LDKCResult_NodeAnnouncementInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeErrorZ_free"))) TS_CResult_NodeAnnouncementInfoDecodeErrorZ_free(uint32_t _res) {
@@ -17102,8 +17163,8 @@ static inline uintptr_t CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(LDKCR
 }
 uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr"))) TS_CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NodeAnnouncementInfoDecodeErrorZ* arg_conv = (LDKCResult_NodeAnnouncementInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeErrorZ_clone"))) TS_CResult_NodeAnnouncementInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -17152,8 +17213,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_is_ok"))) TS_CResult_NodeInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeInfoDecodeErrorZ* o_conv = (LDKCResult_NodeInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_free"))) TS_CResult_NodeInfoDecodeErrorZ_free(uint32_t _res) {
@@ -17172,8 +17233,8 @@ static inline uintptr_t CResult_NodeInfoDecodeErrorZ_clone_ptr(LDKCResult_NodeIn
 }
 uint32_t  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_clone_ptr"))) TS_CResult_NodeInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NodeInfoDecodeErrorZ* arg_conv = (LDKCResult_NodeInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NodeInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NodeInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_clone"))) TS_CResult_NodeInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -17207,8 +17268,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_is_ok"))) TS_CResult_NetworkGraphDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NetworkGraphDecodeErrorZ* o_conv = (LDKCResult_NetworkGraphDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NetworkGraphDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NetworkGraphDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_free"))) TS_CResult_NetworkGraphDecodeErrorZ_free(uint32_t _res) {
@@ -17227,8 +17288,8 @@ static inline uintptr_t CResult_NetworkGraphDecodeErrorZ_clone_ptr(LDKCResult_Ne
 }
 uint32_t  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_clone_ptr"))) TS_CResult_NetworkGraphDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NetworkGraphDecodeErrorZ* arg_conv = (LDKCResult_NetworkGraphDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NetworkGraphDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NetworkGraphDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_clone"))) TS_CResult_NetworkGraphDecodeErrorZ_clone(uint32_t orig) {
@@ -17284,8 +17345,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_CVec_NetAddressZZ_clone_ptr"))) TS_COption_CVec_NetAddressZZ_clone_ptr(uint32_t arg) {
 	LDKCOption_CVec_NetAddressZZ* arg_conv = (LDKCOption_CVec_NetAddressZZ*)arg;
-	uint32_t ret_val = COption_CVec_NetAddressZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_CVec_NetAddressZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_CVec_NetAddressZZ_clone"))) TS_COption_CVec_NetAddressZZ_clone(uint32_t orig) {
@@ -17319,8 +17380,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_err"))) 
 
 jboolean  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_is_ok"))) TS_CResult_NetAddressDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NetAddressDecodeErrorZ* o_conv = (LDKCResult_NetAddressDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NetAddressDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NetAddressDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_free"))) TS_CResult_NetAddressDecodeErrorZ_free(uint32_t _res) {
@@ -17339,8 +17400,8 @@ static inline uintptr_t CResult_NetAddressDecodeErrorZ_clone_ptr(LDKCResult_NetA
 }
 uint32_t  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_clone_ptr"))) TS_CResult_NetAddressDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NetAddressDecodeErrorZ* arg_conv = (LDKCResult_NetAddressDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NetAddressDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NetAddressDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_clone"))) TS_CResult_NetAddressDecodeErrorZ_clone(uint32_t orig) {
@@ -17450,8 +17511,8 @@ uint32_t  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_is_ok"))) TS_CResult_AcceptChannelDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_AcceptChannelDecodeErrorZ* o_conv = (LDKCResult_AcceptChannelDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_AcceptChannelDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_AcceptChannelDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_free"))) TS_CResult_AcceptChannelDecodeErrorZ_free(uint32_t _res) {
@@ -17470,8 +17531,8 @@ static inline uintptr_t CResult_AcceptChannelDecodeErrorZ_clone_ptr(LDKCResult_A
 }
 uint32_t  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_clone_ptr"))) TS_CResult_AcceptChannelDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_AcceptChannelDecodeErrorZ* arg_conv = (LDKCResult_AcceptChannelDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_AcceptChannelDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_AcceptChannelDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_clone"))) TS_CResult_AcceptChannelDecodeErrorZ_clone(uint32_t orig) {
@@ -17505,8 +17566,8 @@ uint32_t  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErr
 
 jboolean  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErrorZ_is_ok"))) TS_CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_AnnouncementSignaturesDecodeErrorZ* o_conv = (LDKCResult_AnnouncementSignaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErrorZ_free"))) TS_CResult_AnnouncementSignaturesDecodeErrorZ_free(uint32_t _res) {
@@ -17525,8 +17586,8 @@ static inline uintptr_t CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(LDK
 }
 uint32_t  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr"))) TS_CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_AnnouncementSignaturesDecodeErrorZ* arg_conv = (LDKCResult_AnnouncementSignaturesDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErrorZ_clone"))) TS_CResult_AnnouncementSignaturesDecodeErrorZ_clone(uint32_t orig) {
@@ -17560,8 +17621,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_is_ok"))) TS_CResult_ChannelReestablishDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelReestablishDecodeErrorZ* o_conv = (LDKCResult_ChannelReestablishDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelReestablishDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelReestablishDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_free"))) TS_CResult_ChannelReestablishDecodeErrorZ_free(uint32_t _res) {
@@ -17580,8 +17641,8 @@ static inline uintptr_t CResult_ChannelReestablishDecodeErrorZ_clone_ptr(LDKCRes
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelReestablishDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelReestablishDecodeErrorZ* arg_conv = (LDKCResult_ChannelReestablishDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelReestablishDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelReestablishDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_clone"))) TS_CResult_ChannelReestablishDecodeErrorZ_clone(uint32_t orig) {
@@ -17615,8 +17676,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_is_ok"))) TS_CResult_ClosingSignedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ClosingSignedDecodeErrorZ* o_conv = (LDKCResult_ClosingSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ClosingSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ClosingSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_free"))) TS_CResult_ClosingSignedDecodeErrorZ_free(uint32_t _res) {
@@ -17635,8 +17696,8 @@ static inline uintptr_t CResult_ClosingSignedDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_clone_ptr"))) TS_CResult_ClosingSignedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ClosingSignedDecodeErrorZ* arg_conv = (LDKCResult_ClosingSignedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ClosingSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ClosingSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_clone"))) TS_CResult_ClosingSignedDecodeErrorZ_clone(uint32_t orig) {
@@ -17670,8 +17731,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok"))) TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ClosingSignedFeeRangeDecodeErrorZ* o_conv = (LDKCResult_ClosingSignedFeeRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_free"))) TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_free(uint32_t _res) {
@@ -17690,8 +17751,8 @@ static inline uintptr_t CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr"))) TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ClosingSignedFeeRangeDecodeErrorZ* arg_conv = (LDKCResult_ClosingSignedFeeRangeDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_clone"))) TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_clone(uint32_t orig) {
@@ -17725,8 +17786,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_is_ok"))) TS_CResult_CommitmentSignedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CommitmentSignedDecodeErrorZ* o_conv = (LDKCResult_CommitmentSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CommitmentSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CommitmentSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_free"))) TS_CResult_CommitmentSignedDecodeErrorZ_free(uint32_t _res) {
@@ -17745,8 +17806,8 @@ static inline uintptr_t CResult_CommitmentSignedDecodeErrorZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_clone_ptr"))) TS_CResult_CommitmentSignedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CommitmentSignedDecodeErrorZ* arg_conv = (LDKCResult_CommitmentSignedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CommitmentSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CommitmentSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_clone"))) TS_CResult_CommitmentSignedDecodeErrorZ_clone(uint32_t orig) {
@@ -17780,8 +17841,8 @@ uint32_t  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_is_ok"))) TS_CResult_FundingCreatedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_FundingCreatedDecodeErrorZ* o_conv = (LDKCResult_FundingCreatedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingCreatedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingCreatedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_free"))) TS_CResult_FundingCreatedDecodeErrorZ_free(uint32_t _res) {
@@ -17800,8 +17861,8 @@ static inline uintptr_t CResult_FundingCreatedDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_clone_ptr"))) TS_CResult_FundingCreatedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_FundingCreatedDecodeErrorZ* arg_conv = (LDKCResult_FundingCreatedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_FundingCreatedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_FundingCreatedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_clone"))) TS_CResult_FundingCreatedDecodeErrorZ_clone(uint32_t orig) {
@@ -17835,8 +17896,8 @@ uint32_t  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_is_ok"))) TS_CResult_FundingSignedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_FundingSignedDecodeErrorZ* o_conv = (LDKCResult_FundingSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_free"))) TS_CResult_FundingSignedDecodeErrorZ_free(uint32_t _res) {
@@ -17855,8 +17916,8 @@ static inline uintptr_t CResult_FundingSignedDecodeErrorZ_clone_ptr(LDKCResult_F
 }
 uint32_t  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_clone_ptr"))) TS_CResult_FundingSignedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_FundingSignedDecodeErrorZ* arg_conv = (LDKCResult_FundingSignedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_FundingSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_FundingSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_clone"))) TS_CResult_FundingSignedDecodeErrorZ_clone(uint32_t orig) {
@@ -17890,8 +17951,8 @@ uint32_t  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_is_ok"))) TS_CResult_FundingLockedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_FundingLockedDecodeErrorZ* o_conv = (LDKCResult_FundingLockedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingLockedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingLockedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_free"))) TS_CResult_FundingLockedDecodeErrorZ_free(uint32_t _res) {
@@ -17910,8 +17971,8 @@ static inline uintptr_t CResult_FundingLockedDecodeErrorZ_clone_ptr(LDKCResult_F
 }
 uint32_t  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_clone_ptr"))) TS_CResult_FundingLockedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_FundingLockedDecodeErrorZ* arg_conv = (LDKCResult_FundingLockedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_FundingLockedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_FundingLockedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_clone"))) TS_CResult_FundingLockedDecodeErrorZ_clone(uint32_t orig) {
@@ -17945,8 +18006,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_is_ok"))) TS_CResult_InitDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InitDecodeErrorZ* o_conv = (LDKCResult_InitDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InitDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InitDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_free"))) TS_CResult_InitDecodeErrorZ_free(uint32_t _res) {
@@ -17965,8 +18026,8 @@ static inline uintptr_t CResult_InitDecodeErrorZ_clone_ptr(LDKCResult_InitDecode
 }
 uint32_t  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_clone_ptr"))) TS_CResult_InitDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InitDecodeErrorZ* arg_conv = (LDKCResult_InitDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InitDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InitDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_clone"))) TS_CResult_InitDecodeErrorZ_clone(uint32_t orig) {
@@ -18000,8 +18061,8 @@ uint32_t  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_err")))
 
 jboolean  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_is_ok"))) TS_CResult_OpenChannelDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_OpenChannelDecodeErrorZ* o_conv = (LDKCResult_OpenChannelDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_OpenChannelDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_OpenChannelDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_free"))) TS_CResult_OpenChannelDecodeErrorZ_free(uint32_t _res) {
@@ -18020,8 +18081,8 @@ static inline uintptr_t CResult_OpenChannelDecodeErrorZ_clone_ptr(LDKCResult_Ope
 }
 uint32_t  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_clone_ptr"))) TS_CResult_OpenChannelDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_OpenChannelDecodeErrorZ* arg_conv = (LDKCResult_OpenChannelDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_OpenChannelDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_OpenChannelDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_clone"))) TS_CResult_OpenChannelDecodeErrorZ_clone(uint32_t orig) {
@@ -18055,8 +18116,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_is_ok"))) TS_CResult_RevokeAndACKDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RevokeAndACKDecodeErrorZ* o_conv = (LDKCResult_RevokeAndACKDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RevokeAndACKDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RevokeAndACKDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_free"))) TS_CResult_RevokeAndACKDecodeErrorZ_free(uint32_t _res) {
@@ -18075,8 +18136,8 @@ static inline uintptr_t CResult_RevokeAndACKDecodeErrorZ_clone_ptr(LDKCResult_Re
 }
 uint32_t  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_clone_ptr"))) TS_CResult_RevokeAndACKDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RevokeAndACKDecodeErrorZ* arg_conv = (LDKCResult_RevokeAndACKDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RevokeAndACKDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RevokeAndACKDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_clone"))) TS_CResult_RevokeAndACKDecodeErrorZ_clone(uint32_t orig) {
@@ -18110,8 +18171,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_is_ok"))) TS_CResult_ShutdownDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ShutdownDecodeErrorZ* o_conv = (LDKCResult_ShutdownDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_free"))) TS_CResult_ShutdownDecodeErrorZ_free(uint32_t _res) {
@@ -18130,8 +18191,8 @@ static inline uintptr_t CResult_ShutdownDecodeErrorZ_clone_ptr(LDKCResult_Shutdo
 }
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_clone_ptr"))) TS_CResult_ShutdownDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ShutdownDecodeErrorZ* arg_conv = (LDKCResult_ShutdownDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ShutdownDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ShutdownDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_clone"))) TS_CResult_ShutdownDecodeErrorZ_clone(uint32_t orig) {
@@ -18165,8 +18226,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_is_ok"))) TS_CResult_UpdateFailHTLCDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateFailHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFailHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFailHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFailHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_free"))) TS_CResult_UpdateFailHTLCDecodeErrorZ_free(uint32_t _res) {
@@ -18185,8 +18246,8 @@ static inline uintptr_t CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateFailHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFailHTLCDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_clone"))) TS_CResult_UpdateFailHTLCDecodeErrorZ_clone(uint32_t orig) {
@@ -18220,8 +18281,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeEr
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok"))) TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_free"))) TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_free(uint32_t _res) {
@@ -18240,8 +18301,8 @@ static inline uintptr_t CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(LD
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone"))) TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone(uint32_t orig) {
@@ -18275,8 +18336,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_err"))) T
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_is_ok"))) TS_CResult_UpdateFeeDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateFeeDecodeErrorZ* o_conv = (LDKCResult_UpdateFeeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFeeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFeeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_free"))) TS_CResult_UpdateFeeDecodeErrorZ_free(uint32_t _res) {
@@ -18295,8 +18356,8 @@ static inline uintptr_t CResult_UpdateFeeDecodeErrorZ_clone_ptr(LDKCResult_Updat
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateFeeDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateFeeDecodeErrorZ* arg_conv = (LDKCResult_UpdateFeeDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateFeeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateFeeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_clone"))) TS_CResult_UpdateFeeDecodeErrorZ_clone(uint32_t orig) {
@@ -18330,8 +18391,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok"))) TS_CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateFulfillHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFulfillHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_free"))) TS_CResult_UpdateFulfillHTLCDecodeErrorZ_free(uint32_t _res) {
@@ -18350,8 +18411,8 @@ static inline uintptr_t CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateFulfillHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFulfillHTLCDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_clone"))) TS_CResult_UpdateFulfillHTLCDecodeErrorZ_clone(uint32_t orig) {
@@ -18385,8 +18446,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_is_ok"))) TS_CResult_UpdateAddHTLCDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateAddHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateAddHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateAddHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateAddHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_free"))) TS_CResult_UpdateAddHTLCDecodeErrorZ_free(uint32_t _res) {
@@ -18405,8 +18466,8 @@ static inline uintptr_t CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(LDKCResult_U
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateAddHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateAddHTLCDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_clone"))) TS_CResult_UpdateAddHTLCDecodeErrorZ_clone(uint32_t orig) {
@@ -18440,8 +18501,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_is_ok"))) TS_CResult_PingDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PingDecodeErrorZ* o_conv = (LDKCResult_PingDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PingDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PingDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_free"))) TS_CResult_PingDecodeErrorZ_free(uint32_t _res) {
@@ -18460,8 +18521,8 @@ static inline uintptr_t CResult_PingDecodeErrorZ_clone_ptr(LDKCResult_PingDecode
 }
 uint32_t  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_clone_ptr"))) TS_CResult_PingDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PingDecodeErrorZ* arg_conv = (LDKCResult_PingDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PingDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PingDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_clone"))) TS_CResult_PingDecodeErrorZ_clone(uint32_t orig) {
@@ -18495,8 +18556,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_is_ok"))) TS_CResult_PongDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PongDecodeErrorZ* o_conv = (LDKCResult_PongDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PongDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PongDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_free"))) TS_CResult_PongDecodeErrorZ_free(uint32_t _res) {
@@ -18515,8 +18576,8 @@ static inline uintptr_t CResult_PongDecodeErrorZ_clone_ptr(LDKCResult_PongDecode
 }
 uint32_t  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_clone_ptr"))) TS_CResult_PongDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PongDecodeErrorZ* arg_conv = (LDKCResult_PongDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PongDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PongDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_clone"))) TS_CResult_PongDecodeErrorZ_clone(uint32_t orig) {
@@ -18550,8 +18611,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDeco
 
 jboolean  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok"))) TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ* o_conv = (LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_free"))) TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_free(uint32_t _res) {
@@ -18570,8 +18631,8 @@ static inline uintptr_t CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_pt
 }
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr"))) TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone"))) TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone(uint32_t orig) {
@@ -18605,8 +18666,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ_is_ok"))) TS_CResult_ChannelAnnouncementDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelAnnouncementDecodeErrorZ* o_conv = (LDKCResult_ChannelAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ_free"))) TS_CResult_ChannelAnnouncementDecodeErrorZ_free(uint32_t _res) {
@@ -18625,8 +18686,8 @@ static inline uintptr_t CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(LDKCRe
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_ChannelAnnouncementDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ_clone"))) TS_CResult_ChannelAnnouncementDecodeErrorZ_clone(uint32_t orig) {
@@ -18660,8 +18721,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok"))) TS_CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UnsignedChannelUpdateDecodeErrorZ* o_conv = (LDKCResult_UnsignedChannelUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErrorZ_free"))) TS_CResult_UnsignedChannelUpdateDecodeErrorZ_free(uint32_t _res) {
@@ -18680,8 +18741,8 @@ static inline uintptr_t CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr"))) TS_CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UnsignedChannelUpdateDecodeErrorZ* arg_conv = (LDKCResult_UnsignedChannelUpdateDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErrorZ_clone"))) TS_CResult_UnsignedChannelUpdateDecodeErrorZ_clone(uint32_t orig) {
@@ -18715,8 +18776,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_is_ok"))) TS_CResult_ChannelUpdateDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelUpdateDecodeErrorZ* o_conv = (LDKCResult_ChannelUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_free"))) TS_CResult_ChannelUpdateDecodeErrorZ_free(uint32_t _res) {
@@ -18735,8 +18796,8 @@ static inline uintptr_t CResult_ChannelUpdateDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelUpdateDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelUpdateDecodeErrorZ* arg_conv = (LDKCResult_ChannelUpdateDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_clone"))) TS_CResult_ChannelUpdateDecodeErrorZ_clone(uint32_t orig) {
@@ -18770,8 +18831,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_is_ok"))) TS_CResult_ErrorMessageDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ErrorMessageDecodeErrorZ* o_conv = (LDKCResult_ErrorMessageDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ErrorMessageDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ErrorMessageDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_free"))) TS_CResult_ErrorMessageDecodeErrorZ_free(uint32_t _res) {
@@ -18790,8 +18851,8 @@ static inline uintptr_t CResult_ErrorMessageDecodeErrorZ_clone_ptr(LDKCResult_Er
 }
 uint32_t  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_clone_ptr"))) TS_CResult_ErrorMessageDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ErrorMessageDecodeErrorZ* arg_conv = (LDKCResult_ErrorMessageDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ErrorMessageDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ErrorMessageDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_clone"))) TS_CResult_ErrorMessageDecodeErrorZ_clone(uint32_t orig) {
@@ -18825,8 +18886,8 @@ uint32_t  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_is_ok"))) TS_CResult_WarningMessageDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_WarningMessageDecodeErrorZ* o_conv = (LDKCResult_WarningMessageDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_WarningMessageDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_WarningMessageDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_free"))) TS_CResult_WarningMessageDecodeErrorZ_free(uint32_t _res) {
@@ -18845,8 +18906,8 @@ static inline uintptr_t CResult_WarningMessageDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_clone_ptr"))) TS_CResult_WarningMessageDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_WarningMessageDecodeErrorZ* arg_conv = (LDKCResult_WarningMessageDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_WarningMessageDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_WarningMessageDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_clone"))) TS_CResult_WarningMessageDecodeErrorZ_clone(uint32_t orig) {
@@ -18880,8 +18941,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeE
 
 jboolean  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok"))) TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* o_conv = (LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_free"))) TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_free(uint32_t _res) {
@@ -18900,8 +18961,8 @@ static inline uintptr_t CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(L
 }
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr"))) TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone"))) TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone(uint32_t orig) {
@@ -18935,8 +18996,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_is_ok"))) TS_CResult_NodeAnnouncementDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeAnnouncementDecodeErrorZ* o_conv = (LDKCResult_NodeAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_free"))) TS_CResult_NodeAnnouncementDecodeErrorZ_free(uint32_t _res) {
@@ -18955,8 +19016,8 @@ static inline uintptr_t CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_clone_ptr"))) TS_CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NodeAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_NodeAnnouncementDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_clone"))) TS_CResult_NodeAnnouncementDecodeErrorZ_clone(uint32_t orig) {
@@ -18990,8 +19051,8 @@ uint32_t  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeError
 
 jboolean  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeErrorZ_is_ok"))) TS_CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_QueryShortChannelIdsDecodeErrorZ* o_conv = (LDKCResult_QueryShortChannelIdsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeErrorZ_free"))) TS_CResult_QueryShortChannelIdsDecodeErrorZ_free(uint32_t _res) {
@@ -19010,8 +19071,8 @@ static inline uintptr_t CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(LDKCR
 }
 uint32_t  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr"))) TS_CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_QueryShortChannelIdsDecodeErrorZ* arg_conv = (LDKCResult_QueryShortChannelIdsDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeErrorZ_clone"))) TS_CResult_QueryShortChannelIdsDecodeErrorZ_clone(uint32_t orig) {
@@ -19045,8 +19106,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeEr
 
 jboolean  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok"))) TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ* o_conv = (LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_free"))) TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_free(uint32_t _res) {
@@ -19065,8 +19126,8 @@ static inline uintptr_t CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(LD
 }
 uint32_t  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr"))) TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ* arg_conv = (LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone"))) TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone(uint32_t orig) {
@@ -19100,8 +19161,8 @@ uint32_t  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_is_ok"))) TS_CResult_QueryChannelRangeDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_QueryChannelRangeDecodeErrorZ* o_conv = (LDKCResult_QueryChannelRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_QueryChannelRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_QueryChannelRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_free"))) TS_CResult_QueryChannelRangeDecodeErrorZ_free(uint32_t _res) {
@@ -19120,8 +19181,8 @@ static inline uintptr_t CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_clone_ptr"))) TS_CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_QueryChannelRangeDecodeErrorZ* arg_conv = (LDKCResult_QueryChannelRangeDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_clone"))) TS_CResult_QueryChannelRangeDecodeErrorZ_clone(uint32_t orig) {
@@ -19155,8 +19216,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_is_ok"))) TS_CResult_ReplyChannelRangeDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ReplyChannelRangeDecodeErrorZ* o_conv = (LDKCResult_ReplyChannelRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ReplyChannelRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ReplyChannelRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_free"))) TS_CResult_ReplyChannelRangeDecodeErrorZ_free(uint32_t _res) {
@@ -19175,8 +19236,8 @@ static inline uintptr_t CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr"))) TS_CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ReplyChannelRangeDecodeErrorZ* arg_conv = (LDKCResult_ReplyChannelRangeDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_clone"))) TS_CResult_ReplyChannelRangeDecodeErrorZ_clone(uint32_t orig) {
@@ -19210,8 +19271,8 @@ uint32_t  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErrorZ_is_ok"))) TS_CResult_GossipTimestampFilterDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_GossipTimestampFilterDecodeErrorZ* o_conv = (LDKCResult_GossipTimestampFilterDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_GossipTimestampFilterDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_GossipTimestampFilterDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErrorZ_free"))) TS_CResult_GossipTimestampFilterDecodeErrorZ_free(uint32_t _res) {
@@ -19230,8 +19291,8 @@ static inline uintptr_t CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr"))) TS_CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_GossipTimestampFilterDecodeErrorZ* arg_conv = (LDKCResult_GossipTimestampFilterDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErrorZ_clone"))) TS_CResult_GossipTimestampFilterDecodeErrorZ_clone(uint32_t orig) {
@@ -19264,8 +19325,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_is_ok"))) TS_CResult_InvoiceSignOrCreationErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InvoiceSignOrCreationErrorZ* o_conv = (LDKCResult_InvoiceSignOrCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceSignOrCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceSignOrCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_free"))) TS_CResult_InvoiceSignOrCreationErrorZ_free(uint32_t _res) {
@@ -19284,8 +19345,8 @@ static inline uintptr_t CResult_InvoiceSignOrCreationErrorZ_clone_ptr(LDKCResult
 }
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_clone_ptr"))) TS_CResult_InvoiceSignOrCreationErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InvoiceSignOrCreationErrorZ* arg_conv = (LDKCResult_InvoiceSignOrCreationErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InvoiceSignOrCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InvoiceSignOrCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_clone"))) TS_CResult_InvoiceSignOrCreationErrorZ_clone(uint32_t orig) {
@@ -19344,8 +19405,8 @@ uint32_t  __attribute__((export_name("TS_CResult_LockedChannelMonitorNoneZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_LockedChannelMonitorNoneZ_is_ok"))) TS_CResult_LockedChannelMonitorNoneZ_is_ok(uint32_t o) {
 	LDKCResult_LockedChannelMonitorNoneZ* o_conv = (LDKCResult_LockedChannelMonitorNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_LockedChannelMonitorNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_LockedChannelMonitorNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_LockedChannelMonitorNoneZ_free"))) TS_CResult_LockedChannelMonitorNoneZ_free(uint32_t _res) {
@@ -19393,8 +19454,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_PaymentPurpose_clone_ptr"))) TS_PaymentPurpose_clone_ptr(uint32_t arg) {
 	LDKPaymentPurpose* arg_conv = (LDKPaymentPurpose*)arg;
-	uint32_t ret_val = PaymentPurpose_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PaymentPurpose_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PaymentPurpose_clone"))) TS_PaymentPurpose_clone(uint32_t orig) {
@@ -19445,8 +19506,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_ClosureReason_clone_ptr"))) TS_ClosureReason_clone_ptr(uint32_t arg) {
 	LDKClosureReason* arg_conv = (LDKClosureReason*)arg;
-	uint32_t ret_val = ClosureReason_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ClosureReason_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosureReason_clone"))) TS_ClosureReason_clone(uint32_t orig) {
@@ -19550,8 +19611,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_Event_clone_ptr"))) TS_Event_clone_ptr(uint32_t arg) {
 	LDKEvent* arg_conv = (LDKEvent*)arg;
-	uint32_t ret_val = Event_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Event_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Event_clone"))) TS_Event_clone(uint32_t orig) {
@@ -19816,8 +19877,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_MessageSendEvent_clone_ptr"))) TS_MessageSendEvent_clone_ptr(uint32_t arg) {
 	LDKMessageSendEvent* arg_conv = (LDKMessageSendEvent*)arg;
-	uint32_t ret_val = MessageSendEvent_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = MessageSendEvent_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_MessageSendEvent_clone"))) TS_MessageSendEvent_clone(uint32_t orig) {
@@ -20167,8 +20228,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_APIError_clone_ptr"))) TS_APIError_clone_ptr(uint32_t arg) {
 	LDKAPIError* arg_conv = (LDKAPIError*)arg;
-	uint32_t ret_val = APIError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = APIError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_APIError_clone"))) TS_APIError_clone(uint32_t orig) {
@@ -20261,8 +20322,8 @@ jboolean  __attribute__((export_name("TS_verify"))) TS_verify(int8_tArray msg, j
 	LDKPublicKey pk_ref;
 	CHECK(pk->arr_len == 33);
 	memcpy(pk_ref.compressed_form, pk->elems, 33); FREE(pk);
-	jboolean ret_val = verify(msg_ref, sig_conv, pk_ref);
-	return ret_val;
+	jboolean ret_conv = verify(msg_ref, sig_conv, pk_ref);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_construct_invoice_preimage"))) TS_construct_invoice_preimage(int8_tArray hrp_bytes, ptrArray data_without_signature) {
@@ -20327,14 +20388,14 @@ uint32_t  __attribute__((export_name("TS_Level_error"))) TS_Level_error() {
 jboolean  __attribute__((export_name("TS_Level_eq"))) TS_Level_eq(uint32_t a, uint32_t b) {
 	LDKLevel* a_conv = (LDKLevel*)(a & ~1);
 	LDKLevel* b_conv = (LDKLevel*)(b & ~1);
-	jboolean ret_val = Level_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Level_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_Level_hash"))) TS_Level_hash(uint32_t o) {
 	LDKLevel* o_conv = (LDKLevel*)(o & ~1);
-	int64_t ret_val = Level_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Level_hash(o_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Level_max"))) TS_Level_max() {
@@ -20433,8 +20494,8 @@ int32_t  __attribute__((export_name("TS_Record_get_line"))) TS_Record_get_line(u
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = Record_get_line(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = Record_get_line(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Record_set_line"))) TS_Record_set_line(uint32_t this_ptr, int32_t val) {
@@ -20462,8 +20523,8 @@ uint32_t  __attribute__((export_name("TS_Record_clone_ptr"))) TS_Record_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Record_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Record_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Record_clone"))) TS_Record_clone(uint32_t orig) {
@@ -20505,8 +20566,8 @@ int32_t  __attribute__((export_name("TS_ChannelHandshakeConfig_get_minimum_depth
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelHandshakeConfig_get_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelHandshakeConfig_get_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeConfig_set_minimum_depth"))) TS_ChannelHandshakeConfig_set_minimum_depth(uint32_t this_ptr, int32_t val) {
@@ -20522,8 +20583,8 @@ int16_t  __attribute__((export_name("TS_ChannelHandshakeConfig_get_our_to_self_d
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeConfig_get_our_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeConfig_get_our_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeConfig_set_our_to_self_delay"))) TS_ChannelHandshakeConfig_set_our_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -20539,8 +20600,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeConfig_get_our_htlc_mini
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeConfig_get_our_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeConfig_get_our_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeConfig_set_our_htlc_minimum_msat"))) TS_ChannelHandshakeConfig_set_our_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -20556,8 +20617,8 @@ jboolean  __attribute__((export_name("TS_ChannelHandshakeConfig_get_negotiate_sc
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelHandshakeConfig_get_negotiate_scid_privacy(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelHandshakeConfig_get_negotiate_scid_privacy(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeConfig_set_negotiate_scid_privacy"))) TS_ChannelHandshakeConfig_set_negotiate_scid_privacy(uint32_t this_ptr, jboolean val) {
@@ -20598,8 +20659,8 @@ uint32_t  __attribute__((export_name("TS_ChannelHandshakeConfig_clone_ptr"))) TS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelHandshakeConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelHandshakeConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelHandshakeConfig_clone"))) TS_ChannelHandshakeConfig_clone(uint32_t orig) {
@@ -20645,8 +20706,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_min_funding_s
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_min_funding_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_min_funding_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_min_funding_satoshis"))) TS_ChannelHandshakeLimits_set_min_funding_satoshis(uint32_t this_ptr, int64_t val) {
@@ -20662,8 +20723,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_max_htlc_mini
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_max_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_max_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_max_htlc_minimum_msat"))) TS_ChannelHandshakeLimits_set_max_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -20679,8 +20740,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_min_max_htlc_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_min_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_min_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_min_max_htlc_value_in_flight_msat"))) TS_ChannelHandshakeLimits_set_min_max_htlc_value_in_flight_msat(uint32_t this_ptr, int64_t val) {
@@ -20696,8 +20757,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_max_channel_r
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_max_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_max_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_max_channel_reserve_satoshis"))) TS_ChannelHandshakeLimits_set_max_channel_reserve_satoshis(uint32_t this_ptr, int64_t val) {
@@ -20713,8 +20774,8 @@ int16_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_min_max_accep
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeLimits_get_min_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeLimits_get_min_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_min_max_accepted_htlcs"))) TS_ChannelHandshakeLimits_set_min_max_accepted_htlcs(uint32_t this_ptr, int16_t val) {
@@ -20730,8 +20791,8 @@ int32_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_max_minimum_d
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelHandshakeLimits_get_max_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelHandshakeLimits_get_max_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_max_minimum_depth"))) TS_ChannelHandshakeLimits_set_max_minimum_depth(uint32_t this_ptr, int32_t val) {
@@ -20747,8 +20808,8 @@ jboolean  __attribute__((export_name("TS_ChannelHandshakeLimits_get_force_announ
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelHandshakeLimits_get_force_announced_channel_preference(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelHandshakeLimits_get_force_announced_channel_preference(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_force_announced_channel_preference"))) TS_ChannelHandshakeLimits_set_force_announced_channel_preference(uint32_t this_ptr, jboolean val) {
@@ -20764,8 +20825,8 @@ int16_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_their_to_self
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeLimits_get_their_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeLimits_get_their_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_their_to_self_delay"))) TS_ChannelHandshakeLimits_set_their_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -20806,8 +20867,8 @@ uint32_t  __attribute__((export_name("TS_ChannelHandshakeLimits_clone_ptr"))) TS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelHandshakeLimits_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelHandshakeLimits_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelHandshakeLimits_clone"))) TS_ChannelHandshakeLimits_clone(uint32_t orig) {
@@ -20853,8 +20914,8 @@ int32_t  __attribute__((export_name("TS_ChannelConfig_get_forwarding_fee_proport
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelConfig_get_forwarding_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelConfig_get_forwarding_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_forwarding_fee_proportional_millionths"))) TS_ChannelConfig_set_forwarding_fee_proportional_millionths(uint32_t this_ptr, int32_t val) {
@@ -20870,8 +20931,8 @@ int32_t  __attribute__((export_name("TS_ChannelConfig_get_forwarding_fee_base_ms
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelConfig_get_forwarding_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelConfig_get_forwarding_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_forwarding_fee_base_msat"))) TS_ChannelConfig_set_forwarding_fee_base_msat(uint32_t this_ptr, int32_t val) {
@@ -20887,8 +20948,8 @@ int16_t  __attribute__((export_name("TS_ChannelConfig_get_cltv_expiry_delta"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelConfig_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelConfig_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_cltv_expiry_delta"))) TS_ChannelConfig_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -20904,8 +20965,8 @@ jboolean  __attribute__((export_name("TS_ChannelConfig_get_announced_channel")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelConfig_get_announced_channel(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelConfig_get_announced_channel(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_announced_channel"))) TS_ChannelConfig_set_announced_channel(uint32_t this_ptr, jboolean val) {
@@ -20921,8 +20982,8 @@ jboolean  __attribute__((export_name("TS_ChannelConfig_get_commit_upfront_shutdo
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelConfig_get_commit_upfront_shutdown_pubkey(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelConfig_get_commit_upfront_shutdown_pubkey(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_commit_upfront_shutdown_pubkey"))) TS_ChannelConfig_set_commit_upfront_shutdown_pubkey(uint32_t this_ptr, jboolean val) {
@@ -20938,8 +20999,8 @@ int64_t  __attribute__((export_name("TS_ChannelConfig_get_max_dust_htlc_exposure
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelConfig_get_max_dust_htlc_exposure_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_get_max_dust_htlc_exposure_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_max_dust_htlc_exposure_msat"))) TS_ChannelConfig_set_max_dust_htlc_exposure_msat(uint32_t this_ptr, int64_t val) {
@@ -20955,8 +21016,8 @@ int64_t  __attribute__((export_name("TS_ChannelConfig_get_force_close_avoidance_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelConfig_get_force_close_avoidance_max_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_get_force_close_avoidance_max_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_force_close_avoidance_max_fee_satoshis"))) TS_ChannelConfig_set_force_close_avoidance_max_fee_satoshis(uint32_t this_ptr, int64_t val) {
@@ -20997,8 +21058,8 @@ uint32_t  __attribute__((export_name("TS_ChannelConfig_clone_ptr"))) TS_ChannelC
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelConfig_clone"))) TS_ChannelConfig_clone(uint32_t orig) {
@@ -21155,8 +21216,8 @@ jboolean  __attribute__((export_name("TS_UserConfig_get_accept_forwards_to_priv_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_accept_forwards_to_priv_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_accept_forwards_to_priv_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UserConfig_set_accept_forwards_to_priv_channels"))) TS_UserConfig_set_accept_forwards_to_priv_channels(uint32_t this_ptr, jboolean val) {
@@ -21172,8 +21233,8 @@ jboolean  __attribute__((export_name("TS_UserConfig_get_accept_inbound_channels"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_accept_inbound_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_accept_inbound_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UserConfig_set_accept_inbound_channels"))) TS_UserConfig_set_accept_inbound_channels(uint32_t this_ptr, jboolean val) {
@@ -21189,8 +21250,8 @@ jboolean  __attribute__((export_name("TS_UserConfig_get_manually_accept_inbound_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_manually_accept_inbound_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_manually_accept_inbound_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UserConfig_set_manually_accept_inbound_channels"))) TS_UserConfig_set_manually_accept_inbound_channels(uint32_t this_ptr, jboolean val) {
@@ -21246,8 +21307,8 @@ uint32_t  __attribute__((export_name("TS_UserConfig_clone_ptr"))) TS_UserConfig_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UserConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UserConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UserConfig_clone"))) TS_UserConfig_clone(uint32_t orig) {
@@ -21305,8 +21366,8 @@ uint32_t  __attribute__((export_name("TS_BestBlock_clone_ptr"))) TS_BestBlock_cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = BestBlock_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = BestBlock_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_BestBlock_clone"))) TS_BestBlock_clone(uint32_t orig) {
@@ -21371,8 +21432,8 @@ int32_t  __attribute__((export_name("TS_BestBlock_height"))) TS_BestBlock_height
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = BestBlock_height(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = BestBlock_height(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_AccessError_clone"))) TS_AccessError_clone(uint32_t orig) {
@@ -21576,8 +21637,8 @@ uint32_t  __attribute__((export_name("TS_WatchedOutput_clone_ptr"))) TS_WatchedO
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = WatchedOutput_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = WatchedOutput_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_WatchedOutput_clone"))) TS_WatchedOutput_clone(uint32_t orig) {
@@ -21602,8 +21663,8 @@ int64_t  __attribute__((export_name("TS_WatchedOutput_hash"))) TS_WatchedOutput_
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = WatchedOutput_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = WatchedOutput_hash(&o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_BroadcasterInterface_free"))) TS_BroadcasterInterface_free(uint32_t this_ptr) {
@@ -21639,8 +21700,8 @@ uint32_t  __attribute__((export_name("TS_ConfirmationTarget_high_priority"))) TS
 jboolean  __attribute__((export_name("TS_ConfirmationTarget_eq"))) TS_ConfirmationTarget_eq(uint32_t a, uint32_t b) {
 	LDKConfirmationTarget* a_conv = (LDKConfirmationTarget*)(a & ~1);
 	LDKConfirmationTarget* b_conv = (LDKConfirmationTarget*)(b & ~1);
-	jboolean ret_val = ConfirmationTarget_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = ConfirmationTarget_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_FeeEstimator_free"))) TS_FeeEstimator_free(uint32_t this_ptr) {
@@ -21677,8 +21738,8 @@ uint32_t  __attribute__((export_name("TS_MonitorUpdateId_clone_ptr"))) TS_Monito
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = MonitorUpdateId_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = MonitorUpdateId_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_MonitorUpdateId_clone"))) TS_MonitorUpdateId_clone(uint32_t orig) {
@@ -21703,8 +21764,8 @@ int64_t  __attribute__((export_name("TS_MonitorUpdateId_hash"))) TS_MonitorUpdat
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = MonitorUpdateId_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = MonitorUpdateId_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_MonitorUpdateId_eq"))) TS_MonitorUpdateId_eq(uint32_t a, uint32_t b) {
@@ -21716,8 +21777,8 @@ jboolean  __attribute__((export_name("TS_MonitorUpdateId_eq"))) TS_MonitorUpdate
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = MonitorUpdateId_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = MonitorUpdateId_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Persist_free"))) TS_Persist_free(uint32_t this_ptr) {
@@ -21947,8 +22008,8 @@ int64_t  __attribute__((export_name("TS_ChannelMonitorUpdate_get_update_id"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelMonitorUpdate_get_update_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitorUpdate_get_update_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelMonitorUpdate_set_update_id"))) TS_ChannelMonitorUpdate_set_update_id(uint32_t this_ptr, int64_t val) {
@@ -21976,8 +22037,8 @@ uint32_t  __attribute__((export_name("TS_ChannelMonitorUpdate_clone_ptr"))) TS_C
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelMonitorUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelMonitorUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelMonitorUpdate_clone"))) TS_ChannelMonitorUpdate_clone(uint32_t orig) {
@@ -22035,8 +22096,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_MonitorEvent_clone_ptr"))) TS_MonitorEvent_clone_ptr(uint32_t arg) {
 	LDKMonitorEvent* arg_conv = (LDKMonitorEvent*)arg;
-	uint32_t ret_val = MonitorEvent_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = MonitorEvent_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_MonitorEvent_clone"))) TS_MonitorEvent_clone(uint32_t orig) {
@@ -22138,8 +22199,8 @@ uint32_t  __attribute__((export_name("TS_HTLCUpdate_clone_ptr"))) TS_HTLCUpdate_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = HTLCUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = HTLCUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_HTLCUpdate_clone"))) TS_HTLCUpdate_clone(uint32_t orig) {
@@ -22197,8 +22258,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_Balance_clone_ptr"))) TS_Balance_clone_ptr(uint32_t arg) {
 	LDKBalance* arg_conv = (LDKBalance*)arg;
-	uint32_t ret_val = Balance_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Balance_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Balance_clone"))) TS_Balance_clone(uint32_t orig) {
@@ -22240,8 +22301,8 @@ uint32_t  __attribute__((export_name("TS_Balance_maybe_claimable_htlcawaiting_ti
 jboolean  __attribute__((export_name("TS_Balance_eq"))) TS_Balance_eq(uint32_t a, uint32_t b) {
 	LDKBalance* a_conv = (LDKBalance*)a;
 	LDKBalance* b_conv = (LDKBalance*)b;
-	jboolean ret_val = Balance_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Balance_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelMonitor_free"))) TS_ChannelMonitor_free(uint32_t this_obj) {
@@ -22269,8 +22330,8 @@ uint32_t  __attribute__((export_name("TS_ChannelMonitor_clone_ptr"))) TS_Channel
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelMonitor_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelMonitor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelMonitor_clone"))) TS_ChannelMonitor_clone(uint32_t orig) {
@@ -22330,8 +22391,8 @@ int64_t  __attribute__((export_name("TS_ChannelMonitor_get_latest_update_id"))) 
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ChannelMonitor_get_latest_update_id(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitor_get_latest_update_id(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelMonitor_get_funding_txo"))) TS_ChannelMonitor_get_funding_txo(uint32_t this_arg) {
@@ -22768,8 +22829,8 @@ int16_t  __attribute__((export_name("TS_OutPoint_get_index"))) TS_OutPoint_get_i
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OutPoint_get_index(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OutPoint_get_index(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OutPoint_set_index"))) TS_OutPoint_set_index(uint32_t this_ptr, int16_t val) {
@@ -22813,8 +22874,8 @@ uint32_t  __attribute__((export_name("TS_OutPoint_clone_ptr"))) TS_OutPoint_clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = OutPoint_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = OutPoint_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_OutPoint_clone"))) TS_OutPoint_clone(uint32_t orig) {
@@ -22843,8 +22904,8 @@ jboolean  __attribute__((export_name("TS_OutPoint_eq"))) TS_OutPoint_eq(uint32_t
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = OutPoint_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = OutPoint_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_OutPoint_hash"))) TS_OutPoint_hash(uint32_t o) {
@@ -22852,8 +22913,8 @@ int64_t  __attribute__((export_name("TS_OutPoint_hash"))) TS_OutPoint_hash(uint3
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = OutPoint_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = OutPoint_hash(&o_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_OutPoint_to_channel_id"))) TS_OutPoint_to_channel_id(uint32_t this_arg) {
@@ -22951,8 +23012,8 @@ int16_t  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_get_to_se
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = DelayedPaymentOutputDescriptor_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = DelayedPaymentOutputDescriptor_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_set_to_self_delay"))) TS_DelayedPaymentOutputDescriptor_set_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -23022,8 +23083,8 @@ int64_t  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_get_chann
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = DelayedPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = DelayedPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_set_channel_value_satoshis"))) TS_DelayedPaymentOutputDescriptor_set_channel_value_satoshis(uint32_t this_ptr, int64_t val) {
@@ -23082,8 +23143,8 @@ uint32_t  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = DelayedPaymentOutputDescriptor_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = DelayedPaymentOutputDescriptor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_clone"))) TS_DelayedPaymentOutputDescriptor_clone(uint32_t orig) {
@@ -23200,8 +23261,8 @@ int64_t  __attribute__((export_name("TS_StaticPaymentOutputDescriptor_get_channe
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = StaticPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = StaticPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_StaticPaymentOutputDescriptor_set_channel_value_satoshis"))) TS_StaticPaymentOutputDescriptor_set_channel_value_satoshis(uint32_t this_ptr, int64_t val) {
@@ -23254,8 +23315,8 @@ uint32_t  __attribute__((export_name("TS_StaticPaymentOutputDescriptor_clone_ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = StaticPaymentOutputDescriptor_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = StaticPaymentOutputDescriptor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_StaticPaymentOutputDescriptor_clone"))) TS_StaticPaymentOutputDescriptor_clone(uint32_t orig) {
@@ -23313,8 +23374,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_SpendableOutputDescriptor_clone_ptr"))) TS_SpendableOutputDescriptor_clone_ptr(uint32_t arg) {
 	LDKSpendableOutputDescriptor* arg_conv = (LDKSpendableOutputDescriptor*)arg;
-	uint32_t ret_val = SpendableOutputDescriptor_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = SpendableOutputDescriptor_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SpendableOutputDescriptor_clone"))) TS_SpendableOutputDescriptor_clone(uint32_t orig) {
@@ -23401,8 +23462,8 @@ uint32_t  __attribute__((export_name("TS_Sign_clone_ptr"))) TS_Sign_clone_ptr(ui
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKSign* arg_conv = (LDKSign*)arg_ptr;
-	uint32_t ret_val = Sign_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Sign_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Sign_clone"))) TS_Sign_clone(uint32_t orig) {
@@ -23599,8 +23660,8 @@ uint32_t  __attribute__((export_name("TS_InMemorySigner_clone_ptr"))) TS_InMemor
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InMemorySigner_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InMemorySigner_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InMemorySigner_clone"))) TS_InMemorySigner_clone(uint32_t orig) {
@@ -23679,8 +23740,8 @@ int16_t  __attribute__((export_name("TS_InMemorySigner_counterparty_selected_con
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = InMemorySigner_counterparty_selected_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = InMemorySigner_counterparty_selected_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 int16_t  __attribute__((export_name("TS_InMemorySigner_holder_selected_contest_delay"))) TS_InMemorySigner_holder_selected_contest_delay(uint32_t this_arg) {
@@ -23688,8 +23749,8 @@ int16_t  __attribute__((export_name("TS_InMemorySigner_holder_selected_contest_d
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = InMemorySigner_holder_selected_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = InMemorySigner_holder_selected_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_InMemorySigner_is_outbound"))) TS_InMemorySigner_is_outbound(uint32_t this_arg) {
@@ -23697,8 +23758,8 @@ jboolean  __attribute__((export_name("TS_InMemorySigner_is_outbound"))) TS_InMem
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InMemorySigner_is_outbound(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InMemorySigner_is_outbound(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InMemorySigner_funding_outpoint"))) TS_InMemorySigner_funding_outpoint(uint32_t this_arg) {
@@ -23740,8 +23801,8 @@ jboolean  __attribute__((export_name("TS_InMemorySigner_opt_anchors"))) TS_InMem
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InMemorySigner_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InMemorySigner_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InMemorySigner_sign_counterparty_payment_input"))) TS_InMemorySigner_sign_counterparty_payment_input(uint32_t this_arg, int8_tArray spend_tx, uint32_t input_idx, uint32_t descriptor) {
@@ -24130,8 +24191,8 @@ uint32_t  __attribute__((export_name("TS_ChainParameters_clone_ptr"))) TS_ChainP
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChainParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChainParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChainParameters_clone"))) TS_ChainParameters_clone(uint32_t orig) {
@@ -24164,8 +24225,8 @@ int32_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_get_fee_base_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = CounterpartyForwardingInfo_get_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = CounterpartyForwardingInfo_get_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CounterpartyForwardingInfo_set_fee_base_msat"))) TS_CounterpartyForwardingInfo_set_fee_base_msat(uint32_t this_ptr, int32_t val) {
@@ -24181,8 +24242,8 @@ int32_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_get_fee_propo
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = CounterpartyForwardingInfo_get_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = CounterpartyForwardingInfo_get_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CounterpartyForwardingInfo_set_fee_proportional_millionths"))) TS_CounterpartyForwardingInfo_set_fee_proportional_millionths(uint32_t this_ptr, int32_t val) {
@@ -24198,8 +24259,8 @@ int16_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_get_cltv_expi
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = CounterpartyForwardingInfo_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = CounterpartyForwardingInfo_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CounterpartyForwardingInfo_set_cltv_expiry_delta"))) TS_CounterpartyForwardingInfo_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -24240,8 +24301,8 @@ uint32_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_clone_ptr"))
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CounterpartyForwardingInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CounterpartyForwardingInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_clone"))) TS_CounterpartyForwardingInfo_clone(uint32_t orig) {
@@ -24325,8 +24386,8 @@ int64_t  __attribute__((export_name("TS_ChannelCounterparty_get_unspendable_puni
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelCounterparty_get_unspendable_punishment_reserve(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelCounterparty_get_unspendable_punishment_reserve(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelCounterparty_set_unspendable_punishment_reserve"))) TS_ChannelCounterparty_set_unspendable_punishment_reserve(uint32_t this_ptr, int64_t val) {
@@ -24412,8 +24473,8 @@ uint32_t  __attribute__((export_name("TS_ChannelCounterparty_clone_ptr"))) TS_Ch
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelCounterparty_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelCounterparty_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelCounterparty_clone"))) TS_ChannelCounterparty_clone(uint32_t orig) {
@@ -24607,8 +24668,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_channel_value_satoshi
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_channel_value_satoshis"))) TS_ChannelDetails_set_channel_value_satoshis(uint32_t this_ptr, int64_t val) {
@@ -24647,8 +24708,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_user_channel_id"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_user_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_user_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_user_channel_id"))) TS_ChannelDetails_set_user_channel_id(uint32_t this_ptr, int64_t val) {
@@ -24664,8 +24725,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_balance_msat"))) TS_C
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_balance_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_balance_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_balance_msat"))) TS_ChannelDetails_set_balance_msat(uint32_t this_ptr, int64_t val) {
@@ -24681,8 +24742,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_outbound_capacity_msa
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_outbound_capacity_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_outbound_capacity_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_outbound_capacity_msat"))) TS_ChannelDetails_set_outbound_capacity_msat(uint32_t this_ptr, int64_t val) {
@@ -24698,8 +24759,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_inbound_capacity_msat
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_inbound_capacity_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_inbound_capacity_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_inbound_capacity_msat"))) TS_ChannelDetails_set_inbound_capacity_msat(uint32_t this_ptr, int64_t val) {
@@ -24761,8 +24822,8 @@ jboolean  __attribute__((export_name("TS_ChannelDetails_get_is_outbound"))) TS_C
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_outbound(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_outbound(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_is_outbound"))) TS_ChannelDetails_set_is_outbound(uint32_t this_ptr, jboolean val) {
@@ -24778,8 +24839,8 @@ jboolean  __attribute__((export_name("TS_ChannelDetails_get_is_funding_locked"))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_funding_locked(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_funding_locked(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_is_funding_locked"))) TS_ChannelDetails_set_is_funding_locked(uint32_t this_ptr, jboolean val) {
@@ -24795,8 +24856,8 @@ jboolean  __attribute__((export_name("TS_ChannelDetails_get_is_usable"))) TS_Cha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_usable(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_usable(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_is_usable"))) TS_ChannelDetails_set_is_usable(uint32_t this_ptr, jboolean val) {
@@ -24812,8 +24873,8 @@ jboolean  __attribute__((export_name("TS_ChannelDetails_get_is_public"))) TS_Cha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_public(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_public(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_is_public"))) TS_ChannelDetails_set_is_public(uint32_t this_ptr, jboolean val) {
@@ -24891,8 +24952,8 @@ uint32_t  __attribute__((export_name("TS_ChannelDetails_clone_ptr"))) TS_Channel
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelDetails_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelDetails_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelDetails_clone"))) TS_ChannelDetails_clone(uint32_t orig) {
@@ -24940,8 +25001,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_PaymentSendFailure_clone_ptr"))) TS_PaymentSendFailure_clone_ptr(uint32_t arg) {
 	LDKPaymentSendFailure* arg_conv = (LDKPaymentSendFailure*)arg;
-	uint32_t ret_val = PaymentSendFailure_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PaymentSendFailure_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PaymentSendFailure_clone"))) TS_PaymentSendFailure_clone(uint32_t orig) {
@@ -25099,8 +25160,8 @@ int64_t  __attribute__((export_name("TS_PhantomRouteHints_get_phantom_scid"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = PhantomRouteHints_get_phantom_scid(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = PhantomRouteHints_get_phantom_scid(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PhantomRouteHints_set_phantom_scid"))) TS_PhantomRouteHints_set_phantom_scid(uint32_t this_ptr, int64_t val) {
@@ -25181,8 +25242,8 @@ uint32_t  __attribute__((export_name("TS_PhantomRouteHints_clone_ptr"))) TS_Phan
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PhantomRouteHints_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PhantomRouteHints_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PhantomRouteHints_clone"))) TS_PhantomRouteHints_clone(uint32_t orig) {
@@ -25534,8 +25595,8 @@ jboolean  __attribute__((export_name("TS_ChannelManager_fail_htlc_backwards"))) 
 	CHECK(payment_hash->arr_len == 32);
 	memcpy(payment_hash_arr, payment_hash->elems, 32); FREE(payment_hash);
 	unsigned char (*payment_hash_ref)[32] = &payment_hash_arr;
-	jboolean ret_val = ChannelManager_fail_htlc_backwards(&this_arg_conv, payment_hash_ref);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_fail_htlc_backwards(&this_arg_conv, payment_hash_ref);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_ChannelManager_claim_funds"))) TS_ChannelManager_claim_funds(uint32_t this_arg, int8_tArray payment_preimage) {
@@ -25546,8 +25607,8 @@ jboolean  __attribute__((export_name("TS_ChannelManager_claim_funds"))) TS_Chann
 	LDKThirtyTwoBytes payment_preimage_ref;
 	CHECK(payment_preimage->arr_len == 32);
 	memcpy(payment_preimage_ref.data, payment_preimage->elems, 32); FREE(payment_preimage);
-	jboolean ret_val = ChannelManager_claim_funds(&this_arg_conv, payment_preimage_ref);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_claim_funds(&this_arg_conv, payment_preimage_ref);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_ChannelManager_get_our_node_id"))) TS_ChannelManager_get_our_node_id(uint32_t this_arg) {
@@ -25657,8 +25718,8 @@ int64_t  __attribute__((export_name("TS_ChannelManager_get_phantom_scid"))) TS_C
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ChannelManager_get_phantom_scid(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelManager_get_phantom_scid(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelManager_get_phantom_route_hints"))) TS_ChannelManager_get_phantom_route_hints(uint32_t this_arg) {
@@ -26119,8 +26180,8 @@ uint32_t  __attribute__((export_name("TS_DecodeError_clone_ptr"))) TS_DecodeErro
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = DecodeError_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = DecodeError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DecodeError_clone"))) TS_DecodeError_clone(uint32_t orig) {
@@ -26239,8 +26300,8 @@ uint32_t  __attribute__((export_name("TS_Init_clone_ptr"))) TS_Init_clone_ptr(ui
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Init_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Init_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Init_clone"))) TS_Init_clone(uint32_t orig) {
@@ -26343,8 +26404,8 @@ uint32_t  __attribute__((export_name("TS_ErrorMessage_clone_ptr"))) TS_ErrorMess
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ErrorMessage_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ErrorMessage_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ErrorMessage_clone"))) TS_ErrorMessage_clone(uint32_t orig) {
@@ -26447,8 +26508,8 @@ uint32_t  __attribute__((export_name("TS_WarningMessage_clone_ptr"))) TS_Warning
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = WarningMessage_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = WarningMessage_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_WarningMessage_clone"))) TS_WarningMessage_clone(uint32_t orig) {
@@ -26481,8 +26542,8 @@ int16_t  __attribute__((export_name("TS_Ping_get_ponglen"))) TS_Ping_get_ponglen
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Ping_get_ponglen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Ping_get_ponglen(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Ping_set_ponglen"))) TS_Ping_set_ponglen(uint32_t this_ptr, int16_t val) {
@@ -26498,8 +26559,8 @@ int16_t  __attribute__((export_name("TS_Ping_get_byteslen"))) TS_Ping_get_bytesl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Ping_get_byteslen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Ping_get_byteslen(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Ping_set_byteslen"))) TS_Ping_set_byteslen(uint32_t this_ptr, int16_t val) {
@@ -26540,8 +26601,8 @@ uint32_t  __attribute__((export_name("TS_Ping_clone_ptr"))) TS_Ping_clone_ptr(ui
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Ping_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Ping_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Ping_clone"))) TS_Ping_clone(uint32_t orig) {
@@ -26574,8 +26635,8 @@ int16_t  __attribute__((export_name("TS_Pong_get_byteslen"))) TS_Pong_get_bytesl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Pong_get_byteslen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Pong_get_byteslen(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Pong_set_byteslen"))) TS_Pong_set_byteslen(uint32_t this_ptr, int16_t val) {
@@ -26616,8 +26677,8 @@ uint32_t  __attribute__((export_name("TS_Pong_clone_ptr"))) TS_Pong_clone_ptr(ui
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Pong_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Pong_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Pong_clone"))) TS_Pong_clone(uint32_t orig) {
@@ -26692,8 +26753,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_funding_satoshis"))) TS_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_funding_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_funding_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_funding_satoshis"))) TS_OpenChannel_set_funding_satoshis(uint32_t this_ptr, int64_t val) {
@@ -26709,8 +26770,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_push_msat"))) TS_OpenCha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_push_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_push_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_push_msat"))) TS_OpenChannel_set_push_msat(uint32_t this_ptr, int64_t val) {
@@ -26726,8 +26787,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_dust_limit_satoshis"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_dust_limit_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_dust_limit_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_dust_limit_satoshis"))) TS_OpenChannel_set_dust_limit_satoshis(uint32_t this_ptr, int64_t val) {
@@ -26743,8 +26804,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_max_htlc_value_in_flight
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_max_htlc_value_in_flight_msat"))) TS_OpenChannel_set_max_htlc_value_in_flight_msat(uint32_t this_ptr, int64_t val) {
@@ -26760,8 +26821,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_channel_reserve_satoshis
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_channel_reserve_satoshis"))) TS_OpenChannel_set_channel_reserve_satoshis(uint32_t this_ptr, int64_t val) {
@@ -26777,8 +26838,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_htlc_minimum_msat"))) TS
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_htlc_minimum_msat"))) TS_OpenChannel_set_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -26794,8 +26855,8 @@ int32_t  __attribute__((export_name("TS_OpenChannel_get_feerate_per_kw"))) TS_Op
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = OpenChannel_get_feerate_per_kw(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = OpenChannel_get_feerate_per_kw(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_feerate_per_kw"))) TS_OpenChannel_set_feerate_per_kw(uint32_t this_ptr, int32_t val) {
@@ -26811,8 +26872,8 @@ int16_t  __attribute__((export_name("TS_OpenChannel_get_to_self_delay"))) TS_Ope
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OpenChannel_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OpenChannel_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_to_self_delay"))) TS_OpenChannel_set_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -26828,8 +26889,8 @@ int16_t  __attribute__((export_name("TS_OpenChannel_get_max_accepted_htlcs"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OpenChannel_get_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OpenChannel_get_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_max_accepted_htlcs"))) TS_OpenChannel_set_max_accepted_htlcs(uint32_t this_ptr, int16_t val) {
@@ -26971,8 +27032,8 @@ int8_t  __attribute__((export_name("TS_OpenChannel_get_channel_flags"))) TS_Open
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int8_t ret_val = OpenChannel_get_channel_flags(&this_ptr_conv);
-	return ret_val;
+	int8_t ret_conv = OpenChannel_get_channel_flags(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_channel_flags"))) TS_OpenChannel_set_channel_flags(uint32_t this_ptr, int8_t val) {
@@ -27032,8 +27093,8 @@ uint32_t  __attribute__((export_name("TS_OpenChannel_clone_ptr"))) TS_OpenChanne
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = OpenChannel_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = OpenChannel_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_OpenChannel_clone"))) TS_OpenChannel_clone(uint32_t orig) {
@@ -27087,8 +27148,8 @@ int64_t  __attribute__((export_name("TS_AcceptChannel_get_dust_limit_satoshis"))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_dust_limit_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_dust_limit_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_dust_limit_satoshis"))) TS_AcceptChannel_set_dust_limit_satoshis(uint32_t this_ptr, int64_t val) {
@@ -27104,8 +27165,8 @@ int64_t  __attribute__((export_name("TS_AcceptChannel_get_max_htlc_value_in_flig
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_max_htlc_value_in_flight_msat"))) TS_AcceptChannel_set_max_htlc_value_in_flight_msat(uint32_t this_ptr, int64_t val) {
@@ -27121,8 +27182,8 @@ int64_t  __attribute__((export_name("TS_AcceptChannel_get_channel_reserve_satosh
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_channel_reserve_satoshis"))) TS_AcceptChannel_set_channel_reserve_satoshis(uint32_t this_ptr, int64_t val) {
@@ -27138,8 +27199,8 @@ int64_t  __attribute__((export_name("TS_AcceptChannel_get_htlc_minimum_msat"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_htlc_minimum_msat"))) TS_AcceptChannel_set_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -27155,8 +27216,8 @@ int32_t  __attribute__((export_name("TS_AcceptChannel_get_minimum_depth"))) TS_A
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = AcceptChannel_get_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = AcceptChannel_get_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_minimum_depth"))) TS_AcceptChannel_set_minimum_depth(uint32_t this_ptr, int32_t val) {
@@ -27172,8 +27233,8 @@ int16_t  __attribute__((export_name("TS_AcceptChannel_get_to_self_delay"))) TS_A
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = AcceptChannel_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = AcceptChannel_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_to_self_delay"))) TS_AcceptChannel_set_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -27189,8 +27250,8 @@ int16_t  __attribute__((export_name("TS_AcceptChannel_get_max_accepted_htlcs")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = AcceptChannel_get_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = AcceptChannel_get_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_max_accepted_htlcs"))) TS_AcceptChannel_set_max_accepted_htlcs(uint32_t this_ptr, int16_t val) {
@@ -27376,8 +27437,8 @@ uint32_t  __attribute__((export_name("TS_AcceptChannel_clone_ptr"))) TS_AcceptCh
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = AcceptChannel_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = AcceptChannel_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_AcceptChannel_clone"))) TS_AcceptChannel_clone(uint32_t orig) {
@@ -27452,8 +27513,8 @@ int16_t  __attribute__((export_name("TS_FundingCreated_get_funding_output_index"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = FundingCreated_get_funding_output_index(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = FundingCreated_get_funding_output_index(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_FundingCreated_set_funding_output_index"))) TS_FundingCreated_set_funding_output_index(uint32_t this_ptr, int16_t val) {
@@ -27524,8 +27585,8 @@ uint32_t  __attribute__((export_name("TS_FundingCreated_clone_ptr"))) TS_Funding
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = FundingCreated_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = FundingCreated_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_FundingCreated_clone"))) TS_FundingCreated_clone(uint32_t orig) {
@@ -27631,8 +27692,8 @@ uint32_t  __attribute__((export_name("TS_FundingSigned_clone_ptr"))) TS_FundingS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = FundingSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = FundingSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_FundingSigned_clone"))) TS_FundingSigned_clone(uint32_t orig) {
@@ -27765,8 +27826,8 @@ uint32_t  __attribute__((export_name("TS_FundingLocked_clone_ptr"))) TS_FundingL
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = FundingLocked_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = FundingLocked_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_FundingLocked_clone"))) TS_FundingLocked_clone(uint32_t orig) {
@@ -27875,8 +27936,8 @@ uint32_t  __attribute__((export_name("TS_Shutdown_clone_ptr"))) TS_Shutdown_clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Shutdown_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Shutdown_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Shutdown_clone"))) TS_Shutdown_clone(uint32_t orig) {
@@ -27909,8 +27970,8 @@ int64_t  __attribute__((export_name("TS_ClosingSignedFeeRange_get_min_fee_satosh
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSignedFeeRange_get_min_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_get_min_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ClosingSignedFeeRange_set_min_fee_satoshis"))) TS_ClosingSignedFeeRange_set_min_fee_satoshis(uint32_t this_ptr, int64_t val) {
@@ -27926,8 +27987,8 @@ int64_t  __attribute__((export_name("TS_ClosingSignedFeeRange_get_max_fee_satosh
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSignedFeeRange_get_max_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_get_max_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ClosingSignedFeeRange_set_max_fee_satoshis"))) TS_ClosingSignedFeeRange_set_max_fee_satoshis(uint32_t this_ptr, int64_t val) {
@@ -27968,8 +28029,8 @@ uint32_t  __attribute__((export_name("TS_ClosingSignedFeeRange_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ClosingSignedFeeRange_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ClosingSignedFeeRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosingSignedFeeRange_clone"))) TS_ClosingSignedFeeRange_clone(uint32_t orig) {
@@ -28023,8 +28084,8 @@ int64_t  __attribute__((export_name("TS_ClosingSigned_get_fee_satoshis"))) TS_Cl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSigned_get_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSigned_get_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ClosingSigned_set_fee_satoshis"))) TS_ClosingSigned_set_fee_satoshis(uint32_t this_ptr, int64_t val) {
@@ -28129,8 +28190,8 @@ uint32_t  __attribute__((export_name("TS_ClosingSigned_clone_ptr"))) TS_ClosingS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ClosingSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ClosingSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosingSigned_clone"))) TS_ClosingSigned_clone(uint32_t orig) {
@@ -28184,8 +28245,8 @@ int64_t  __attribute__((export_name("TS_UpdateAddHTLC_get_htlc_id"))) TS_UpdateA
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateAddHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateAddHTLC_set_htlc_id"))) TS_UpdateAddHTLC_set_htlc_id(uint32_t this_ptr, int64_t val) {
@@ -28201,8 +28262,8 @@ int64_t  __attribute__((export_name("TS_UpdateAddHTLC_get_amount_msat"))) TS_Upd
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateAddHTLC_get_amount_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_get_amount_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateAddHTLC_set_amount_msat"))) TS_UpdateAddHTLC_set_amount_msat(uint32_t this_ptr, int64_t val) {
@@ -28239,8 +28300,8 @@ int32_t  __attribute__((export_name("TS_UpdateAddHTLC_get_cltv_expiry"))) TS_Upd
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UpdateAddHTLC_get_cltv_expiry(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UpdateAddHTLC_get_cltv_expiry(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateAddHTLC_set_cltv_expiry"))) TS_UpdateAddHTLC_set_cltv_expiry(uint32_t this_ptr, int32_t val) {
@@ -28268,8 +28329,8 @@ uint32_t  __attribute__((export_name("TS_UpdateAddHTLC_clone_ptr"))) TS_UpdateAd
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateAddHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateAddHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateAddHTLC_clone"))) TS_UpdateAddHTLC_clone(uint32_t orig) {
@@ -28323,8 +28384,8 @@ int64_t  __attribute__((export_name("TS_UpdateFulfillHTLC_get_htlc_id"))) TS_Upd
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFulfillHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFulfillHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFulfillHTLC_set_htlc_id"))) TS_UpdateFulfillHTLC_set_htlc_id(uint32_t this_ptr, int64_t val) {
@@ -28392,8 +28453,8 @@ uint32_t  __attribute__((export_name("TS_UpdateFulfillHTLC_clone_ptr"))) TS_Upda
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateFulfillHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateFulfillHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateFulfillHTLC_clone"))) TS_UpdateFulfillHTLC_clone(uint32_t orig) {
@@ -28447,8 +28508,8 @@ int64_t  __attribute__((export_name("TS_UpdateFailHTLC_get_htlc_id"))) TS_Update
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFailHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFailHTLC_set_htlc_id"))) TS_UpdateFailHTLC_set_htlc_id(uint32_t this_ptr, int64_t val) {
@@ -28476,8 +28537,8 @@ uint32_t  __attribute__((export_name("TS_UpdateFailHTLC_clone_ptr"))) TS_UpdateF
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateFailHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateFailHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateFailHTLC_clone"))) TS_UpdateFailHTLC_clone(uint32_t orig) {
@@ -28531,8 +28592,8 @@ int64_t  __attribute__((export_name("TS_UpdateFailMalformedHTLC_get_htlc_id"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFailMalformedHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailMalformedHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFailMalformedHTLC_set_htlc_id"))) TS_UpdateFailMalformedHTLC_set_htlc_id(uint32_t this_ptr, int64_t val) {
@@ -28548,8 +28609,8 @@ int16_t  __attribute__((export_name("TS_UpdateFailMalformedHTLC_get_failure_code
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = UpdateFailMalformedHTLC_get_failure_code(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = UpdateFailMalformedHTLC_get_failure_code(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFailMalformedHTLC_set_failure_code"))) TS_UpdateFailMalformedHTLC_set_failure_code(uint32_t this_ptr, int16_t val) {
@@ -28577,8 +28638,8 @@ uint32_t  __attribute__((export_name("TS_UpdateFailMalformedHTLC_clone_ptr"))) T
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateFailMalformedHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateFailMalformedHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateFailMalformedHTLC_clone"))) TS_UpdateFailMalformedHTLC_clone(uint32_t orig) {
@@ -28720,8 +28781,8 @@ uint32_t  __attribute__((export_name("TS_CommitmentSigned_clone_ptr"))) TS_Commi
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CommitmentSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CommitmentSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CommitmentSigned_clone"))) TS_CommitmentSigned_clone(uint32_t orig) {
@@ -28851,8 +28912,8 @@ uint32_t  __attribute__((export_name("TS_RevokeAndACK_clone_ptr"))) TS_RevokeAnd
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RevokeAndACK_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RevokeAndACK_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RevokeAndACK_clone"))) TS_RevokeAndACK_clone(uint32_t orig) {
@@ -28906,8 +28967,8 @@ int32_t  __attribute__((export_name("TS_UpdateFee_get_feerate_per_kw"))) TS_Upda
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UpdateFee_get_feerate_per_kw(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UpdateFee_get_feerate_per_kw(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFee_set_feerate_per_kw"))) TS_UpdateFee_set_feerate_per_kw(uint32_t this_ptr, int32_t val) {
@@ -28951,8 +29012,8 @@ uint32_t  __attribute__((export_name("TS_UpdateFee_clone_ptr"))) TS_UpdateFee_cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateFee_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateFee_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateFee_clone"))) TS_UpdateFee_clone(uint32_t orig) {
@@ -29058,8 +29119,8 @@ uint32_t  __attribute__((export_name("TS_DataLossProtect_clone_ptr"))) TS_DataLo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = DataLossProtect_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = DataLossProtect_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DataLossProtect_clone"))) TS_DataLossProtect_clone(uint32_t orig) {
@@ -29113,8 +29174,8 @@ int64_t  __attribute__((export_name("TS_ChannelReestablish_get_next_local_commit
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelReestablish_get_next_local_commitment_number(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_get_next_local_commitment_number(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelReestablish_set_next_local_commitment_number"))) TS_ChannelReestablish_set_next_local_commitment_number(uint32_t this_ptr, int64_t val) {
@@ -29130,8 +29191,8 @@ int64_t  __attribute__((export_name("TS_ChannelReestablish_get_next_remote_commi
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelReestablish_get_next_remote_commitment_number(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_get_next_remote_commitment_number(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelReestablish_set_next_remote_commitment_number"))) TS_ChannelReestablish_set_next_remote_commitment_number(uint32_t this_ptr, int64_t val) {
@@ -29159,8 +29220,8 @@ uint32_t  __attribute__((export_name("TS_ChannelReestablish_clone_ptr"))) TS_Cha
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelReestablish_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelReestablish_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelReestablish_clone"))) TS_ChannelReestablish_clone(uint32_t orig) {
@@ -29214,8 +29275,8 @@ int64_t  __attribute__((export_name("TS_AnnouncementSignatures_get_short_channel
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AnnouncementSignatures_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AnnouncementSignatures_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AnnouncementSignatures_set_short_channel_id"))) TS_AnnouncementSignatures_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -29307,8 +29368,8 @@ uint32_t  __attribute__((export_name("TS_AnnouncementSignatures_clone_ptr"))) TS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = AnnouncementSignatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = AnnouncementSignatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_AnnouncementSignatures_clone"))) TS_AnnouncementSignatures_clone(uint32_t orig) {
@@ -29345,8 +29406,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_NetAddress_clone_ptr"))) TS_NetAddress_clone_ptr(uint32_t arg) {
 	LDKNetAddress* arg_conv = (LDKNetAddress*)arg;
-	uint32_t ret_val = NetAddress_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NetAddress_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NetAddress_clone"))) TS_NetAddress_clone(uint32_t orig) {
@@ -29458,8 +29519,8 @@ int32_t  __attribute__((export_name("TS_UnsignedNodeAnnouncement_get_timestamp")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedNodeAnnouncement_get_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedNodeAnnouncement_get_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedNodeAnnouncement_set_timestamp"))) TS_UnsignedNodeAnnouncement_set_timestamp(uint32_t this_ptr, int32_t val) {
@@ -29573,8 +29634,8 @@ uint32_t  __attribute__((export_name("TS_UnsignedNodeAnnouncement_clone_ptr"))) 
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UnsignedNodeAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UnsignedNodeAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UnsignedNodeAnnouncement_clone"))) TS_UnsignedNodeAnnouncement_clone(uint32_t orig) {
@@ -29691,8 +29752,8 @@ uint32_t  __attribute__((export_name("TS_NodeAnnouncement_clone_ptr"))) TS_NodeA
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeAnnouncement_clone"))) TS_NodeAnnouncement_clone(uint32_t orig) {
@@ -29776,8 +29837,8 @@ int64_t  __attribute__((export_name("TS_UnsignedChannelAnnouncement_get_short_ch
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelAnnouncement_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelAnnouncement_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelAnnouncement_set_short_channel_id"))) TS_UnsignedChannelAnnouncement_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -29889,8 +29950,8 @@ uint32_t  __attribute__((export_name("TS_UnsignedChannelAnnouncement_clone_ptr")
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UnsignedChannelAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UnsignedChannelAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UnsignedChannelAnnouncement_clone"))) TS_UnsignedChannelAnnouncement_clone(uint32_t orig) {
@@ -30079,8 +30140,8 @@ uint32_t  __attribute__((export_name("TS_ChannelAnnouncement_clone_ptr"))) TS_Ch
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelAnnouncement_clone"))) TS_ChannelAnnouncement_clone(uint32_t orig) {
@@ -30134,8 +30195,8 @@ int64_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_short_channel_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelUpdate_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_short_channel_id"))) TS_UnsignedChannelUpdate_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -30151,8 +30212,8 @@ int32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_timestamp"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_timestamp"))) TS_UnsignedChannelUpdate_set_timestamp(uint32_t this_ptr, int32_t val) {
@@ -30168,8 +30229,8 @@ int8_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_flags"))) TS_Un
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int8_t ret_val = UnsignedChannelUpdate_get_flags(&this_ptr_conv);
-	return ret_val;
+	int8_t ret_conv = UnsignedChannelUpdate_get_flags(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_flags"))) TS_UnsignedChannelUpdate_set_flags(uint32_t this_ptr, int8_t val) {
@@ -30185,8 +30246,8 @@ int16_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_cltv_expiry_de
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = UnsignedChannelUpdate_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = UnsignedChannelUpdate_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_cltv_expiry_delta"))) TS_UnsignedChannelUpdate_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -30202,8 +30263,8 @@ int64_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_htlc_minimum_m
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelUpdate_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_htlc_minimum_msat"))) TS_UnsignedChannelUpdate_set_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -30219,8 +30280,8 @@ int32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_fee_base_msat"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_fee_base_msat"))) TS_UnsignedChannelUpdate_set_fee_base_msat(uint32_t this_ptr, int32_t val) {
@@ -30236,8 +30297,8 @@ int32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_fee_proportion
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_fee_proportional_millionths"))) TS_UnsignedChannelUpdate_set_fee_proportional_millionths(uint32_t this_ptr, int32_t val) {
@@ -30265,8 +30326,8 @@ uint32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UnsignedChannelUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UnsignedChannelUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_clone"))) TS_UnsignedChannelUpdate_clone(uint32_t orig) {
@@ -30383,8 +30444,8 @@ uint32_t  __attribute__((export_name("TS_ChannelUpdate_clone_ptr"))) TS_ChannelU
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelUpdate_clone"))) TS_ChannelUpdate_clone(uint32_t orig) {
@@ -30438,8 +30499,8 @@ int32_t  __attribute__((export_name("TS_QueryChannelRange_get_first_blocknum")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = QueryChannelRange_get_first_blocknum(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_get_first_blocknum(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_QueryChannelRange_set_first_blocknum"))) TS_QueryChannelRange_set_first_blocknum(uint32_t this_ptr, int32_t val) {
@@ -30455,8 +30516,8 @@ int32_t  __attribute__((export_name("TS_QueryChannelRange_get_number_of_blocks")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = QueryChannelRange_get_number_of_blocks(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_get_number_of_blocks(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_QueryChannelRange_set_number_of_blocks"))) TS_QueryChannelRange_set_number_of_blocks(uint32_t this_ptr, int32_t val) {
@@ -30500,8 +30561,8 @@ uint32_t  __attribute__((export_name("TS_QueryChannelRange_clone_ptr"))) TS_Quer
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = QueryChannelRange_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = QueryChannelRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_QueryChannelRange_clone"))) TS_QueryChannelRange_clone(uint32_t orig) {
@@ -30555,8 +30616,8 @@ int32_t  __attribute__((export_name("TS_ReplyChannelRange_get_first_blocknum")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ReplyChannelRange_get_first_blocknum(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ReplyChannelRange_get_first_blocknum(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ReplyChannelRange_set_first_blocknum"))) TS_ReplyChannelRange_set_first_blocknum(uint32_t this_ptr, int32_t val) {
@@ -30572,8 +30633,8 @@ int32_t  __attribute__((export_name("TS_ReplyChannelRange_get_number_of_blocks")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ReplyChannelRange_get_number_of_blocks(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ReplyChannelRange_get_number_of_blocks(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ReplyChannelRange_set_number_of_blocks"))) TS_ReplyChannelRange_set_number_of_blocks(uint32_t this_ptr, int32_t val) {
@@ -30589,8 +30650,8 @@ jboolean  __attribute__((export_name("TS_ReplyChannelRange_get_sync_complete")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ReplyChannelRange_get_sync_complete(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ReplyChannelRange_get_sync_complete(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ReplyChannelRange_set_sync_complete"))) TS_ReplyChannelRange_set_sync_complete(uint32_t this_ptr, jboolean val) {
@@ -30664,8 +30725,8 @@ uint32_t  __attribute__((export_name("TS_ReplyChannelRange_clone_ptr"))) TS_Repl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ReplyChannelRange_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ReplyChannelRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ReplyChannelRange_clone"))) TS_ReplyChannelRange_clone(uint32_t orig) {
@@ -30777,8 +30838,8 @@ uint32_t  __attribute__((export_name("TS_QueryShortChannelIds_clone_ptr"))) TS_Q
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = QueryShortChannelIds_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = QueryShortChannelIds_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_QueryShortChannelIds_clone"))) TS_QueryShortChannelIds_clone(uint32_t orig) {
@@ -30832,8 +30893,8 @@ jboolean  __attribute__((export_name("TS_ReplyShortChannelIdsEnd_get_full_inform
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ReplyShortChannelIdsEnd_get_full_information(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ReplyShortChannelIdsEnd_get_full_information(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ReplyShortChannelIdsEnd_set_full_information"))) TS_ReplyShortChannelIdsEnd_set_full_information(uint32_t this_ptr, jboolean val) {
@@ -30877,8 +30938,8 @@ uint32_t  __attribute__((export_name("TS_ReplyShortChannelIdsEnd_clone_ptr"))) T
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ReplyShortChannelIdsEnd_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ReplyShortChannelIdsEnd_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ReplyShortChannelIdsEnd_clone"))) TS_ReplyShortChannelIdsEnd_clone(uint32_t orig) {
@@ -30932,8 +30993,8 @@ int32_t  __attribute__((export_name("TS_GossipTimestampFilter_get_first_timestam
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = GossipTimestampFilter_get_first_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = GossipTimestampFilter_get_first_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_GossipTimestampFilter_set_first_timestamp"))) TS_GossipTimestampFilter_set_first_timestamp(uint32_t this_ptr, int32_t val) {
@@ -30949,8 +31010,8 @@ int32_t  __attribute__((export_name("TS_GossipTimestampFilter_get_timestamp_rang
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = GossipTimestampFilter_get_timestamp_range(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = GossipTimestampFilter_get_timestamp_range(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_GossipTimestampFilter_set_timestamp_range"))) TS_GossipTimestampFilter_set_timestamp_range(uint32_t this_ptr, int32_t val) {
@@ -30994,8 +31055,8 @@ uint32_t  __attribute__((export_name("TS_GossipTimestampFilter_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = GossipTimestampFilter_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = GossipTimestampFilter_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_GossipTimestampFilter_clone"))) TS_GossipTimestampFilter_clone(uint32_t orig) {
@@ -31032,8 +31093,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_ErrorAction_clone_ptr"))) TS_ErrorAction_clone_ptr(uint32_t arg) {
 	LDKErrorAction* arg_conv = (LDKErrorAction*)arg;
-	uint32_t ret_val = ErrorAction_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ErrorAction_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ErrorAction_clone"))) TS_ErrorAction_clone(uint32_t orig) {
@@ -31189,8 +31250,8 @@ uint32_t  __attribute__((export_name("TS_LightningError_clone_ptr"))) TS_Lightni
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = LightningError_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = LightningError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_LightningError_clone"))) TS_LightningError_clone(uint32_t orig) {
@@ -31584,8 +31645,8 @@ uint32_t  __attribute__((export_name("TS_CommitmentUpdate_clone_ptr"))) TS_Commi
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CommitmentUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CommitmentUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CommitmentUpdate_clone"))) TS_CommitmentUpdate_clone(uint32_t orig) {
@@ -32258,8 +32319,8 @@ int32_t  __attribute__((export_name("TS_QueryChannelRange_end_blocknum"))) TS_Qu
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = QueryChannelRange_end_blocknum(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_end_blocknum(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_QueryChannelRange_write"))) TS_QueryChannelRange_write(uint32_t obj) {
@@ -32530,8 +32591,8 @@ uint32_t  __attribute__((export_name("TS_SocketDescriptor_clone_ptr"))) TS_Socke
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKSocketDescriptor* arg_conv = (LDKSocketDescriptor*)arg_ptr;
-	uint32_t ret_val = SocketDescriptor_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = SocketDescriptor_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SocketDescriptor_clone"))) TS_SocketDescriptor_clone(uint32_t orig) {
@@ -32565,8 +32626,8 @@ jboolean  __attribute__((export_name("TS_PeerHandleError_get_no_connection_possi
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = PeerHandleError_get_no_connection_possible(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = PeerHandleError_get_no_connection_possible(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PeerHandleError_set_no_connection_possible"))) TS_PeerHandleError_set_no_connection_possible(uint32_t this_ptr, jboolean val) {
@@ -32607,8 +32668,8 @@ uint32_t  __attribute__((export_name("TS_PeerHandleError_clone_ptr"))) TS_PeerHa
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PeerHandleError_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PeerHandleError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PeerHandleError_clone"))) TS_PeerHandleError_clone(uint32_t orig) {
@@ -32813,13 +32874,13 @@ void  __attribute__((export_name("TS_PeerManager_timer_tick_occurred"))) TS_Peer
 }
 
 int64_t  __attribute__((export_name("TS_htlc_success_tx_weight"))) TS_htlc_success_tx_weight(jboolean opt_anchors) {
-	int64_t ret_val = htlc_success_tx_weight(opt_anchors);
-	return ret_val;
+	int64_t ret_conv = htlc_success_tx_weight(opt_anchors);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_htlc_timeout_tx_weight"))) TS_htlc_timeout_tx_weight(jboolean opt_anchors) {
-	int64_t ret_val = htlc_timeout_tx_weight(opt_anchors);
-	return ret_val;
+	int64_t ret_conv = htlc_timeout_tx_weight(opt_anchors);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_build_commitment_secret"))) TS_build_commitment_secret(int8_tArray commitment_seed, int64_t idx) {
@@ -32878,8 +32939,8 @@ uint32_t  __attribute__((export_name("TS_CounterpartyCommitmentSecrets_clone_ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CounterpartyCommitmentSecrets_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CounterpartyCommitmentSecrets_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CounterpartyCommitmentSecrets_clone"))) TS_CounterpartyCommitmentSecrets_clone(uint32_t orig) {
@@ -32917,8 +32978,8 @@ int64_t  __attribute__((export_name("TS_CounterpartyCommitmentSecrets_get_min_se
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CounterpartyCommitmentSecrets_get_min_seen_secret(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyCommitmentSecrets_get_min_seen_secret(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CounterpartyCommitmentSecrets_provide_secret"))) TS_CounterpartyCommitmentSecrets_provide_secret(uint32_t this_arg, int64_t idx, int8_tArray secret) {
@@ -33174,8 +33235,8 @@ uint32_t  __attribute__((export_name("TS_TxCreationKeys_clone_ptr"))) TS_TxCreat
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = TxCreationKeys_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = TxCreationKeys_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_TxCreationKeys_clone"))) TS_TxCreationKeys_clone(uint32_t orig) {
@@ -33374,8 +33435,8 @@ uint32_t  __attribute__((export_name("TS_ChannelPublicKeys_clone_ptr"))) TS_Chan
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelPublicKeys_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelPublicKeys_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelPublicKeys_clone"))) TS_ChannelPublicKeys_clone(uint32_t orig) {
@@ -33481,8 +33542,8 @@ jboolean  __attribute__((export_name("TS_HTLCOutputInCommitment_get_offered"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = HTLCOutputInCommitment_get_offered(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = HTLCOutputInCommitment_get_offered(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_HTLCOutputInCommitment_set_offered"))) TS_HTLCOutputInCommitment_set_offered(uint32_t this_ptr, jboolean val) {
@@ -33498,8 +33559,8 @@ int64_t  __attribute__((export_name("TS_HTLCOutputInCommitment_get_amount_msat")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = HTLCOutputInCommitment_get_amount_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = HTLCOutputInCommitment_get_amount_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_HTLCOutputInCommitment_set_amount_msat"))) TS_HTLCOutputInCommitment_set_amount_msat(uint32_t this_ptr, int64_t val) {
@@ -33515,8 +33576,8 @@ int32_t  __attribute__((export_name("TS_HTLCOutputInCommitment_get_cltv_expiry")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = HTLCOutputInCommitment_get_cltv_expiry(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = HTLCOutputInCommitment_get_cltv_expiry(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_HTLCOutputInCommitment_set_cltv_expiry"))) TS_HTLCOutputInCommitment_set_cltv_expiry(uint32_t this_ptr, int32_t val) {
@@ -33608,8 +33669,8 @@ uint32_t  __attribute__((export_name("TS_HTLCOutputInCommitment_clone_ptr"))) TS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = HTLCOutputInCommitment_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = HTLCOutputInCommitment_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_HTLCOutputInCommitment_clone"))) TS_HTLCOutputInCommitment_clone(uint32_t orig) {
@@ -33756,8 +33817,8 @@ int16_t  __attribute__((export_name("TS_ChannelTransactionParameters_get_holder_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelTransactionParameters_get_holder_selected_contest_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelTransactionParameters_get_holder_selected_contest_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelTransactionParameters_set_holder_selected_contest_delay"))) TS_ChannelTransactionParameters_set_holder_selected_contest_delay(uint32_t this_ptr, int16_t val) {
@@ -33773,8 +33834,8 @@ jboolean  __attribute__((export_name("TS_ChannelTransactionParameters_get_is_out
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelTransactionParameters_get_is_outbound_from_holder(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTransactionParameters_get_is_outbound_from_holder(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelTransactionParameters_set_is_outbound_from_holder"))) TS_ChannelTransactionParameters_set_is_outbound_from_holder(uint32_t this_ptr, jboolean val) {
@@ -33913,8 +33974,8 @@ uint32_t  __attribute__((export_name("TS_ChannelTransactionParameters_clone_ptr"
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelTransactionParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelTransactionParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelTransactionParameters_clone"))) TS_ChannelTransactionParameters_clone(uint32_t orig) {
@@ -33977,8 +34038,8 @@ int16_t  __attribute__((export_name("TS_CounterpartyChannelTransactionParameters
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = CounterpartyChannelTransactionParameters_get_selected_contest_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = CounterpartyChannelTransactionParameters_get_selected_contest_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CounterpartyChannelTransactionParameters_set_selected_contest_delay"))) TS_CounterpartyChannelTransactionParameters_set_selected_contest_delay(uint32_t this_ptr, int16_t val) {
@@ -34024,8 +34085,8 @@ uint32_t  __attribute__((export_name("TS_CounterpartyChannelTransactionParameter
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CounterpartyChannelTransactionParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CounterpartyChannelTransactionParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CounterpartyChannelTransactionParameters_clone"))) TS_CounterpartyChannelTransactionParameters_clone(uint32_t orig) {
@@ -34050,8 +34111,8 @@ jboolean  __attribute__((export_name("TS_ChannelTransactionParameters_is_populat
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelTransactionParameters_is_populated(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTransactionParameters_is_populated(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelTransactionParameters_as_holder_broadcastable"))) TS_ChannelTransactionParameters_as_holder_broadcastable(uint32_t this_arg) {
@@ -34177,8 +34238,8 @@ int16_t  __attribute__((export_name("TS_DirectedChannelTransactionParameters_con
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = DirectedChannelTransactionParameters_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = DirectedChannelTransactionParameters_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_DirectedChannelTransactionParameters_is_outbound"))) TS_DirectedChannelTransactionParameters_is_outbound(uint32_t this_arg) {
@@ -34186,8 +34247,8 @@ jboolean  __attribute__((export_name("TS_DirectedChannelTransactionParameters_is
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = DirectedChannelTransactionParameters_is_outbound(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = DirectedChannelTransactionParameters_is_outbound(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DirectedChannelTransactionParameters_funding_outpoint"))) TS_DirectedChannelTransactionParameters_funding_outpoint(uint32_t this_arg) {
@@ -34212,8 +34273,8 @@ jboolean  __attribute__((export_name("TS_DirectedChannelTransactionParameters_op
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = DirectedChannelTransactionParameters_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = DirectedChannelTransactionParameters_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_HolderCommitmentTransaction_free"))) TS_HolderCommitmentTransaction_free(uint32_t this_obj) {
@@ -34284,8 +34345,8 @@ uint32_t  __attribute__((export_name("TS_HolderCommitmentTransaction_clone_ptr")
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = HolderCommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = HolderCommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_HolderCommitmentTransaction_clone"))) TS_HolderCommitmentTransaction_clone(uint32_t orig) {
@@ -34459,8 +34520,8 @@ uint32_t  __attribute__((export_name("TS_BuiltCommitmentTransaction_clone_ptr"))
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = BuiltCommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = BuiltCommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_BuiltCommitmentTransaction_clone"))) TS_BuiltCommitmentTransaction_clone(uint32_t orig) {
@@ -34556,8 +34617,8 @@ uint32_t  __attribute__((export_name("TS_ClosingTransaction_clone_ptr"))) TS_Clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ClosingTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ClosingTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosingTransaction_clone"))) TS_ClosingTransaction_clone(uint32_t orig) {
@@ -34582,8 +34643,8 @@ int64_t  __attribute__((export_name("TS_ClosingTransaction_hash"))) TS_ClosingTr
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = ClosingTransaction_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_hash(&o_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosingTransaction_new"))) TS_ClosingTransaction_new(int64_t to_holder_value_sat, int64_t to_counterparty_value_sat, int8_tArray to_holder_script, int8_tArray to_counterparty_script, uint32_t funding_outpoint) {
@@ -34649,8 +34710,8 @@ int64_t  __attribute__((export_name("TS_ClosingTransaction_to_holder_value_sat")
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ClosingTransaction_to_holder_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_to_holder_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_ClosingTransaction_to_counterparty_value_sat"))) TS_ClosingTransaction_to_counterparty_value_sat(uint32_t this_arg) {
@@ -34658,8 +34719,8 @@ int64_t  __attribute__((export_name("TS_ClosingTransaction_to_counterparty_value
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ClosingTransaction_to_counterparty_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_to_counterparty_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_ClosingTransaction_to_holder_script"))) TS_ClosingTransaction_to_holder_script(uint32_t this_arg) {
@@ -34759,8 +34820,8 @@ uint32_t  __attribute__((export_name("TS_CommitmentTransaction_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CommitmentTransaction_clone"))) TS_CommitmentTransaction_clone(uint32_t orig) {
@@ -34806,8 +34867,8 @@ int64_t  __attribute__((export_name("TS_CommitmentTransaction_commitment_number"
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_commitment_number(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_commitment_number(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_CommitmentTransaction_to_broadcaster_value_sat"))) TS_CommitmentTransaction_to_broadcaster_value_sat(uint32_t this_arg) {
@@ -34815,8 +34876,8 @@ int64_t  __attribute__((export_name("TS_CommitmentTransaction_to_broadcaster_val
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_to_broadcaster_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_to_broadcaster_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_CommitmentTransaction_to_countersignatory_value_sat"))) TS_CommitmentTransaction_to_countersignatory_value_sat(uint32_t this_arg) {
@@ -34824,8 +34885,8 @@ int64_t  __attribute__((export_name("TS_CommitmentTransaction_to_countersignator
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_to_countersignatory_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_to_countersignatory_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 int32_t  __attribute__((export_name("TS_CommitmentTransaction_feerate_per_kw"))) TS_CommitmentTransaction_feerate_per_kw(uint32_t this_arg) {
@@ -34833,8 +34894,8 @@ int32_t  __attribute__((export_name("TS_CommitmentTransaction_feerate_per_kw")))
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = CommitmentTransaction_feerate_per_kw(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = CommitmentTransaction_feerate_per_kw(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CommitmentTransaction_trust"))) TS_CommitmentTransaction_trust(uint32_t this_arg) {
@@ -34933,8 +34994,8 @@ jboolean  __attribute__((export_name("TS_TrustedCommitmentTransaction_opt_anchor
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = TrustedCommitmentTransaction_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = TrustedCommitmentTransaction_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_TrustedCommitmentTransaction_get_htlc_sigs"))) TS_TrustedCommitmentTransaction_get_htlc_sigs(uint32_t this_arg, int8_tArray htlc_base_key, uint32_t channel_parameters) {
@@ -34962,8 +35023,8 @@ int64_t  __attribute__((export_name("TS_get_commitment_transaction_number_obscur
 	LDKPublicKey countersignatory_payment_basepoint_ref;
 	CHECK(countersignatory_payment_basepoint->arr_len == 33);
 	memcpy(countersignatory_payment_basepoint_ref.compressed_form, countersignatory_payment_basepoint->elems, 33); FREE(countersignatory_payment_basepoint);
-	int64_t ret_val = get_commitment_transaction_number_obscure_factor(broadcaster_payment_basepoint_ref, countersignatory_payment_basepoint_ref, outbound_from_broadcaster);
-	return ret_val;
+	int64_t ret_conv = get_commitment_transaction_number_obscure_factor(broadcaster_payment_basepoint_ref, countersignatory_payment_basepoint_ref, outbound_from_broadcaster);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_InitFeatures_eq"))) TS_InitFeatures_eq(uint32_t a, uint32_t b) {
@@ -34975,8 +35036,8 @@ jboolean  __attribute__((export_name("TS_InitFeatures_eq"))) TS_InitFeatures_eq(
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InitFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InitFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_NodeFeatures_eq"))) TS_NodeFeatures_eq(uint32_t a, uint32_t b) {
@@ -34988,8 +35049,8 @@ jboolean  __attribute__((export_name("TS_NodeFeatures_eq"))) TS_NodeFeatures_eq(
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = NodeFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = NodeFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_ChannelFeatures_eq"))) TS_ChannelFeatures_eq(uint32_t a, uint32_t b) {
@@ -35001,8 +35062,8 @@ jboolean  __attribute__((export_name("TS_ChannelFeatures_eq"))) TS_ChannelFeatur
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ChannelFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_InvoiceFeatures_eq"))) TS_InvoiceFeatures_eq(uint32_t a, uint32_t b) {
@@ -35014,8 +35075,8 @@ jboolean  __attribute__((export_name("TS_InvoiceFeatures_eq"))) TS_InvoiceFeatur
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InvoiceFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_ChannelTypeFeatures_eq"))) TS_ChannelTypeFeatures_eq(uint32_t a, uint32_t b) {
@@ -35027,8 +35088,8 @@ jboolean  __attribute__((export_name("TS_ChannelTypeFeatures_eq"))) TS_ChannelTy
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ChannelTypeFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTypeFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t InitFeatures_clone_ptr(LDKInitFeatures *NONNULL_PTR arg) {
@@ -35048,8 +35109,8 @@ uint32_t  __attribute__((export_name("TS_InitFeatures_clone_ptr"))) TS_InitFeatu
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InitFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InitFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InitFeatures_clone"))) TS_InitFeatures_clone(uint32_t orig) {
@@ -35086,8 +35147,8 @@ uint32_t  __attribute__((export_name("TS_NodeFeatures_clone_ptr"))) TS_NodeFeatu
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeFeatures_clone"))) TS_NodeFeatures_clone(uint32_t orig) {
@@ -35124,8 +35185,8 @@ uint32_t  __attribute__((export_name("TS_ChannelFeatures_clone_ptr"))) TS_Channe
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelFeatures_clone"))) TS_ChannelFeatures_clone(uint32_t orig) {
@@ -35162,8 +35223,8 @@ uint32_t  __attribute__((export_name("TS_InvoiceFeatures_clone_ptr"))) TS_Invoic
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InvoiceFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InvoiceFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InvoiceFeatures_clone"))) TS_InvoiceFeatures_clone(uint32_t orig) {
@@ -35200,8 +35261,8 @@ uint32_t  __attribute__((export_name("TS_ChannelTypeFeatures_clone_ptr"))) TS_Ch
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelTypeFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelTypeFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelTypeFeatures_clone"))) TS_ChannelTypeFeatures_clone(uint32_t orig) {
@@ -35292,8 +35353,8 @@ jboolean  __attribute__((export_name("TS_InitFeatures_requires_unknown_bits"))) 
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InitFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InitFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeFeatures_empty"))) TS_NodeFeatures_empty() {
@@ -35327,8 +35388,8 @@ jboolean  __attribute__((export_name("TS_NodeFeatures_requires_unknown_bits"))) 
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = NodeFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = NodeFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelFeatures_empty"))) TS_ChannelFeatures_empty() {
@@ -35362,8 +35423,8 @@ jboolean  __attribute__((export_name("TS_ChannelFeatures_requires_unknown_bits")
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InvoiceFeatures_empty"))) TS_InvoiceFeatures_empty() {
@@ -35397,8 +35458,8 @@ jboolean  __attribute__((export_name("TS_InvoiceFeatures_requires_unknown_bits")
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InvoiceFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelTypeFeatures_empty"))) TS_ChannelTypeFeatures_empty() {
@@ -35432,8 +35493,8 @@ jboolean  __attribute__((export_name("TS_ChannelTypeFeatures_requires_unknown_bi
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelTypeFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTypeFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_InitFeatures_write"))) TS_InitFeatures_write(uint32_t obj) {
@@ -35566,8 +35627,8 @@ uint32_t  __attribute__((export_name("TS_ShutdownScript_clone_ptr"))) TS_Shutdow
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ShutdownScript_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ShutdownScript_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ShutdownScript_clone"))) TS_ShutdownScript_clone(uint32_t orig) {
@@ -35652,8 +35713,8 @@ uint32_t  __attribute__((export_name("TS_InvalidShutdownScript_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InvalidShutdownScript_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InvalidShutdownScript_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InvalidShutdownScript_clone"))) TS_InvalidShutdownScript_clone(uint32_t orig) {
@@ -35769,8 +35830,8 @@ jboolean  __attribute__((export_name("TS_ShutdownScript_is_compatible"))) TS_Shu
 	features_conv.inner = (void*)(features & (~1));
 	features_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(features_conv);
-	jboolean ret_val = ShutdownScript_is_compatible(&this_arg_conv, &features_conv);
-	return ret_val;
+	jboolean ret_conv = ShutdownScript_is_compatible(&this_arg_conv, &features_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CustomMessageReader_free"))) TS_CustomMessageReader_free(uint32_t this_ptr) {
@@ -35791,8 +35852,8 @@ uint32_t  __attribute__((export_name("TS_Type_clone_ptr"))) TS_Type_clone_ptr(ui
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKType* arg_conv = (LDKType*)arg_ptr;
-	uint32_t ret_val = Type_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Type_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Type_clone"))) TS_Type_clone(uint32_t orig) {
@@ -35838,8 +35899,8 @@ uint32_t  __attribute__((export_name("TS_NodeId_clone_ptr"))) TS_NodeId_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeId_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeId_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeId_clone"))) TS_NodeId_clone(uint32_t orig) {
@@ -35891,8 +35952,8 @@ int64_t  __attribute__((export_name("TS_NodeId_hash"))) TS_NodeId_hash(uint32_t 
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = NodeId_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = NodeId_hash(&o_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_NodeId_write"))) TS_NodeId_write(uint32_t obj) {
@@ -35941,8 +36002,8 @@ uint32_t  __attribute__((export_name("TS_NetworkGraph_clone_ptr"))) TS_NetworkGr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NetworkGraph_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NetworkGraph_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NetworkGraph_clone"))) TS_NetworkGraph_clone(uint32_t orig) {
@@ -35987,8 +36048,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_NetworkUpdate_clone_ptr"))) TS_NetworkUpdate_clone_ptr(uint32_t arg) {
 	LDKNetworkUpdate* arg_conv = (LDKNetworkUpdate*)arg;
-	uint32_t ret_val = NetworkUpdate_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NetworkUpdate_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NetworkUpdate_clone"))) TS_NetworkUpdate_clone(uint32_t orig) {
@@ -36151,8 +36212,8 @@ int32_t  __attribute__((export_name("TS_ChannelUpdateInfo_get_last_update"))) TS
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelUpdateInfo_get_last_update(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelUpdateInfo_get_last_update(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelUpdateInfo_set_last_update"))) TS_ChannelUpdateInfo_set_last_update(uint32_t this_ptr, int32_t val) {
@@ -36168,8 +36229,8 @@ jboolean  __attribute__((export_name("TS_ChannelUpdateInfo_get_enabled"))) TS_Ch
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelUpdateInfo_get_enabled(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelUpdateInfo_get_enabled(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelUpdateInfo_set_enabled"))) TS_ChannelUpdateInfo_set_enabled(uint32_t this_ptr, jboolean val) {
@@ -36185,8 +36246,8 @@ int16_t  __attribute__((export_name("TS_ChannelUpdateInfo_get_cltv_expiry_delta"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelUpdateInfo_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelUpdateInfo_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelUpdateInfo_set_cltv_expiry_delta"))) TS_ChannelUpdateInfo_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -36202,8 +36263,8 @@ int64_t  __attribute__((export_name("TS_ChannelUpdateInfo_get_htlc_minimum_msat"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelUpdateInfo_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelUpdateInfo_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelUpdateInfo_set_htlc_minimum_msat"))) TS_ChannelUpdateInfo_set_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -36343,8 +36404,8 @@ uint32_t  __attribute__((export_name("TS_ChannelUpdateInfo_clone_ptr"))) TS_Chan
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelUpdateInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelUpdateInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelUpdateInfo_clone"))) TS_ChannelUpdateInfo_clone(uint32_t orig) {
@@ -36619,8 +36680,8 @@ uint32_t  __attribute__((export_name("TS_ChannelInfo_clone_ptr"))) TS_ChannelInf
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelInfo_clone"))) TS_ChannelInfo_clone(uint32_t orig) {
@@ -36686,8 +36747,8 @@ uint32_t  __attribute__((export_name("TS_DirectedChannelInfo_clone_ptr"))) TS_Di
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = DirectedChannelInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = DirectedChannelInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DirectedChannelInfo_clone"))) TS_DirectedChannelInfo_clone(uint32_t orig) {
@@ -36771,8 +36832,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_EffectiveCapacity_clone_ptr"))) TS_EffectiveCapacity_clone_ptr(uint32_t arg) {
 	LDKEffectiveCapacity* arg_conv = (LDKEffectiveCapacity*)arg;
-	uint32_t ret_val = EffectiveCapacity_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = EffectiveCapacity_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_EffectiveCapacity_clone"))) TS_EffectiveCapacity_clone(uint32_t orig) {
@@ -36820,8 +36881,8 @@ uint32_t  __attribute__((export_name("TS_EffectiveCapacity_unknown"))) TS_Effect
 
 int64_t  __attribute__((export_name("TS_EffectiveCapacity_as_msat"))) TS_EffectiveCapacity_as_msat(uint32_t this_arg) {
 	LDKEffectiveCapacity* this_arg_conv = (LDKEffectiveCapacity*)this_arg;
-	int64_t ret_val = EffectiveCapacity_as_msat(this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = EffectiveCapacity_as_msat(this_arg_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RoutingFees_free"))) TS_RoutingFees_free(uint32_t this_obj) {
@@ -36837,8 +36898,8 @@ int32_t  __attribute__((export_name("TS_RoutingFees_get_base_msat"))) TS_Routing
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RoutingFees_get_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RoutingFees_get_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RoutingFees_set_base_msat"))) TS_RoutingFees_set_base_msat(uint32_t this_ptr, int32_t val) {
@@ -36854,8 +36915,8 @@ int32_t  __attribute__((export_name("TS_RoutingFees_get_proportional_millionths"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RoutingFees_get_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RoutingFees_get_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RoutingFees_set_proportional_millionths"))) TS_RoutingFees_set_proportional_millionths(uint32_t this_ptr, int32_t val) {
@@ -36888,8 +36949,8 @@ jboolean  __attribute__((export_name("TS_RoutingFees_eq"))) TS_RoutingFees_eq(ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RoutingFees_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RoutingFees_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RoutingFees_clone_ptr(LDKRoutingFees *NONNULL_PTR arg) {
@@ -36909,8 +36970,8 @@ uint32_t  __attribute__((export_name("TS_RoutingFees_clone_ptr"))) TS_RoutingFee
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RoutingFees_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RoutingFees_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RoutingFees_clone"))) TS_RoutingFees_clone(uint32_t orig) {
@@ -36935,8 +36996,8 @@ int64_t  __attribute__((export_name("TS_RoutingFees_hash"))) TS_RoutingFees_hash
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RoutingFees_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RoutingFees_hash(&o_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RoutingFees_write"))) TS_RoutingFees_write(uint32_t obj) {
@@ -37003,8 +37064,8 @@ int32_t  __attribute__((export_name("TS_NodeAnnouncementInfo_get_last_update")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = NodeAnnouncementInfo_get_last_update(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = NodeAnnouncementInfo_get_last_update(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_NodeAnnouncementInfo_set_last_update"))) TS_NodeAnnouncementInfo_set_last_update(uint32_t this_ptr, int32_t val) {
@@ -37172,8 +37233,8 @@ uint32_t  __attribute__((export_name("TS_NodeAnnouncementInfo_clone_ptr"))) TS_N
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeAnnouncementInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeAnnouncementInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeAnnouncementInfo_clone"))) TS_NodeAnnouncementInfo_clone(uint32_t orig) {
@@ -37356,8 +37417,8 @@ uint32_t  __attribute__((export_name("TS_NodeInfo_clone_ptr"))) TS_NodeInfo_clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeInfo_clone"))) TS_NodeInfo_clone(uint32_t orig) {
@@ -37663,8 +37724,8 @@ int64_t  __attribute__((export_name("TS_RouteHop_get_short_channel_id"))) TS_Rou
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHop_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHop_set_short_channel_id"))) TS_RouteHop_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -37710,8 +37771,8 @@ int64_t  __attribute__((export_name("TS_RouteHop_get_fee_msat"))) TS_RouteHop_ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHop_get_fee_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_get_fee_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHop_set_fee_msat"))) TS_RouteHop_set_fee_msat(uint32_t this_ptr, int64_t val) {
@@ -37727,8 +37788,8 @@ int32_t  __attribute__((export_name("TS_RouteHop_get_cltv_expiry_delta"))) TS_Ro
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RouteHop_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RouteHop_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHop_set_cltv_expiry_delta"))) TS_RouteHop_set_cltv_expiry_delta(uint32_t this_ptr, int32_t val) {
@@ -37782,8 +37843,8 @@ uint32_t  __attribute__((export_name("TS_RouteHop_clone_ptr"))) TS_RouteHop_clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RouteHop_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RouteHop_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RouteHop_clone"))) TS_RouteHop_clone(uint32_t orig) {
@@ -37808,8 +37869,8 @@ int64_t  __attribute__((export_name("TS_RouteHop_hash"))) TS_RouteHop_hash(uint3
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHop_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_RouteHop_eq"))) TS_RouteHop_eq(uint32_t a, uint32_t b) {
@@ -37821,8 +37882,8 @@ jboolean  __attribute__((export_name("TS_RouteHop_eq"))) TS_RouteHop_eq(uint32_t
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHop_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHop_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RouteHop_write"))) TS_RouteHop_write(uint32_t obj) {
@@ -38018,8 +38079,8 @@ uint32_t  __attribute__((export_name("TS_Route_clone_ptr"))) TS_Route_clone_ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Route_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Route_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Route_clone"))) TS_Route_clone(uint32_t orig) {
@@ -38044,8 +38105,8 @@ int64_t  __attribute__((export_name("TS_Route_hash"))) TS_Route_hash(uint32_t o)
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Route_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Route_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Route_eq"))) TS_Route_eq(uint32_t a, uint32_t b) {
@@ -38057,8 +38118,8 @@ jboolean  __attribute__((export_name("TS_Route_eq"))) TS_Route_eq(uint32_t a, ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Route_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Route_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_Route_get_total_fees"))) TS_Route_get_total_fees(uint32_t this_arg) {
@@ -38066,8 +38127,8 @@ int64_t  __attribute__((export_name("TS_Route_get_total_fees"))) TS_Route_get_to
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Route_get_total_fees(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_get_total_fees(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_Route_get_total_amount"))) TS_Route_get_total_amount(uint32_t this_arg) {
@@ -38075,8 +38136,8 @@ int64_t  __attribute__((export_name("TS_Route_get_total_amount"))) TS_Route_get_
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Route_get_total_amount(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_get_total_amount(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_Route_write"))) TS_Route_write(uint32_t obj) {
@@ -38143,8 +38204,8 @@ int64_t  __attribute__((export_name("TS_RouteParameters_get_final_value_msat")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteParameters_get_final_value_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteParameters_get_final_value_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteParameters_set_final_value_msat"))) TS_RouteParameters_set_final_value_msat(uint32_t this_ptr, int64_t val) {
@@ -38160,8 +38221,8 @@ int32_t  __attribute__((export_name("TS_RouteParameters_get_final_cltv_expiry_de
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RouteParameters_get_final_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RouteParameters_get_final_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteParameters_set_final_cltv_expiry_delta"))) TS_RouteParameters_set_final_cltv_expiry_delta(uint32_t this_ptr, int32_t val) {
@@ -38207,8 +38268,8 @@ uint32_t  __attribute__((export_name("TS_RouteParameters_clone_ptr"))) TS_RouteP
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RouteParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RouteParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RouteParameters_clone"))) TS_RouteParameters_clone(uint32_t orig) {
@@ -38388,8 +38449,8 @@ int32_t  __attribute__((export_name("TS_PaymentParameters_get_max_total_cltv_exp
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = PaymentParameters_get_max_total_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = PaymentParameters_get_max_total_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PaymentParameters_set_max_total_cltv_expiry_delta"))) TS_PaymentParameters_set_max_total_cltv_expiry_delta(uint32_t this_ptr, int32_t val) {
@@ -38458,8 +38519,8 @@ uint32_t  __attribute__((export_name("TS_PaymentParameters_clone_ptr"))) TS_Paym
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PaymentParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PaymentParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PaymentParameters_clone"))) TS_PaymentParameters_clone(uint32_t orig) {
@@ -38484,8 +38545,8 @@ int64_t  __attribute__((export_name("TS_PaymentParameters_hash"))) TS_PaymentPar
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PaymentParameters_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentParameters_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_PaymentParameters_eq"))) TS_PaymentParameters_eq(uint32_t a, uint32_t b) {
@@ -38497,8 +38558,8 @@ jboolean  __attribute__((export_name("TS_PaymentParameters_eq"))) TS_PaymentPara
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PaymentParameters_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PaymentParameters_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_PaymentParameters_write"))) TS_PaymentParameters_write(uint32_t obj) {
@@ -38658,8 +38719,8 @@ uint32_t  __attribute__((export_name("TS_RouteHint_clone_ptr"))) TS_RouteHint_cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RouteHint_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RouteHint_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RouteHint_clone"))) TS_RouteHint_clone(uint32_t orig) {
@@ -38684,8 +38745,8 @@ int64_t  __attribute__((export_name("TS_RouteHint_hash"))) TS_RouteHint_hash(uin
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHint_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHint_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_RouteHint_eq"))) TS_RouteHint_eq(uint32_t a, uint32_t b) {
@@ -38697,8 +38758,8 @@ jboolean  __attribute__((export_name("TS_RouteHint_eq"))) TS_RouteHint_eq(uint32
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHint_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHint_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RouteHint_write"))) TS_RouteHint_write(uint32_t obj) {
@@ -38756,8 +38817,8 @@ int64_t  __attribute__((export_name("TS_RouteHintHop_get_short_channel_id"))) TS
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHintHop_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHintHop_set_short_channel_id"))) TS_RouteHintHop_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -38803,8 +38864,8 @@ int16_t  __attribute__((export_name("TS_RouteHintHop_get_cltv_expiry_delta"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = RouteHintHop_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = RouteHintHop_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHintHop_set_cltv_expiry_delta"))) TS_RouteHintHop_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -38907,8 +38968,8 @@ uint32_t  __attribute__((export_name("TS_RouteHintHop_clone_ptr"))) TS_RouteHint
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RouteHintHop_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RouteHintHop_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RouteHintHop_clone"))) TS_RouteHintHop_clone(uint32_t orig) {
@@ -38933,8 +38994,8 @@ int64_t  __attribute__((export_name("TS_RouteHintHop_hash"))) TS_RouteHintHop_ha
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHintHop_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_RouteHintHop_eq"))) TS_RouteHintHop_eq(uint32_t a, uint32_t b) {
@@ -38946,8 +39007,8 @@ jboolean  __attribute__((export_name("TS_RouteHintHop_eq"))) TS_RouteHintHop_eq(
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHintHop_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHintHop_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RouteHintHop_write"))) TS_RouteHintHop_write(uint32_t obj) {
@@ -39093,8 +39154,8 @@ uint32_t  __attribute__((export_name("TS_FixedPenaltyScorer_clone_ptr"))) TS_Fix
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = FixedPenaltyScorer_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = FixedPenaltyScorer_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_FixedPenaltyScorer_clone"))) TS_FixedPenaltyScorer_clone(uint32_t orig) {
@@ -39179,8 +39240,8 @@ int64_t  __attribute__((export_name("TS_ScoringParameters_get_base_penalty_msat"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_base_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_base_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_base_penalty_msat"))) TS_ScoringParameters_set_base_penalty_msat(uint32_t this_ptr, int64_t val) {
@@ -39196,8 +39257,8 @@ int64_t  __attribute__((export_name("TS_ScoringParameters_get_failure_penalty_ms
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_failure_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_failure_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_failure_penalty_msat"))) TS_ScoringParameters_set_failure_penalty_msat(uint32_t this_ptr, int64_t val) {
@@ -39213,8 +39274,8 @@ int16_t  __attribute__((export_name("TS_ScoringParameters_get_overuse_penalty_st
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ScoringParameters_get_overuse_penalty_start_1024th(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ScoringParameters_get_overuse_penalty_start_1024th(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_overuse_penalty_start_1024th"))) TS_ScoringParameters_set_overuse_penalty_start_1024th(uint32_t this_ptr, int16_t val) {
@@ -39230,8 +39291,8 @@ int64_t  __attribute__((export_name("TS_ScoringParameters_get_overuse_penalty_ms
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_overuse_penalty_msat_per_1024th(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_overuse_penalty_msat_per_1024th(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_overuse_penalty_msat_per_1024th"))) TS_ScoringParameters_set_overuse_penalty_msat_per_1024th(uint32_t this_ptr, int64_t val) {
@@ -39247,8 +39308,8 @@ int64_t  __attribute__((export_name("TS_ScoringParameters_get_failure_penalty_ha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_failure_penalty_half_life(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_failure_penalty_half_life(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_failure_penalty_half_life"))) TS_ScoringParameters_set_failure_penalty_half_life(uint32_t this_ptr, int64_t val) {
@@ -39289,8 +39350,8 @@ uint32_t  __attribute__((export_name("TS_ScoringParameters_clone_ptr"))) TS_Scor
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ScoringParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ScoringParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ScoringParameters_clone"))) TS_ScoringParameters_clone(uint32_t orig) {
@@ -39427,8 +39488,8 @@ int64_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_get_base_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_base_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_base_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ProbabilisticScoringParameters_set_base_penalty_msat"))) TS_ProbabilisticScoringParameters_set_base_penalty_msat(uint32_t this_ptr, int64_t val) {
@@ -39444,8 +39505,8 @@ int64_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_get_liqui
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_liquidity_penalty_multiplier_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_liquidity_penalty_multiplier_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ProbabilisticScoringParameters_set_liquidity_penalty_multiplier_msat"))) TS_ProbabilisticScoringParameters_set_liquidity_penalty_multiplier_msat(uint32_t this_ptr, int64_t val) {
@@ -39461,8 +39522,8 @@ int64_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_get_liqui
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_liquidity_offset_half_life(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_liquidity_offset_half_life(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ProbabilisticScoringParameters_set_liquidity_offset_half_life"))) TS_ProbabilisticScoringParameters_set_liquidity_offset_half_life(uint32_t this_ptr, int64_t val) {
@@ -39478,8 +39539,8 @@ int64_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_get_amoun
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_amount_penalty_multiplier_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_amount_penalty_multiplier_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ProbabilisticScoringParameters_set_amount_penalty_multiplier_msat"))) TS_ProbabilisticScoringParameters_set_amount_penalty_multiplier_msat(uint32_t this_ptr, int64_t val) {
@@ -39520,8 +39581,8 @@ uint32_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ProbabilisticScoringParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ProbabilisticScoringParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_clone"))) TS_ProbabilisticScoringParameters_clone(uint32_t orig) {
@@ -39633,8 +39694,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_ParseError_clone_ptr"))) TS_ParseError_clone_ptr(uint32_t arg) {
 	LDKParseError* arg_conv = (LDKParseError*)arg;
-	uint32_t ret_val = ParseError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ParseError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ParseError_clone"))) TS_ParseError_clone(uint32_t orig) {
@@ -39796,8 +39857,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_ParseOrSemanticError_clone_ptr"))) TS_ParseOrSemanticError_clone_ptr(uint32_t arg) {
 	LDKParseOrSemanticError* arg_conv = (LDKParseOrSemanticError*)arg;
-	uint32_t ret_val = ParseOrSemanticError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ParseOrSemanticError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ParseOrSemanticError_clone"))) TS_ParseOrSemanticError_clone(uint32_t orig) {
@@ -39844,8 +39905,8 @@ jboolean  __attribute__((export_name("TS_Invoice_eq"))) TS_Invoice_eq(uint32_t a
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Invoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Invoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t Invoice_clone_ptr(LDKInvoice *NONNULL_PTR arg) {
@@ -39865,8 +39926,8 @@ uint32_t  __attribute__((export_name("TS_Invoice_clone_ptr"))) TS_Invoice_clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Invoice_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Invoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Invoice_clone"))) TS_Invoice_clone(uint32_t orig) {
@@ -39903,8 +39964,8 @@ jboolean  __attribute__((export_name("TS_SignedRawInvoice_eq"))) TS_SignedRawInv
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = SignedRawInvoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = SignedRawInvoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t SignedRawInvoice_clone_ptr(LDKSignedRawInvoice *NONNULL_PTR arg) {
@@ -39924,8 +39985,8 @@ uint32_t  __attribute__((export_name("TS_SignedRawInvoice_clone_ptr"))) TS_Signe
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = SignedRawInvoice_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = SignedRawInvoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SignedRawInvoice_clone"))) TS_SignedRawInvoice_clone(uint32_t orig) {
@@ -39992,8 +40053,8 @@ jboolean  __attribute__((export_name("TS_RawInvoice_eq"))) TS_RawInvoice_eq(uint
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RawInvoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RawInvoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RawInvoice_clone_ptr(LDKRawInvoice *NONNULL_PTR arg) {
@@ -40013,8 +40074,8 @@ uint32_t  __attribute__((export_name("TS_RawInvoice_clone_ptr"))) TS_RawInvoice_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RawInvoice_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RawInvoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RawInvoice_clone"))) TS_RawInvoice_clone(uint32_t orig) {
@@ -40081,8 +40142,8 @@ jboolean  __attribute__((export_name("TS_RawDataPart_eq"))) TS_RawDataPart_eq(ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RawDataPart_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RawDataPart_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RawDataPart_clone_ptr(LDKRawDataPart *NONNULL_PTR arg) {
@@ -40102,8 +40163,8 @@ uint32_t  __attribute__((export_name("TS_RawDataPart_clone_ptr"))) TS_RawDataPar
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RawDataPart_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RawDataPart_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RawDataPart_clone"))) TS_RawDataPart_clone(uint32_t orig) {
@@ -40140,8 +40201,8 @@ jboolean  __attribute__((export_name("TS_PositiveTimestamp_eq"))) TS_PositiveTim
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PositiveTimestamp_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PositiveTimestamp_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t PositiveTimestamp_clone_ptr(LDKPositiveTimestamp *NONNULL_PTR arg) {
@@ -40161,8 +40222,8 @@ uint32_t  __attribute__((export_name("TS_PositiveTimestamp_clone_ptr"))) TS_Posi
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PositiveTimestamp_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PositiveTimestamp_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PositiveTimestamp_clone"))) TS_PositiveTimestamp_clone(uint32_t orig) {
@@ -40211,14 +40272,14 @@ uint32_t  __attribute__((export_name("TS_SiPrefix_pico"))) TS_SiPrefix_pico() {
 jboolean  __attribute__((export_name("TS_SiPrefix_eq"))) TS_SiPrefix_eq(uint32_t a, uint32_t b) {
 	LDKSiPrefix* a_conv = (LDKSiPrefix*)(a & ~1);
 	LDKSiPrefix* b_conv = (LDKSiPrefix*)(b & ~1);
-	jboolean ret_val = SiPrefix_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SiPrefix_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_SiPrefix_multiplier"))) TS_SiPrefix_multiplier(uint32_t this_arg) {
 	LDKSiPrefix* this_arg_conv = (LDKSiPrefix*)(this_arg & ~1);
-	int64_t ret_val = SiPrefix_multiplier(this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = SiPrefix_multiplier(this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Currency_clone"))) TS_Currency_clone(uint32_t orig) {
@@ -40254,15 +40315,15 @@ uint32_t  __attribute__((export_name("TS_Currency_signet"))) TS_Currency_signet(
 
 int64_t  __attribute__((export_name("TS_Currency_hash"))) TS_Currency_hash(uint32_t o) {
 	LDKCurrency* o_conv = (LDKCurrency*)(o & ~1);
-	int64_t ret_val = Currency_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Currency_hash(o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Currency_eq"))) TS_Currency_eq(uint32_t a, uint32_t b) {
 	LDKCurrency* a_conv = (LDKCurrency*)(a & ~1);
 	LDKCurrency* b_conv = (LDKCurrency*)(b & ~1);
-	jboolean ret_val = Currency_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Currency_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Sha256_free"))) TS_Sha256_free(uint32_t this_obj) {
@@ -40290,8 +40351,8 @@ uint32_t  __attribute__((export_name("TS_Sha256_clone_ptr"))) TS_Sha256_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Sha256_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Sha256_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Sha256_clone"))) TS_Sha256_clone(uint32_t orig) {
@@ -40316,8 +40377,8 @@ int64_t  __attribute__((export_name("TS_Sha256_hash"))) TS_Sha256_hash(uint32_t 
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Sha256_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Sha256_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Sha256_eq"))) TS_Sha256_eq(uint32_t a, uint32_t b) {
@@ -40329,8 +40390,8 @@ jboolean  __attribute__((export_name("TS_Sha256_eq"))) TS_Sha256_eq(uint32_t a, 
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Sha256_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Sha256_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Description_free"))) TS_Description_free(uint32_t this_obj) {
@@ -40358,8 +40419,8 @@ uint32_t  __attribute__((export_name("TS_Description_clone_ptr"))) TS_Descriptio
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Description_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Description_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Description_clone"))) TS_Description_clone(uint32_t orig) {
@@ -40384,8 +40445,8 @@ int64_t  __attribute__((export_name("TS_Description_hash"))) TS_Description_hash
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Description_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Description_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Description_eq"))) TS_Description_eq(uint32_t a, uint32_t b) {
@@ -40397,8 +40458,8 @@ jboolean  __attribute__((export_name("TS_Description_eq"))) TS_Description_eq(ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Description_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Description_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PayeePubKey_free"))) TS_PayeePubKey_free(uint32_t this_obj) {
@@ -40463,8 +40524,8 @@ uint32_t  __attribute__((export_name("TS_PayeePubKey_clone_ptr"))) TS_PayeePubKe
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PayeePubKey_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PayeePubKey_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PayeePubKey_clone"))) TS_PayeePubKey_clone(uint32_t orig) {
@@ -40489,8 +40550,8 @@ int64_t  __attribute__((export_name("TS_PayeePubKey_hash"))) TS_PayeePubKey_hash
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PayeePubKey_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PayeePubKey_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_PayeePubKey_eq"))) TS_PayeePubKey_eq(uint32_t a, uint32_t b) {
@@ -40502,8 +40563,8 @@ jboolean  __attribute__((export_name("TS_PayeePubKey_eq"))) TS_PayeePubKey_eq(ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PayeePubKey_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PayeePubKey_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ExpiryTime_free"))) TS_ExpiryTime_free(uint32_t this_obj) {
@@ -40531,8 +40592,8 @@ uint32_t  __attribute__((export_name("TS_ExpiryTime_clone_ptr"))) TS_ExpiryTime_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ExpiryTime_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ExpiryTime_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ExpiryTime_clone"))) TS_ExpiryTime_clone(uint32_t orig) {
@@ -40557,8 +40618,8 @@ int64_t  __attribute__((export_name("TS_ExpiryTime_hash"))) TS_ExpiryTime_hash(u
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = ExpiryTime_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_ExpiryTime_eq"))) TS_ExpiryTime_eq(uint32_t a, uint32_t b) {
@@ -40570,8 +40631,8 @@ jboolean  __attribute__((export_name("TS_ExpiryTime_eq"))) TS_ExpiryTime_eq(uint
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ExpiryTime_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ExpiryTime_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_MinFinalCltvExpiry_free"))) TS_MinFinalCltvExpiry_free(uint32_t this_obj) {
@@ -40587,8 +40648,8 @@ int64_t  __attribute__((export_name("TS_MinFinalCltvExpiry_get_a"))) TS_MinFinal
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = MinFinalCltvExpiry_get_a(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_get_a(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_MinFinalCltvExpiry_set_a"))) TS_MinFinalCltvExpiry_set_a(uint32_t this_ptr, int64_t val) {
@@ -40629,8 +40690,8 @@ uint32_t  __attribute__((export_name("TS_MinFinalCltvExpiry_clone_ptr"))) TS_Min
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = MinFinalCltvExpiry_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = MinFinalCltvExpiry_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_MinFinalCltvExpiry_clone"))) TS_MinFinalCltvExpiry_clone(uint32_t orig) {
@@ -40655,8 +40716,8 @@ int64_t  __attribute__((export_name("TS_MinFinalCltvExpiry_hash"))) TS_MinFinalC
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = MinFinalCltvExpiry_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_MinFinalCltvExpiry_eq"))) TS_MinFinalCltvExpiry_eq(uint32_t a, uint32_t b) {
@@ -40668,8 +40729,8 @@ jboolean  __attribute__((export_name("TS_MinFinalCltvExpiry_eq"))) TS_MinFinalCl
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = MinFinalCltvExpiry_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = MinFinalCltvExpiry_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Fallback_free"))) TS_Fallback_free(uint32_t this_ptr) {
@@ -40689,8 +40750,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_Fallback_clone_ptr"))) TS_Fallback_clone_ptr(uint32_t arg) {
 	LDKFallback* arg_conv = (LDKFallback*)arg;
-	uint32_t ret_val = Fallback_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Fallback_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Fallback_clone"))) TS_Fallback_clone(uint32_t orig) {
@@ -40735,15 +40796,15 @@ uint32_t  __attribute__((export_name("TS_Fallback_script_hash"))) TS_Fallback_sc
 
 int64_t  __attribute__((export_name("TS_Fallback_hash"))) TS_Fallback_hash(uint32_t o) {
 	LDKFallback* o_conv = (LDKFallback*)o;
-	int64_t ret_val = Fallback_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Fallback_hash(o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Fallback_eq"))) TS_Fallback_eq(uint32_t a, uint32_t b) {
 	LDKFallback* a_conv = (LDKFallback*)a;
 	LDKFallback* b_conv = (LDKFallback*)b;
-	jboolean ret_val = Fallback_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Fallback_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_InvoiceSignature_free"))) TS_InvoiceSignature_free(uint32_t this_obj) {
@@ -40771,8 +40832,8 @@ uint32_t  __attribute__((export_name("TS_InvoiceSignature_clone_ptr"))) TS_Invoi
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InvoiceSignature_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InvoiceSignature_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InvoiceSignature_clone"))) TS_InvoiceSignature_clone(uint32_t orig) {
@@ -40801,8 +40862,8 @@ jboolean  __attribute__((export_name("TS_InvoiceSignature_eq"))) TS_InvoiceSigna
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InvoiceSignature_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceSignature_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PrivateRoute_free"))) TS_PrivateRoute_free(uint32_t this_obj) {
@@ -40830,8 +40891,8 @@ uint32_t  __attribute__((export_name("TS_PrivateRoute_clone_ptr"))) TS_PrivateRo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PrivateRoute_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PrivateRoute_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PrivateRoute_clone"))) TS_PrivateRoute_clone(uint32_t orig) {
@@ -40856,8 +40917,8 @@ int64_t  __attribute__((export_name("TS_PrivateRoute_hash"))) TS_PrivateRoute_ha
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PrivateRoute_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PrivateRoute_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_PrivateRoute_eq"))) TS_PrivateRoute_eq(uint32_t a, uint32_t b) {
@@ -40869,8 +40930,8 @@ jboolean  __attribute__((export_name("TS_PrivateRoute_eq"))) TS_PrivateRoute_eq(
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PrivateRoute_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PrivateRoute_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SignedRawInvoice_into_parts"))) TS_SignedRawInvoice_into_parts(uint32_t this_arg) {
@@ -40943,8 +41004,8 @@ jboolean  __attribute__((export_name("TS_SignedRawInvoice_check_signature"))) TS
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = SignedRawInvoice_check_signature(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = SignedRawInvoice_check_signature(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RawInvoice_hash"))) TS_RawInvoice_hash(uint32_t this_arg) {
@@ -41163,8 +41224,8 @@ int64_t  __attribute__((export_name("TS_PositiveTimestamp_as_unix_timestamp"))) 
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_unix_timestamp(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_unix_timestamp(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_PositiveTimestamp_as_duration_since_epoch"))) TS_PositiveTimestamp_as_duration_since_epoch(uint32_t this_arg) {
@@ -41172,8 +41233,8 @@ int64_t  __attribute__((export_name("TS_PositiveTimestamp_as_duration_since_epoc
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_duration_since_epoch(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_duration_since_epoch(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Invoice_into_signed_raw"))) TS_Invoice_into_signed_raw(uint32_t this_arg) {
@@ -41220,8 +41281,8 @@ int64_t  __attribute__((export_name("TS_Invoice_duration_since_epoch"))) TS_Invo
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_duration_since_epoch(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_duration_since_epoch(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_Invoice_payment_hash"))) TS_Invoice_payment_hash(uint32_t this_arg) {
@@ -41288,8 +41349,8 @@ int64_t  __attribute__((export_name("TS_Invoice_expiry_time"))) TS_Invoice_expir
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_expiry_time(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_expiry_time(&this_arg_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Invoice_would_expire"))) TS_Invoice_would_expire(uint32_t this_arg, int64_t at_time) {
@@ -41297,8 +41358,8 @@ jboolean  __attribute__((export_name("TS_Invoice_would_expire"))) TS_Invoice_wou
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = Invoice_would_expire(&this_arg_conv, at_time);
-	return ret_val;
+	jboolean ret_conv = Invoice_would_expire(&this_arg_conv, at_time);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_Invoice_min_final_cltv_expiry"))) TS_Invoice_min_final_cltv_expiry(uint32_t this_arg) {
@@ -41306,8 +41367,8 @@ int64_t  __attribute__((export_name("TS_Invoice_min_final_cltv_expiry"))) TS_Inv
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_min_final_cltv_expiry(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_min_final_cltv_expiry(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_tArray  __attribute__((export_name("TS_Invoice_private_routes"))) TS_Invoice_private_routes(uint32_t this_arg) {
@@ -41432,8 +41493,8 @@ int64_t  __attribute__((export_name("TS_ExpiryTime_as_seconds"))) TS_ExpiryTime_
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ExpiryTime_as_seconds(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_as_seconds(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_ExpiryTime_as_duration"))) TS_ExpiryTime_as_duration(uint32_t this_arg) {
@@ -41441,8 +41502,8 @@ int64_t  __attribute__((export_name("TS_ExpiryTime_as_duration"))) TS_ExpiryTime
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ExpiryTime_as_duration(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_as_duration(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PrivateRoute_new"))) TS_PrivateRoute_new(uint32_t hops) {
@@ -41508,8 +41569,8 @@ uint32_t  __attribute__((export_name("TS_CreationError_missing_route_hints"))) T
 jboolean  __attribute__((export_name("TS_CreationError_eq"))) TS_CreationError_eq(uint32_t a, uint32_t b) {
 	LDKCreationError* a_conv = (LDKCreationError*)(a & ~1);
 	LDKCreationError* b_conv = (LDKCreationError*)(b & ~1);
-	jboolean ret_val = CreationError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = CreationError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 jstring  __attribute__((export_name("TS_CreationError_to_str"))) TS_CreationError_to_str(uint32_t o) {
@@ -41579,8 +41640,8 @@ uint32_t  __attribute__((export_name("TS_SemanticError_imprecise_amount"))) TS_S
 jboolean  __attribute__((export_name("TS_SemanticError_eq"))) TS_SemanticError_eq(uint32_t a, uint32_t b) {
 	LDKSemanticError* a_conv = (LDKSemanticError*)(a & ~1);
 	LDKSemanticError* b_conv = (LDKSemanticError*)(b & ~1);
-	jboolean ret_val = SemanticError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SemanticError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 jstring  __attribute__((export_name("TS_SemanticError_to_str"))) TS_SemanticError_to_str(uint32_t o) {
@@ -41608,8 +41669,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_SignOrCreationError_clone_ptr"))) TS_SignOrCreationError_clone_ptr(uint32_t arg) {
 	LDKSignOrCreationError* arg_conv = (LDKSignOrCreationError*)arg;
-	uint32_t ret_val = SignOrCreationError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = SignOrCreationError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SignOrCreationError_clone"))) TS_SignOrCreationError_clone(uint32_t orig) {
@@ -41638,8 +41699,8 @@ uint32_t  __attribute__((export_name("TS_SignOrCreationError_creation_error"))) 
 jboolean  __attribute__((export_name("TS_SignOrCreationError_eq"))) TS_SignOrCreationError_eq(uint32_t a, uint32_t b) {
 	LDKSignOrCreationError* a_conv = (LDKSignOrCreationError*)a;
 	LDKSignOrCreationError* b_conv = (LDKSignOrCreationError*)b;
-	jboolean ret_val = SignOrCreationError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SignOrCreationError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 jstring  __attribute__((export_name("TS_SignOrCreationError_to_str"))) TS_SignOrCreationError_to_str(uint32_t o) {
@@ -41689,8 +41750,8 @@ uint32_t  __attribute__((export_name("TS_RetryAttempts_get_a"))) TS_RetryAttempt
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	uint32_t ret_val = RetryAttempts_get_a(&this_ptr_conv);
-	return ret_val;
+	uint32_t ret_conv = RetryAttempts_get_a(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RetryAttempts_set_a"))) TS_RetryAttempts_set_a(uint32_t this_ptr, uint32_t val) {
@@ -41731,8 +41792,8 @@ uint32_t  __attribute__((export_name("TS_RetryAttempts_clone_ptr"))) TS_RetryAtt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RetryAttempts_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RetryAttempts_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RetryAttempts_clone"))) TS_RetryAttempts_clone(uint32_t orig) {
@@ -41761,8 +41822,8 @@ jboolean  __attribute__((export_name("TS_RetryAttempts_eq"))) TS_RetryAttempts_e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RetryAttempts_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RetryAttempts_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_RetryAttempts_hash"))) TS_RetryAttempts_hash(uint32_t o) {
@@ -41770,8 +41831,8 @@ int64_t  __attribute__((export_name("TS_RetryAttempts_hash"))) TS_RetryAttempts_
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RetryAttempts_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RetryAttempts_hash(&o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PaymentError_free"))) TS_PaymentError_free(uint32_t this_ptr) {
@@ -41791,8 +41852,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_PaymentError_clone_ptr"))) TS_PaymentError_clone_ptr(uint32_t arg) {
 	LDKPaymentError* arg_conv = (LDKPaymentError*)arg;
-	uint32_t ret_val = PaymentError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PaymentError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PaymentError_clone"))) TS_PaymentError_clone(uint32_t orig) {

--- a/ts/bindings.c.body
+++ b/ts/bindings.c.body
@@ -336,12 +336,14 @@ uint32_t __attribute__((export_name("TS_LDKBech32Error_ty_from_ptr"))) TS_LDKBec
 int32_t __attribute__((export_name("TS_LDKBech32Error_InvalidChar_get_invalid_char"))) TS_LDKBech32Error_InvalidChar_get_invalid_char(uint32_t ptr) {
 	LDKBech32Error *obj = (LDKBech32Error*)(ptr & ~1);
 	assert(obj->tag == LDKBech32Error_InvalidChar);
-	return obj->invalid_char;
+			int32_t invalid_char_conv = obj->invalid_char;
+	return invalid_char_conv;
 }
 int8_t __attribute__((export_name("TS_LDKBech32Error_InvalidData_get_invalid_data"))) TS_LDKBech32Error_InvalidData_get_invalid_data(uint32_t ptr) {
 	LDKBech32Error *obj = (LDKBech32Error*)(ptr & ~1);
 	assert(obj->tag == LDKBech32Error_InvalidData);
-	return obj->invalid_data;
+			int8_t invalid_data_conv = obj->invalid_data;
+	return invalid_data_conv;
 }
 static inline LDKCVec_u8Z CVec_u8Z_clone(const LDKCVec_u8Z *orig) {
 	LDKCVec_u8Z ret = { .data = MALLOC(sizeof(int8_t) * orig->datalen, "LDKCVec_u8Z clone bytes"), .datalen = orig->datalen };
@@ -359,8 +361,8 @@ struct LDKCVec_u8Z TxOut_get_script_pubkey (struct LDKTxOut* thing) {	return CVe
 
 uint64_t TxOut_get_value (struct LDKTxOut* thing) {	return thing->value;}int64_t  __attribute__((export_name("TS_TxOut_get_value"))) TS_TxOut_get_value(uint32_t thing) {
 	LDKTxOut* thing_conv = (LDKTxOut*)(thing & ~1);
-	int64_t ret_val = TxOut_get_value(thing_conv);
-	return ret_val;
+	int64_t ret_conv = TxOut_get_value(thing_conv);
+	return ret_conv;
 }
 
 static inline void CResult_NoneNoneZ_get_ok(LDKCResult_NoneNoneZ *NONNULL_PTR owner){
@@ -570,7 +572,8 @@ uint32_t __attribute__((export_name("TS_LDKCOption_u32Z_ty_from_ptr"))) TS_LDKCO
 int32_t __attribute__((export_name("TS_LDKCOption_u32Z_Some_get_some"))) TS_LDKCOption_u32Z_Some_get_some(uint32_t ptr) {
 	LDKCOption_u32Z *obj = (LDKCOption_u32Z*)(ptr & ~1);
 	assert(obj->tag == LDKCOption_u32Z_Some);
-	return obj->some;
+			int32_t some_conv = obj->some;
+	return some_conv;
 }
 static inline struct LDKHTLCOutputInCommitment CResult_HTLCOutputInCommitmentDecodeErrorZ_get_ok(LDKCResult_HTLCOutputInCommitmentDecodeErrorZ *NONNULL_PTR owner){
 CHECK(owner->result_ok);
@@ -1076,7 +1079,8 @@ uint32_t __attribute__((export_name("TS_LDKCOption_u64Z_ty_from_ptr"))) TS_LDKCO
 int64_t __attribute__((export_name("TS_LDKCOption_u64Z_Some_get_some"))) TS_LDKCOption_u64Z_Some_get_some(uint32_t ptr) {
 	LDKCOption_u64Z *obj = (LDKCOption_u64Z*)(ptr & ~1);
 	assert(obj->tag == LDKCOption_u64Z_Some);
-	return obj->some;
+			int64_t some_conv = obj->some;
+	return some_conv;
 }
 static inline struct LDKPaymentParameters CResult_PaymentParametersDecodeErrorZ_get_ok(LDKCResult_PaymentParametersDecodeErrorZ *NONNULL_PTR owner){
 CHECK(owner->result_ok);
@@ -1262,8 +1266,8 @@ static inline uintptr_t C2Tuple_usizeTransactionZ_get_a(LDKC2Tuple_usizeTransact
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_usizeTransactionZ_get_a"))) TS_C2Tuple_usizeTransactionZ_get_a(uint32_t owner) {
 	LDKC2Tuple_usizeTransactionZ* owner_conv = (LDKC2Tuple_usizeTransactionZ*)(owner & ~1);
-	uint32_t ret_val = C2Tuple_usizeTransactionZ_get_a(owner_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_usizeTransactionZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKTransaction C2Tuple_usizeTransactionZ_get_b(LDKC2Tuple_usizeTransactionZ *NONNULL_PTR owner){
@@ -1356,7 +1360,8 @@ uint32_t __attribute__((export_name("TS_LDKMonitorEvent_UpdateCompleted_get_fund
 int64_t __attribute__((export_name("TS_LDKMonitorEvent_UpdateCompleted_get_monitor_update_id"))) TS_LDKMonitorEvent_UpdateCompleted_get_monitor_update_id(uint32_t ptr) {
 	LDKMonitorEvent *obj = (LDKMonitorEvent*)(ptr & ~1);
 	assert(obj->tag == LDKMonitorEvent_UpdateCompleted);
-	return obj->update_completed.monitor_update_id;
+			int64_t monitor_update_id_conv = obj->update_completed.monitor_update_id;
+	return monitor_update_id_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKMonitorEvent_UpdateFailed_get_update_failed"))) TS_LDKMonitorEvent_UpdateFailed_get_update_failed(uint32_t ptr) {
 	LDKMonitorEvent *obj = (LDKMonitorEvent*)(ptr & ~1);
@@ -1487,12 +1492,14 @@ uint32_t __attribute__((export_name("TS_LDKNetworkUpdate_ChannelUpdateMessage_ge
 int64_t __attribute__((export_name("TS_LDKNetworkUpdate_ChannelClosed_get_short_channel_id"))) TS_LDKNetworkUpdate_ChannelClosed_get_short_channel_id(uint32_t ptr) {
 	LDKNetworkUpdate *obj = (LDKNetworkUpdate*)(ptr & ~1);
 	assert(obj->tag == LDKNetworkUpdate_ChannelClosed);
-	return obj->channel_closed.short_channel_id;
+			int64_t short_channel_id_conv = obj->channel_closed.short_channel_id;
+	return short_channel_id_conv;
 }
 jboolean __attribute__((export_name("TS_LDKNetworkUpdate_ChannelClosed_get_is_permanent"))) TS_LDKNetworkUpdate_ChannelClosed_get_is_permanent(uint32_t ptr) {
 	LDKNetworkUpdate *obj = (LDKNetworkUpdate*)(ptr & ~1);
 	assert(obj->tag == LDKNetworkUpdate_ChannelClosed);
-	return obj->channel_closed.is_permanent;
+			jboolean is_permanent_conv = obj->channel_closed.is_permanent;
+	return is_permanent_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKNetworkUpdate_NodeFailure_get_node_id"))) TS_LDKNetworkUpdate_NodeFailure_get_node_id(uint32_t ptr) {
 	LDKNetworkUpdate *obj = (LDKNetworkUpdate*)(ptr & ~1);
@@ -1504,7 +1511,8 @@ int8_tArray __attribute__((export_name("TS_LDKNetworkUpdate_NodeFailure_get_node
 jboolean __attribute__((export_name("TS_LDKNetworkUpdate_NodeFailure_get_is_permanent"))) TS_LDKNetworkUpdate_NodeFailure_get_is_permanent(uint32_t ptr) {
 	LDKNetworkUpdate *obj = (LDKNetworkUpdate*)(ptr & ~1);
 	assert(obj->tag == LDKNetworkUpdate_NodeFailure);
-	return obj->node_failure.is_permanent;
+			jboolean is_permanent_conv = obj->node_failure.is_permanent;
+	return is_permanent_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKCOption_NetworkUpdateZ_ty_from_ptr"))) TS_LDKCOption_NetworkUpdateZ_ty_from_ptr(uint32_t ptr) {
 	LDKCOption_NetworkUpdateZ *obj = (LDKCOption_NetworkUpdateZ*)(ptr & ~1);
@@ -1632,7 +1640,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_t
 int64_t __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_channel_value_satoshis"))) TS_LDKEvent_FundingGenerationReady_get_channel_value_satoshis(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_FundingGenerationReady);
-	return obj->funding_generation_ready.channel_value_satoshis;
+			int64_t channel_value_satoshis_conv = obj->funding_generation_ready.channel_value_satoshis;
+	return channel_value_satoshis_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_output_script"))) TS_LDKEvent_FundingGenerationReady_get_output_script(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1645,7 +1654,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_o
 int64_t __attribute__((export_name("TS_LDKEvent_FundingGenerationReady_get_user_channel_id"))) TS_LDKEvent_FundingGenerationReady_get_user_channel_id(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_FundingGenerationReady);
-	return obj->funding_generation_ready.user_channel_id;
+			int64_t user_channel_id_conv = obj->funding_generation_ready.user_channel_id;
+	return user_channel_id_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKEvent_PaymentReceived_get_payment_hash"))) TS_LDKEvent_PaymentReceived_get_payment_hash(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1657,7 +1667,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_PaymentReceived_get_payment_
 int64_t __attribute__((export_name("TS_LDKEvent_PaymentReceived_get_amt"))) TS_LDKEvent_PaymentReceived_get_amt(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PaymentReceived);
-	return obj->payment_received.amt;
+			int64_t amt_conv = obj->payment_received.amt;
+	return amt_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKEvent_PaymentReceived_get_purpose"))) TS_LDKEvent_PaymentReceived_get_purpose(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1709,7 +1720,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_paymen
 jboolean __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_rejected_by_dest"))) TS_LDKEvent_PaymentPathFailed_get_rejected_by_dest(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PaymentPathFailed);
-	return obj->payment_path_failed.rejected_by_dest;
+			jboolean rejected_by_dest_conv = obj->payment_path_failed.rejected_by_dest;
+	return rejected_by_dest_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_network_update"))) TS_LDKEvent_PaymentPathFailed_get_network_update(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1720,7 +1732,8 @@ uint32_t __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_network_u
 jboolean __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_all_paths_failed"))) TS_LDKEvent_PaymentPathFailed_get_all_paths_failed(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PaymentPathFailed);
-	return obj->payment_path_failed.all_paths_failed;
+			jboolean all_paths_failed_conv = obj->payment_path_failed.all_paths_failed;
+	return all_paths_failed_conv;
 }
 uint32_tArray __attribute__((export_name("TS_LDKEvent_PaymentPathFailed_get_path"))) TS_LDKEvent_PaymentPathFailed_get_path(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1777,7 +1790,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_PaymentFailed_get_payment_ha
 int64_t __attribute__((export_name("TS_LDKEvent_PendingHTLCsForwardable_get_time_forwardable"))) TS_LDKEvent_PendingHTLCsForwardable_get_time_forwardable(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PendingHTLCsForwardable);
-	return obj->pending_htl_cs_forwardable.time_forwardable;
+			int64_t time_forwardable_conv = obj->pending_htl_cs_forwardable.time_forwardable;
+	return time_forwardable_conv;
 }
 uint32_tArray __attribute__((export_name("TS_LDKEvent_SpendableOutputs_get_outputs"))) TS_LDKEvent_SpendableOutputs_get_outputs(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1802,7 +1816,8 @@ uint32_t __attribute__((export_name("TS_LDKEvent_PaymentForwarded_get_fee_earned
 jboolean __attribute__((export_name("TS_LDKEvent_PaymentForwarded_get_claim_from_onchain_tx"))) TS_LDKEvent_PaymentForwarded_get_claim_from_onchain_tx(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_PaymentForwarded);
-	return obj->payment_forwarded.claim_from_onchain_tx;
+			jboolean claim_from_onchain_tx_conv = obj->payment_forwarded.claim_from_onchain_tx;
+	return claim_from_onchain_tx_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKEvent_ChannelClosed_get_channel_id"))) TS_LDKEvent_ChannelClosed_get_channel_id(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1814,7 +1829,8 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_ChannelClosed_get_channel_id
 int64_t __attribute__((export_name("TS_LDKEvent_ChannelClosed_get_user_channel_id"))) TS_LDKEvent_ChannelClosed_get_user_channel_id(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_ChannelClosed);
-	return obj->channel_closed.user_channel_id;
+			int64_t user_channel_id_conv = obj->channel_closed.user_channel_id;
+	return user_channel_id_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKEvent_ChannelClosed_get_reason"))) TS_LDKEvent_ChannelClosed_get_reason(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -1887,12 +1903,14 @@ int8_tArray __attribute__((export_name("TS_LDKEvent_OpenChannelRequest_get_count
 int64_t __attribute__((export_name("TS_LDKEvent_OpenChannelRequest_get_funding_satoshis"))) TS_LDKEvent_OpenChannelRequest_get_funding_satoshis(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_OpenChannelRequest);
-	return obj->open_channel_request.funding_satoshis;
+			int64_t funding_satoshis_conv = obj->open_channel_request.funding_satoshis;
+	return funding_satoshis_conv;
 }
 int64_t __attribute__((export_name("TS_LDKEvent_OpenChannelRequest_get_push_msat"))) TS_LDKEvent_OpenChannelRequest_get_push_msat(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
 	assert(obj->tag == LDKEvent_OpenChannelRequest);
-	return obj->open_channel_request.push_msat;
+			int64_t push_msat_conv = obj->open_channel_request.push_msat;
+	return push_msat_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKEvent_OpenChannelRequest_get_channel_type"))) TS_LDKEvent_OpenChannelRequest_get_channel_type(uint32_t ptr) {
 	LDKEvent *obj = (LDKEvent*)(ptr & ~1);
@@ -2953,7 +2971,8 @@ static void LDKBaseSign_JCalls_free(void* this_arg) {
 }
 LDKPublicKey get_per_commitment_point_LDKBaseSign_jcall(const void* this_arg, uint64_t idx) {
 	LDKBaseSign_JCalls *j_calls = (LDKBaseSign_JCalls*) this_arg;
-	int8_tArray ret = (int8_tArray)js_invoke_function_1(j_calls->instance_ptr, 0, (uint32_t)idx);
+	int64_t idx_conv = idx;
+	int8_tArray ret = (int8_tArray)js_invoke_function_1(j_calls->instance_ptr, 0, (uint32_t)idx_conv);
 	LDKPublicKey ret_ref;
 	CHECK(ret->arr_len == 33);
 	memcpy(ret_ref.compressed_form, ret->elems, 33); FREE(ret);
@@ -2961,7 +2980,8 @@ LDKPublicKey get_per_commitment_point_LDKBaseSign_jcall(const void* this_arg, ui
 }
 LDKThirtyTwoBytes release_commitment_secret_LDKBaseSign_jcall(const void* this_arg, uint64_t idx) {
 	LDKBaseSign_JCalls *j_calls = (LDKBaseSign_JCalls*) this_arg;
-	int8_tArray ret = (int8_tArray)js_invoke_function_1(j_calls->instance_ptr, 1, (uint32_t)idx);
+	int64_t idx_conv = idx;
+	int8_tArray ret = (int8_tArray)js_invoke_function_1(j_calls->instance_ptr, 1, (uint32_t)idx_conv);
 	LDKThirtyTwoBytes ret_ref;
 	CHECK(ret->arr_len == 32);
 	memcpy(ret_ref.data, ret->elems, 32); FREE(ret);
@@ -3037,9 +3057,10 @@ LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ sign_counterparty_commitment_L
 }
 LDKCResult_NoneNoneZ validate_counterparty_revocation_LDKBaseSign_jcall(const void* this_arg, uint64_t idx, const uint8_t (* secret)[32]) {
 	LDKBaseSign_JCalls *j_calls = (LDKBaseSign_JCalls*) this_arg;
+	int64_t idx_conv = idx;
 	int8_tArray secret_arr = init_int8_tArray(32, __LINE__);
 	memcpy(secret_arr->elems, *secret, 32);
-	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 5, (uint32_t)idx, (uint32_t)secret_arr);
+	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 5, (uint32_t)idx_conv, (uint32_t)secret_arr);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_NoneNoneZ ret_conv = *(LDKCResult_NoneNoneZ*)(ret_ptr);
@@ -3071,9 +3092,11 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_output_LDKBaseSign_jcall(const vo
 	int8_tArray justice_tx_arr = init_int8_tArray(justice_tx_var.datalen, __LINE__);
 	memcpy(justice_tx_arr->elems, justice_tx_var.data, justice_tx_var.datalen);
 	Transaction_free(justice_tx_var);
+	uint32_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_key_arr = init_int8_tArray(32, __LINE__);
 	memcpy(per_commitment_key_arr->elems, *per_commitment_key, 32);
-	uint32_t ret = js_invoke_function_4(j_calls->instance_ptr, 7, (uint32_t)justice_tx_arr, (uint32_t)input, (uint32_t)amount, (uint32_t)per_commitment_key_arr);
+	uint32_t ret = js_invoke_function_4(j_calls->instance_ptr, 7, (uint32_t)justice_tx_arr, (uint32_t)input_conv, (uint32_t)amount_conv, (uint32_t)per_commitment_key_arr);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_SignatureNoneZ ret_conv = *(LDKCResult_SignatureNoneZ*)(ret_ptr);
@@ -3086,6 +3109,8 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_htlc_LDKBaseSign_jcall(const void
 	int8_tArray justice_tx_arr = init_int8_tArray(justice_tx_var.datalen, __LINE__);
 	memcpy(justice_tx_arr->elems, justice_tx_var.data, justice_tx_var.datalen);
 	Transaction_free(justice_tx_var);
+	uint32_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_key_arr = init_int8_tArray(32, __LINE__);
 	memcpy(per_commitment_key_arr->elems, *per_commitment_key, 32);
 	LDKHTLCOutputInCommitment htlc_var = *htlc;
@@ -3098,7 +3123,7 @@ LDKCResult_SignatureNoneZ sign_justice_revoked_htlc_LDKBaseSign_jcall(const void
 	if (htlc_var.is_owned) {
 		htlc_ref |= 1;
 	}
-	uint32_t ret = js_invoke_function_5(j_calls->instance_ptr, 8, (uint32_t)justice_tx_arr, (uint32_t)input, (uint32_t)amount, (uint32_t)per_commitment_key_arr, (uint32_t)htlc_ref);
+	uint32_t ret = js_invoke_function_5(j_calls->instance_ptr, 8, (uint32_t)justice_tx_arr, (uint32_t)input_conv, (uint32_t)amount_conv, (uint32_t)per_commitment_key_arr, (uint32_t)htlc_ref);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_SignatureNoneZ ret_conv = *(LDKCResult_SignatureNoneZ*)(ret_ptr);
@@ -3111,6 +3136,8 @@ LDKCResult_SignatureNoneZ sign_counterparty_htlc_transaction_LDKBaseSign_jcall(c
 	int8_tArray htlc_tx_arr = init_int8_tArray(htlc_tx_var.datalen, __LINE__);
 	memcpy(htlc_tx_arr->elems, htlc_tx_var.data, htlc_tx_var.datalen);
 	Transaction_free(htlc_tx_var);
+	uint32_t input_conv = input;
+	int64_t amount_conv = amount;
 	int8_tArray per_commitment_point_arr = init_int8_tArray(33, __LINE__);
 	memcpy(per_commitment_point_arr->elems, per_commitment_point.compressed_form, 33);
 	LDKHTLCOutputInCommitment htlc_var = *htlc;
@@ -3123,7 +3150,7 @@ LDKCResult_SignatureNoneZ sign_counterparty_htlc_transaction_LDKBaseSign_jcall(c
 	if (htlc_var.is_owned) {
 		htlc_ref |= 1;
 	}
-	uint32_t ret = js_invoke_function_5(j_calls->instance_ptr, 9, (uint32_t)htlc_tx_arr, (uint32_t)input, (uint32_t)amount, (uint32_t)per_commitment_point_arr, (uint32_t)htlc_ref);
+	uint32_t ret = js_invoke_function_5(j_calls->instance_ptr, 9, (uint32_t)htlc_tx_arr, (uint32_t)input_conv, (uint32_t)amount_conv, (uint32_t)per_commitment_point_arr, (uint32_t)htlc_ref);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_SignatureNoneZ ret_conv = *(LDKCResult_SignatureNoneZ*)(ret_ptr);
@@ -3671,7 +3698,8 @@ uint32_t __attribute__((export_name("TS_LDKCOption_u16Z_ty_from_ptr"))) TS_LDKCO
 int16_t __attribute__((export_name("TS_LDKCOption_u16Z_Some_get_some"))) TS_LDKCOption_u16Z_Some_get_some(uint32_t ptr) {
 	LDKCOption_u16Z *obj = (LDKCOption_u16Z*)(ptr & ~1);
 	assert(obj->tag == LDKCOption_u16Z_Some);
-	return obj->some;
+			int16_t some_conv = obj->some;
+	return some_conv;
 }
 uint32_t __attribute__((export_name("TS_LDKAPIError_ty_from_ptr"))) TS_LDKAPIError_ty_from_ptr(uint32_t ptr) {
 	LDKAPIError *obj = (LDKAPIError*)(ptr & ~1);
@@ -3702,7 +3730,8 @@ jstring __attribute__((export_name("TS_LDKAPIError_FeeRateTooHigh_get_err"))) TS
 int32_t __attribute__((export_name("TS_LDKAPIError_FeeRateTooHigh_get_feerate"))) TS_LDKAPIError_FeeRateTooHigh_get_feerate(uint32_t ptr) {
 	LDKAPIError *obj = (LDKAPIError*)(ptr & ~1);
 	assert(obj->tag == LDKAPIError_FeeRateTooHigh);
-	return obj->fee_rate_too_high.feerate;
+			int32_t feerate_conv = obj->fee_rate_too_high.feerate;
+	return feerate_conv;
 }
 jstring __attribute__((export_name("TS_LDKAPIError_RouteError_get_err"))) TS_LDKAPIError_RouteError_get_err(uint32_t ptr) {
 	LDKAPIError *obj = (LDKAPIError*)(ptr & ~1);
@@ -3976,7 +4005,8 @@ int8_tArray __attribute__((export_name("TS_LDKNetAddress_IPv4_get_addr"))) TS_LD
 int16_t __attribute__((export_name("TS_LDKNetAddress_IPv4_get_port"))) TS_LDKNetAddress_IPv4_get_port(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_IPv4);
-	return obj->i_pv4.port;
+			int16_t port_conv = obj->i_pv4.port;
+	return port_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKNetAddress_IPv6_get_addr"))) TS_LDKNetAddress_IPv6_get_addr(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
@@ -3988,7 +4018,8 @@ int8_tArray __attribute__((export_name("TS_LDKNetAddress_IPv6_get_addr"))) TS_LD
 int16_t __attribute__((export_name("TS_LDKNetAddress_IPv6_get_port"))) TS_LDKNetAddress_IPv6_get_port(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_IPv6);
-	return obj->i_pv6.port;
+			int16_t port_conv = obj->i_pv6.port;
+	return port_conv;
 }
 int8_tArray __attribute__((export_name("TS_LDKNetAddress_OnionV2_get_onion_v2"))) TS_LDKNetAddress_OnionV2_get_onion_v2(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
@@ -4007,17 +4038,20 @@ int8_tArray __attribute__((export_name("TS_LDKNetAddress_OnionV3_get_ed25519_pub
 int16_t __attribute__((export_name("TS_LDKNetAddress_OnionV3_get_checksum"))) TS_LDKNetAddress_OnionV3_get_checksum(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_OnionV3);
-	return obj->onion_v3.checksum;
+			int16_t checksum_conv = obj->onion_v3.checksum;
+	return checksum_conv;
 }
 int8_t __attribute__((export_name("TS_LDKNetAddress_OnionV3_get_version"))) TS_LDKNetAddress_OnionV3_get_version(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_OnionV3);
-	return obj->onion_v3.version;
+			int8_t version_conv = obj->onion_v3.version;
+	return version_conv;
 }
 int16_t __attribute__((export_name("TS_LDKNetAddress_OnionV3_get_port"))) TS_LDKNetAddress_OnionV3_get_port(uint32_t ptr) {
 	LDKNetAddress *obj = (LDKNetAddress*)(ptr & ~1);
 	assert(obj->tag == LDKNetAddress_OnionV3);
-	return obj->onion_v3.port;
+			int16_t port_conv = obj->onion_v3.port;
+	return port_conv;
 }
 static inline LDKCVec_NetAddressZ CVec_NetAddressZ_clone(const LDKCVec_NetAddressZ *orig) {
 	LDKCVec_NetAddressZ ret = { .data = MALLOC(sizeof(LDKNetAddress) * orig->datalen, "LDKCVec_NetAddressZ clone bytes"), .datalen = orig->datalen };
@@ -4561,7 +4595,9 @@ LDKShutdownScript get_shutdown_scriptpubkey_LDKKeysInterface_jcall(const void* t
 }
 LDKSign get_channel_signer_LDKKeysInterface_jcall(const void* this_arg, bool inbound, uint64_t channel_value_satoshis) {
 	LDKKeysInterface_JCalls *j_calls = (LDKKeysInterface_JCalls*) this_arg;
-	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 21, (uint32_t)inbound, (uint32_t)channel_value_satoshis);
+	jboolean inbound_conv = inbound;
+	int64_t channel_value_satoshis_conv = channel_value_satoshis;
+	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 21, (uint32_t)inbound_conv, (uint32_t)channel_value_satoshis_conv);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKSign ret_conv = *(LDKSign*)(ret_ptr);
@@ -4789,8 +4825,8 @@ int32_t  __attribute__((export_name("TS_FeeEstimator_get_est_sat_per_1000_weight
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKFeeEstimator* this_arg_conv = (LDKFeeEstimator*)this_arg_ptr;
 	LDKConfirmationTarget confirmation_target_conv = LDKConfirmationTarget_from_js(confirmation_target);
-	int32_t ret_val = (this_arg_conv->get_est_sat_per_1000_weight)(this_arg_conv->this_arg, confirmation_target_conv);
-	return ret_val;
+	int32_t ret_conv = (this_arg_conv->get_est_sat_per_1000_weight)(this_arg_conv->this_arg, confirmation_target_conv);
+	return ret_conv;
 }
 
 typedef struct LDKLogger_JCalls {
@@ -5019,8 +5055,8 @@ int16_t  __attribute__((export_name("TS_Type_type_id"))) TS_Type_type_id(uint32_
 	void* this_arg_ptr = (void*)(((uintptr_t)this_arg) & ~1);
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKType* this_arg_conv = (LDKType*)this_arg_ptr;
-	int16_t ret_val = (this_arg_conv->type_id)(this_arg_conv->this_arg);
-	return ret_val;
+	int16_t ret_conv = (this_arg_conv->type_id)(this_arg_conv->this_arg);
+	return ret_conv;
 }
 
 jstring  __attribute__((export_name("TS_Type_debug_str"))) TS_Type_debug_str(uint32_t this_arg) {
@@ -5683,8 +5719,8 @@ static inline uint32_t C2Tuple_u32ScriptZ_get_a(LDKC2Tuple_u32ScriptZ *NONNULL_P
 }
 int32_t  __attribute__((export_name("TS_C2Tuple_u32ScriptZ_get_a"))) TS_C2Tuple_u32ScriptZ_get_a(uint32_t owner) {
 	LDKC2Tuple_u32ScriptZ* owner_conv = (LDKC2Tuple_u32ScriptZ*)(owner & ~1);
-	int32_t ret_val = C2Tuple_u32ScriptZ_get_a(owner_conv);
-	return ret_val;
+	int32_t ret_conv = C2Tuple_u32ScriptZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKCVec_u8Z C2Tuple_u32ScriptZ_get_b(LDKC2Tuple_u32ScriptZ *NONNULL_PTR owner){
@@ -5754,8 +5790,8 @@ static inline uint32_t C2Tuple_u32TxOutZ_get_a(LDKC2Tuple_u32TxOutZ *NONNULL_PTR
 }
 int32_t  __attribute__((export_name("TS_C2Tuple_u32TxOutZ_get_a"))) TS_C2Tuple_u32TxOutZ_get_a(uint32_t owner) {
 	LDKC2Tuple_u32TxOutZ* owner_conv = (LDKC2Tuple_u32TxOutZ*)(owner & ~1);
-	int32_t ret_val = C2Tuple_u32TxOutZ_get_a(owner_conv);
-	return ret_val;
+	int32_t ret_conv = C2Tuple_u32TxOutZ_get_a(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKTxOut C2Tuple_u32TxOutZ_get_b(LDKC2Tuple_u32TxOutZ *NONNULL_PTR owner){
@@ -5824,37 +5860,44 @@ uint32_t __attribute__((export_name("TS_LDKBalance_ty_from_ptr"))) TS_LDKBalance
 int64_t __attribute__((export_name("TS_LDKBalance_ClaimableOnChannelClose_get_claimable_amount_satoshis"))) TS_LDKBalance_ClaimableOnChannelClose_get_claimable_amount_satoshis(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ClaimableOnChannelClose);
-	return obj->claimable_on_channel_close.claimable_amount_satoshis;
+			int64_t claimable_amount_satoshis_conv = obj->claimable_on_channel_close.claimable_amount_satoshis;
+	return claimable_amount_satoshis_conv;
 }
 int64_t __attribute__((export_name("TS_LDKBalance_ClaimableAwaitingConfirmations_get_claimable_amount_satoshis"))) TS_LDKBalance_ClaimableAwaitingConfirmations_get_claimable_amount_satoshis(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ClaimableAwaitingConfirmations);
-	return obj->claimable_awaiting_confirmations.claimable_amount_satoshis;
+			int64_t claimable_amount_satoshis_conv = obj->claimable_awaiting_confirmations.claimable_amount_satoshis;
+	return claimable_amount_satoshis_conv;
 }
 int32_t __attribute__((export_name("TS_LDKBalance_ClaimableAwaitingConfirmations_get_confirmation_height"))) TS_LDKBalance_ClaimableAwaitingConfirmations_get_confirmation_height(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ClaimableAwaitingConfirmations);
-	return obj->claimable_awaiting_confirmations.confirmation_height;
+			int32_t confirmation_height_conv = obj->claimable_awaiting_confirmations.confirmation_height;
+	return confirmation_height_conv;
 }
 int64_t __attribute__((export_name("TS_LDKBalance_ContentiousClaimable_get_claimable_amount_satoshis"))) TS_LDKBalance_ContentiousClaimable_get_claimable_amount_satoshis(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ContentiousClaimable);
-	return obj->contentious_claimable.claimable_amount_satoshis;
+			int64_t claimable_amount_satoshis_conv = obj->contentious_claimable.claimable_amount_satoshis;
+	return claimable_amount_satoshis_conv;
 }
 int32_t __attribute__((export_name("TS_LDKBalance_ContentiousClaimable_get_timeout_height"))) TS_LDKBalance_ContentiousClaimable_get_timeout_height(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_ContentiousClaimable);
-	return obj->contentious_claimable.timeout_height;
+			int32_t timeout_height_conv = obj->contentious_claimable.timeout_height;
+	return timeout_height_conv;
 }
 int64_t __attribute__((export_name("TS_LDKBalance_MaybeClaimableHTLCAwaitingTimeout_get_claimable_amount_satoshis"))) TS_LDKBalance_MaybeClaimableHTLCAwaitingTimeout_get_claimable_amount_satoshis(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_MaybeClaimableHTLCAwaitingTimeout);
-	return obj->maybe_claimable_htlc_awaiting_timeout.claimable_amount_satoshis;
+			int64_t claimable_amount_satoshis_conv = obj->maybe_claimable_htlc_awaiting_timeout.claimable_amount_satoshis;
+	return claimable_amount_satoshis_conv;
 }
 int32_t __attribute__((export_name("TS_LDKBalance_MaybeClaimableHTLCAwaitingTimeout_get_claimable_height"))) TS_LDKBalance_MaybeClaimableHTLCAwaitingTimeout_get_claimable_height(uint32_t ptr) {
 	LDKBalance *obj = (LDKBalance*)(ptr & ~1);
 	assert(obj->tag == LDKBalance_MaybeClaimableHTLCAwaitingTimeout);
-	return obj->maybe_claimable_htlc_awaiting_timeout.claimable_height;
+			int32_t claimable_height_conv = obj->maybe_claimable_htlc_awaiting_timeout.claimable_height;
+	return claimable_height_conv;
 }
 static inline LDKCVec_BalanceZ CVec_BalanceZ_clone(const LDKCVec_BalanceZ *orig) {
 	LDKCVec_BalanceZ ret = { .data = MALLOC(sizeof(LDKBalance) * orig->datalen, "LDKCVec_BalanceZ clone bytes"), .datalen = orig->datalen };
@@ -5979,8 +6022,8 @@ CHECK(owner->result_ok);
 }
 jboolean  __attribute__((export_name("TS_CResult_boolLightningErrorZ_get_ok"))) TS_CResult_boolLightningErrorZ_get_ok(uint32_t owner) {
 	LDKCResult_boolLightningErrorZ* owner_conv = (LDKCResult_boolLightningErrorZ*)(owner & ~1);
-	jboolean ret_val = CResult_boolLightningErrorZ_get_ok(owner_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolLightningErrorZ_get_ok(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKLightningError CResult_boolLightningErrorZ_get_err(LDKCResult_boolLightningErrorZ *NONNULL_PTR owner){
@@ -6144,8 +6187,8 @@ CHECK(owner->result_ok);
 }
 jboolean  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_get_ok"))) TS_CResult_boolPeerHandleErrorZ_get_ok(uint32_t owner) {
 	LDKCResult_boolPeerHandleErrorZ* owner_conv = (LDKCResult_boolPeerHandleErrorZ*)(owner & ~1);
-	jboolean ret_val = CResult_boolPeerHandleErrorZ_get_ok(owner_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolPeerHandleErrorZ_get_ok(owner_conv);
+	return ret_conv;
 }
 
 static inline struct LDKPeerHandleError CResult_boolPeerHandleErrorZ_get_err(LDKCResult_boolPeerHandleErrorZ *NONNULL_PTR owner){
@@ -6246,7 +6289,8 @@ LDKCResult_TxOutAccessErrorZ get_utxo_LDKAccess_jcall(const void* this_arg, cons
 	LDKAccess_JCalls *j_calls = (LDKAccess_JCalls*) this_arg;
 	int8_tArray genesis_hash_arr = init_int8_tArray(32, __LINE__);
 	memcpy(genesis_hash_arr->elems, *genesis_hash, 32);
-	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 31, (uint32_t)genesis_hash_arr, (uint32_t)short_channel_id);
+	int64_t short_channel_id_conv = short_channel_id;
+	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 31, (uint32_t)genesis_hash_arr, (uint32_t)short_channel_id_conv);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_TxOutAccessErrorZ ret_conv = *(LDKCResult_TxOutAccessErrorZ*)(ret_ptr);
@@ -8160,13 +8204,15 @@ void block_connected_LDKListen_jcall(const void* this_arg, LDKu8slice block, uin
 	LDKu8slice block_var = block;
 	int8_tArray block_arr = init_int8_tArray(block_var.datalen, __LINE__);
 	memcpy(block_arr->elems, block_var.data, block_var.datalen);
-	js_invoke_function_2(j_calls->instance_ptr, 37, (uint32_t)block_arr, (uint32_t)height);
+	int32_t height_conv = height;
+	js_invoke_function_2(j_calls->instance_ptr, 37, (uint32_t)block_arr, (uint32_t)height_conv);
 }
 void block_disconnected_LDKListen_jcall(const void* this_arg, const uint8_t (* header)[80], uint32_t height) {
 	LDKListen_JCalls *j_calls = (LDKListen_JCalls*) this_arg;
 	int8_tArray header_arr = init_int8_tArray(80, __LINE__);
 	memcpy(header_arr->elems, *header, 80);
-	js_invoke_function_2(j_calls->instance_ptr, 38, (uint32_t)header_arr, (uint32_t)height);
+	int32_t height_conv = height;
+	js_invoke_function_2(j_calls->instance_ptr, 38, (uint32_t)header_arr, (uint32_t)height_conv);
 }
 static void LDKListen_JCalls_cloned(LDKListen* new_obj) {
 	LDKListen_JCalls *j_calls = (LDKListen_JCalls*) new_obj->this_arg;
@@ -8236,7 +8282,8 @@ void transactions_confirmed_LDKConfirm_jcall(const void* this_arg, const uint8_t
 	}
 	
 	FREE(txdata_var.data);
-	js_invoke_function_3(j_calls->instance_ptr, 39, (uint32_t)header_arr, (uint32_t)txdata_arr, (uint32_t)height);
+	int32_t height_conv = height;
+	js_invoke_function_3(j_calls->instance_ptr, 39, (uint32_t)header_arr, (uint32_t)txdata_arr, (uint32_t)height_conv);
 }
 void transaction_unconfirmed_LDKConfirm_jcall(const void* this_arg, const uint8_t (* txid)[32]) {
 	LDKConfirm_JCalls *j_calls = (LDKConfirm_JCalls*) this_arg;
@@ -8248,7 +8295,8 @@ void best_block_updated_LDKConfirm_jcall(const void* this_arg, const uint8_t (* 
 	LDKConfirm_JCalls *j_calls = (LDKConfirm_JCalls*) this_arg;
 	int8_tArray header_arr = init_int8_tArray(80, __LINE__);
 	memcpy(header_arr->elems, *header, 80);
-	js_invoke_function_2(j_calls->instance_ptr, 41, (uint32_t)header_arr, (uint32_t)height);
+	int32_t height_conv = height;
+	js_invoke_function_2(j_calls->instance_ptr, 41, (uint32_t)header_arr, (uint32_t)height_conv);
 }
 LDKCVec_TxidZ get_relevant_txids_LDKConfirm_jcall(const void* this_arg) {
 	LDKConfirm_JCalls *j_calls = (LDKConfirm_JCalls*) this_arg;
@@ -8810,7 +8858,8 @@ void peer_disconnected_LDKChannelMessageHandler_jcall(const void* this_arg, LDKP
 	LDKChannelMessageHandler_JCalls *j_calls = (LDKChannelMessageHandler_JCalls*) this_arg;
 	int8_tArray their_node_id_arr = init_int8_tArray(33, __LINE__);
 	memcpy(their_node_id_arr->elems, their_node_id.compressed_form, 33);
-	js_invoke_function_2(j_calls->instance_ptr, 60, (uint32_t)their_node_id_arr, (uint32_t)no_connection_possible);
+	jboolean no_connection_possible_conv = no_connection_possible;
+	js_invoke_function_2(j_calls->instance_ptr, 60, (uint32_t)their_node_id_arr, (uint32_t)no_connection_possible_conv);
 }
 void peer_connected_LDKChannelMessageHandler_jcall(const void* this_arg, LDKPublicKey their_node_id, const LDKInit * msg) {
 	LDKChannelMessageHandler_JCalls *j_calls = (LDKChannelMessageHandler_JCalls*) this_arg;
@@ -9279,7 +9328,9 @@ LDKCResult_boolLightningErrorZ handle_channel_update_LDKRoutingMessageHandler_jc
 }
 LDKCVec_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZZ get_next_channel_announcements_LDKRoutingMessageHandler_jcall(const void* this_arg, uint64_t starting_point, uint8_t batch_amount) {
 	LDKRoutingMessageHandler_JCalls *j_calls = (LDKRoutingMessageHandler_JCalls*) this_arg;
-	uint32_tArray ret = (uint32_tArray)js_invoke_function_2(j_calls->instance_ptr, 68, (uint32_t)starting_point, (uint32_t)batch_amount);
+	int64_t starting_point_conv = starting_point;
+	int8_t batch_amount_conv = batch_amount;
+	uint32_tArray ret = (uint32_tArray)js_invoke_function_2(j_calls->instance_ptr, 68, (uint32_t)starting_point_conv, (uint32_t)batch_amount_conv);
 	LDKCVec_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZZ ret_constr;
 	ret_constr.datalen = ret->arr_len;
 	if (ret_constr.datalen > 0)
@@ -9301,7 +9352,8 @@ LDKCVec_NodeAnnouncementZ get_next_node_announcements_LDKRoutingMessageHandler_j
 	LDKRoutingMessageHandler_JCalls *j_calls = (LDKRoutingMessageHandler_JCalls*) this_arg;
 	int8_tArray starting_point_arr = init_int8_tArray(33, __LINE__);
 	memcpy(starting_point_arr->elems, starting_point.compressed_form, 33);
-	uint32_tArray ret = (uint32_tArray)js_invoke_function_2(j_calls->instance_ptr, 69, (uint32_t)starting_point_arr, (uint32_t)batch_amount);
+	int8_t batch_amount_conv = batch_amount;
+	uint32_tArray ret = (uint32_tArray)js_invoke_function_2(j_calls->instance_ptr, 69, (uint32_t)starting_point_arr, (uint32_t)batch_amount_conv);
 	LDKCVec_NodeAnnouncementZ ret_constr;
 	ret_constr.datalen = ret->arr_len;
 	if (ret_constr.datalen > 0)
@@ -9627,10 +9679,11 @@ static void LDKCustomMessageReader_JCalls_free(void* this_arg) {
 }
 LDKCResult_COption_TypeZDecodeErrorZ read_LDKCustomMessageReader_jcall(const void* this_arg, uint16_t message_type, LDKu8slice buffer) {
 	LDKCustomMessageReader_JCalls *j_calls = (LDKCustomMessageReader_JCalls*) this_arg;
+	int16_t message_type_conv = message_type;
 	LDKu8slice buffer_var = buffer;
 	int8_tArray buffer_arr = init_int8_tArray(buffer_var.datalen, __LINE__);
 	memcpy(buffer_arr->elems, buffer_var.data, buffer_var.datalen);
-	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 75, (uint32_t)message_type, (uint32_t)buffer_arr);
+	uint32_t ret = js_invoke_function_2(j_calls->instance_ptr, 75, (uint32_t)message_type_conv, (uint32_t)buffer_arr);
 	void* ret_ptr = (void*)(((uintptr_t)ret) & ~1);
 	CHECK_ACCESS(ret_ptr);
 	LDKCResult_COption_TypeZDecodeErrorZ ret_conv = *(LDKCResult_COption_TypeZDecodeErrorZ*)(ret_ptr);
@@ -9791,7 +9844,8 @@ uintptr_t send_data_LDKSocketDescriptor_jcall(void* this_arg, LDKu8slice data, b
 	LDKu8slice data_var = data;
 	int8_tArray data_arr = init_int8_tArray(data_var.datalen, __LINE__);
 	memcpy(data_arr->elems, data_var.data, data_var.datalen);
-	return js_invoke_function_2(j_calls->instance_ptr, 78, (uint32_t)data_arr, (uint32_t)resume_read);
+	jboolean resume_read_conv = resume_read;
+	return js_invoke_function_2(j_calls->instance_ptr, 78, (uint32_t)data_arr, (uint32_t)resume_read_conv);
 }
 void disconnect_socket_LDKSocketDescriptor_jcall(void* this_arg) {
 	LDKSocketDescriptor_JCalls *j_calls = (LDKSocketDescriptor_JCalls*) this_arg;
@@ -9839,8 +9893,8 @@ uint32_t  __attribute__((export_name("TS_SocketDescriptor_send_data"))) TS_Socke
 	LDKu8slice data_ref;
 	data_ref.datalen = data->arr_len;
 	data_ref.data = data->elems /* XXX data leaks */;
-	uint32_t ret_val = (this_arg_conv->send_data)(this_arg_conv->this_arg, data_ref, resume_read);
-	return ret_val;
+	uint32_t ret_conv = (this_arg_conv->send_data)(this_arg_conv->this_arg, data_ref, resume_read);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_SocketDescriptor_disconnect_socket"))) TS_SocketDescriptor_disconnect_socket(uint32_t this_arg) {
@@ -9854,8 +9908,8 @@ int64_t  __attribute__((export_name("TS_SocketDescriptor_hash"))) TS_SocketDescr
 	void* this_arg_ptr = (void*)(((uintptr_t)this_arg) & ~1);
 	if (!(this_arg & 1)) { CHECK_ACCESS(this_arg_ptr); }
 	LDKSocketDescriptor* this_arg_conv = (LDKSocketDescriptor*)this_arg_ptr;
-	int64_t ret_val = (this_arg_conv->hash)(this_arg_conv->this_arg);
-	return ret_val;
+	int64_t ret_conv = (this_arg_conv->hash)(this_arg_conv->this_arg);
+	return ret_conv;
 }
 
 uint32_t __attribute__((export_name("TS_LDKEffectiveCapacity_ty_from_ptr"))) TS_LDKEffectiveCapacity_ty_from_ptr(uint32_t ptr) {
@@ -9872,17 +9926,20 @@ uint32_t __attribute__((export_name("TS_LDKEffectiveCapacity_ty_from_ptr"))) TS_
 int64_t __attribute__((export_name("TS_LDKEffectiveCapacity_ExactLiquidity_get_liquidity_msat"))) TS_LDKEffectiveCapacity_ExactLiquidity_get_liquidity_msat(uint32_t ptr) {
 	LDKEffectiveCapacity *obj = (LDKEffectiveCapacity*)(ptr & ~1);
 	assert(obj->tag == LDKEffectiveCapacity_ExactLiquidity);
-	return obj->exact_liquidity.liquidity_msat;
+			int64_t liquidity_msat_conv = obj->exact_liquidity.liquidity_msat;
+	return liquidity_msat_conv;
 }
 int64_t __attribute__((export_name("TS_LDKEffectiveCapacity_MaximumHTLC_get_amount_msat"))) TS_LDKEffectiveCapacity_MaximumHTLC_get_amount_msat(uint32_t ptr) {
 	LDKEffectiveCapacity *obj = (LDKEffectiveCapacity*)(ptr & ~1);
 	assert(obj->tag == LDKEffectiveCapacity_MaximumHTLC);
-	return obj->maximum_htlc.amount_msat;
+			int64_t amount_msat_conv = obj->maximum_htlc.amount_msat;
+	return amount_msat_conv;
 }
 int64_t __attribute__((export_name("TS_LDKEffectiveCapacity_Total_get_capacity_msat"))) TS_LDKEffectiveCapacity_Total_get_capacity_msat(uint32_t ptr) {
 	LDKEffectiveCapacity *obj = (LDKEffectiveCapacity*)(ptr & ~1);
 	assert(obj->tag == LDKEffectiveCapacity_Total);
-	return obj->total.capacity_msat;
+			int64_t capacity_msat_conv = obj->total.capacity_msat;
+	return capacity_msat_conv;
 }
 typedef struct LDKScore_JCalls {
 	atomic_size_t refcnt;
@@ -9896,6 +9953,9 @@ static void LDKScore_JCalls_free(void* this_arg) {
 }
 uint64_t channel_penalty_msat_LDKScore_jcall(const void* this_arg, uint64_t short_channel_id, uint64_t send_amt_msat, uint64_t capacity_msat, const LDKNodeId * source, const LDKNodeId * target) {
 	LDKScore_JCalls *j_calls = (LDKScore_JCalls*) this_arg;
+	int64_t short_channel_id_conv = short_channel_id;
+	int64_t send_amt_msat_conv = send_amt_msat;
+	int64_t capacity_msat_conv = capacity_msat;
 	LDKNodeId source_var = *source;
 	uint32_t source_ref = 0;
 	source_var = NodeId_clone(&source_var);
@@ -9916,7 +9976,7 @@ uint64_t channel_penalty_msat_LDKScore_jcall(const void* this_arg, uint64_t shor
 	if (target_var.is_owned) {
 		target_ref |= 1;
 	}
-	return js_invoke_function_5(j_calls->instance_ptr, 82, (uint32_t)short_channel_id, (uint32_t)send_amt_msat, (uint32_t)capacity_msat, (uint32_t)source_ref, (uint32_t)target_ref);
+	return js_invoke_function_5(j_calls->instance_ptr, 82, (uint32_t)short_channel_id_conv, (uint32_t)send_amt_msat_conv, (uint32_t)capacity_msat_conv, (uint32_t)source_ref, (uint32_t)target_ref);
 }
 void payment_path_failed_LDKScore_jcall(void* this_arg, LDKCVec_RouteHopZ path, uint64_t short_channel_id) {
 	LDKScore_JCalls *j_calls = (LDKScore_JCalls*) this_arg;
@@ -9938,7 +9998,8 @@ void payment_path_failed_LDKScore_jcall(void* this_arg, LDKCVec_RouteHopZ path, 
 	}
 	
 	FREE(path_var.data);
-	js_invoke_function_2(j_calls->instance_ptr, 83, (uint32_t)path_arr, (uint32_t)short_channel_id);
+	int64_t short_channel_id_conv = short_channel_id;
+	js_invoke_function_2(j_calls->instance_ptr, 83, (uint32_t)path_arr, (uint32_t)short_channel_id_conv);
 }
 void payment_path_successful_LDKScore_jcall(void* this_arg, LDKCVec_RouteHopZ path) {
 	LDKScore_JCalls *j_calls = (LDKScore_JCalls*) this_arg;
@@ -10007,8 +10068,8 @@ int64_t  __attribute__((export_name("TS_Score_channel_penalty_msat"))) TS_Score_
 	target_conv.inner = (void*)(target & (~1));
 	target_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(target_conv);
-	int64_t ret_val = (this_arg_conv->channel_penalty_msat)(this_arg_conv->this_arg, short_channel_id, send_amt_msat, capacity_msat, &source_conv, &target_conv);
-	return ret_val;
+	int64_t ret_conv = (this_arg_conv->channel_penalty_msat)(this_arg_conv->this_arg, short_channel_id, send_amt_msat, capacity_msat, &source_conv, &target_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Score_payment_path_failed"))) TS_Score_payment_path_failed(uint32_t this_arg, uint32_tArray path, int64_t short_channel_id) {
@@ -10529,8 +10590,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_Bech32Error_clone_ptr"))) TS_Bech32Error_clone_ptr(uint32_t arg) {
 	LDKBech32Error* arg_conv = (LDKBech32Error*)arg;
-	uint32_t ret_val = Bech32Error_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Bech32Error_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Bech32Error_clone"))) TS_Bech32Error_clone(uint32_t orig) {
@@ -10585,8 +10646,8 @@ static inline uintptr_t TxOut_clone_ptr(LDKTxOut *NONNULL_PTR arg) {
 }
 uint32_t  __attribute__((export_name("TS_TxOut_clone_ptr"))) TS_TxOut_clone_ptr(uint32_t arg) {
 	LDKTxOut* arg_conv = (LDKTxOut*)(arg & ~1);
-	uint32_t ret_val = TxOut_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = TxOut_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_TxOut_clone"))) TS_TxOut_clone(uint32_t orig) {
@@ -10615,8 +10676,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneNoneZ_err"))) TS_CResult_No
 
 jboolean  __attribute__((export_name("TS_CResult_NoneNoneZ_is_ok"))) TS_CResult_NoneNoneZ_is_ok(uint32_t o) {
 	LDKCResult_NoneNoneZ* o_conv = (LDKCResult_NoneNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneNoneZ_free"))) TS_CResult_NoneNoneZ_free(uint32_t _res) {
@@ -10635,8 +10696,8 @@ static inline uintptr_t CResult_NoneNoneZ_clone_ptr(LDKCResult_NoneNoneZ *NONNUL
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneNoneZ_clone_ptr"))) TS_CResult_NoneNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneNoneZ* arg_conv = (LDKCResult_NoneNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneNoneZ_clone"))) TS_CResult_NoneNoneZ_clone(uint32_t orig) {
@@ -10670,8 +10731,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDe
 
 jboolean  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok"))) TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ* o_conv = (LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_free"))) TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_free(uint32_t _res) {
@@ -10690,8 +10751,8 @@ static inline uintptr_t CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_
 }
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr"))) TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyCommitmentSecretsDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone"))) TS_CResult_CounterpartyCommitmentSecretsDecodeErrorZ_clone(uint32_t orig) {
@@ -10719,8 +10780,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_err"))) TS_CRes
 
 jboolean  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_is_ok"))) TS_CResult_SecretKeyErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SecretKeyErrorZ* o_conv = (LDKCResult_SecretKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SecretKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SecretKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_free"))) TS_CResult_SecretKeyErrorZ_free(uint32_t _res) {
@@ -10739,8 +10800,8 @@ static inline uintptr_t CResult_SecretKeyErrorZ_clone_ptr(LDKCResult_SecretKeyEr
 }
 uint32_t  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_clone_ptr"))) TS_CResult_SecretKeyErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SecretKeyErrorZ* arg_conv = (LDKCResult_SecretKeyErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SecretKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SecretKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SecretKeyErrorZ_clone"))) TS_CResult_SecretKeyErrorZ_clone(uint32_t orig) {
@@ -10768,8 +10829,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_err"))) TS_CRes
 
 jboolean  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_is_ok"))) TS_CResult_PublicKeyErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PublicKeyErrorZ* o_conv = (LDKCResult_PublicKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PublicKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PublicKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_free"))) TS_CResult_PublicKeyErrorZ_free(uint32_t _res) {
@@ -10788,8 +10849,8 @@ static inline uintptr_t CResult_PublicKeyErrorZ_clone_ptr(LDKCResult_PublicKeyEr
 }
 uint32_t  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_clone_ptr"))) TS_CResult_PublicKeyErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PublicKeyErrorZ* arg_conv = (LDKCResult_PublicKeyErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PublicKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PublicKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PublicKeyErrorZ_clone"))) TS_CResult_PublicKeyErrorZ_clone(uint32_t orig) {
@@ -10823,8 +10884,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_is_ok"))) TS_CResult_TxCreationKeysDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_TxCreationKeysDecodeErrorZ* o_conv = (LDKCResult_TxCreationKeysDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxCreationKeysDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxCreationKeysDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_free"))) TS_CResult_TxCreationKeysDecodeErrorZ_free(uint32_t _res) {
@@ -10843,8 +10904,8 @@ static inline uintptr_t CResult_TxCreationKeysDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_clone_ptr"))) TS_CResult_TxCreationKeysDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_TxCreationKeysDecodeErrorZ* arg_conv = (LDKCResult_TxCreationKeysDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_TxCreationKeysDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_TxCreationKeysDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysDecodeErrorZ_clone"))) TS_CResult_TxCreationKeysDecodeErrorZ_clone(uint32_t orig) {
@@ -10878,8 +10939,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_is_ok"))) TS_CResult_ChannelPublicKeysDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelPublicKeysDecodeErrorZ* o_conv = (LDKCResult_ChannelPublicKeysDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelPublicKeysDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelPublicKeysDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_free"))) TS_CResult_ChannelPublicKeysDecodeErrorZ_free(uint32_t _res) {
@@ -10898,8 +10959,8 @@ static inline uintptr_t CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelPublicKeysDecodeErrorZ* arg_conv = (LDKCResult_ChannelPublicKeysDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelPublicKeysDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelPublicKeysDecodeErrorZ_clone"))) TS_CResult_ChannelPublicKeysDecodeErrorZ_clone(uint32_t orig) {
@@ -10929,8 +10990,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_is_ok"))) TS_CResult_TxCreationKeysErrorZ_is_ok(uint32_t o) {
 	LDKCResult_TxCreationKeysErrorZ* o_conv = (LDKCResult_TxCreationKeysErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxCreationKeysErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxCreationKeysErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_free"))) TS_CResult_TxCreationKeysErrorZ_free(uint32_t _res) {
@@ -10949,8 +11010,8 @@ static inline uintptr_t CResult_TxCreationKeysErrorZ_clone_ptr(LDKCResult_TxCrea
 }
 uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_clone_ptr"))) TS_CResult_TxCreationKeysErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_TxCreationKeysErrorZ* arg_conv = (LDKCResult_TxCreationKeysErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_TxCreationKeysErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_TxCreationKeysErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_TxCreationKeysErrorZ_clone"))) TS_CResult_TxCreationKeysErrorZ_clone(uint32_t orig) {
@@ -10991,8 +11052,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_u32Z_clone_ptr"))) TS_COption_u32Z_clone_ptr(uint32_t arg) {
 	LDKCOption_u32Z* arg_conv = (LDKCOption_u32Z*)arg;
-	uint32_t ret_val = COption_u32Z_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_u32Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_u32Z_clone"))) TS_COption_u32Z_clone(uint32_t orig) {
@@ -11027,8 +11088,8 @@ uint32_t  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErr
 
 jboolean  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok"))) TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_HTLCOutputInCommitmentDecodeErrorZ* o_conv = (LDKCResult_HTLCOutputInCommitmentDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HTLCOutputInCommitmentDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_free"))) TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_free(uint32_t _res) {
@@ -11047,8 +11108,8 @@ static inline uintptr_t CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(LDK
 }
 uint32_t  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr"))) TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_HTLCOutputInCommitmentDecodeErrorZ* arg_conv = (LDKCResult_HTLCOutputInCommitmentDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_HTLCOutputInCommitmentDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_clone"))) TS_CResult_HTLCOutputInCommitmentDecodeErrorZ_clone(uint32_t orig) {
@@ -11097,8 +11158,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionP
 
 jboolean  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok"))) TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ* o_conv = (LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_free"))) TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_free(uint32_t _res) {
@@ -11117,8 +11178,8 @@ static inline uintptr_t CResult_CounterpartyChannelTransactionParametersDecodeEr
 }
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr"))) TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyChannelTransactionParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone"))) TS_CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -11152,8 +11213,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDec
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDecodeErrorZ_is_ok"))) TS_CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelTransactionParametersDecodeErrorZ* o_conv = (LDKCResult_ChannelTransactionParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelTransactionParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDecodeErrorZ_free"))) TS_CResult_ChannelTransactionParametersDecodeErrorZ_free(uint32_t _res) {
@@ -11172,8 +11233,8 @@ static inline uintptr_t CResult_ChannelTransactionParametersDecodeErrorZ_clone_p
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelTransactionParametersDecodeErrorZ* arg_conv = (LDKCResult_ChannelTransactionParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelTransactionParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelTransactionParametersDecodeErrorZ_clone"))) TS_CResult_ChannelTransactionParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -11225,8 +11286,8 @@ uint32_t  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDeco
 
 jboolean  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok"))) TS_CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_HolderCommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_HolderCommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HolderCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDecodeErrorZ_free"))) TS_CResult_HolderCommitmentTransactionDecodeErrorZ_free(uint32_t _res) {
@@ -11245,8 +11306,8 @@ static inline uintptr_t CResult_HolderCommitmentTransactionDecodeErrorZ_clone_pt
 }
 uint32_t  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr"))) TS_CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_HolderCommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_HolderCommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_HolderCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_HolderCommitmentTransactionDecodeErrorZ_clone"))) TS_CResult_HolderCommitmentTransactionDecodeErrorZ_clone(uint32_t orig) {
@@ -11280,8 +11341,8 @@ uint32_t  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecod
 
 jboolean  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok"))) TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_BuiltCommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_BuiltCommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_BuiltCommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_free"))) TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_free(uint32_t _res) {
@@ -11300,8 +11361,8 @@ static inline uintptr_t CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr
 }
 uint32_t  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr"))) TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_BuiltCommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_BuiltCommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_BuiltCommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_clone"))) TS_CResult_BuiltCommitmentTransactionDecodeErrorZ_clone(uint32_t orig) {
@@ -11330,8 +11391,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TrustedClosingTransactionNoneZ_
 
 jboolean  __attribute__((export_name("TS_CResult_TrustedClosingTransactionNoneZ_is_ok"))) TS_CResult_TrustedClosingTransactionNoneZ_is_ok(uint32_t o) {
 	LDKCResult_TrustedClosingTransactionNoneZ* o_conv = (LDKCResult_TrustedClosingTransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TrustedClosingTransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TrustedClosingTransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TrustedClosingTransactionNoneZ_free"))) TS_CResult_TrustedClosingTransactionNoneZ_free(uint32_t _res) {
@@ -11367,8 +11428,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErrorZ_is_ok"))) TS_CResult_CommitmentTransactionDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CommitmentTransactionDecodeErrorZ* o_conv = (LDKCResult_CommitmentTransactionDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CommitmentTransactionDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CommitmentTransactionDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErrorZ_free"))) TS_CResult_CommitmentTransactionDecodeErrorZ_free(uint32_t _res) {
@@ -11387,8 +11448,8 @@ static inline uintptr_t CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErrorZ_clone_ptr"))) TS_CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CommitmentTransactionDecodeErrorZ* arg_conv = (LDKCResult_CommitmentTransactionDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CommitmentTransactionDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CommitmentTransactionDecodeErrorZ_clone"))) TS_CResult_CommitmentTransactionDecodeErrorZ_clone(uint32_t orig) {
@@ -11417,8 +11478,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TrustedCommitmentTransactionNon
 
 jboolean  __attribute__((export_name("TS_CResult_TrustedCommitmentTransactionNoneZ_is_ok"))) TS_CResult_TrustedCommitmentTransactionNoneZ_is_ok(uint32_t o) {
 	LDKCResult_TrustedCommitmentTransactionNoneZ* o_conv = (LDKCResult_TrustedCommitmentTransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TrustedCommitmentTransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TrustedCommitmentTransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TrustedCommitmentTransactionNoneZ_free"))) TS_CResult_TrustedCommitmentTransactionNoneZ_free(uint32_t _res) {
@@ -11458,8 +11519,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_is_ok"))) TS_CResult_CVec_SignatureZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_CVec_SignatureZNoneZ* o_conv = (LDKCResult_CVec_SignatureZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_SignatureZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_SignatureZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_free"))) TS_CResult_CVec_SignatureZNoneZ_free(uint32_t _res) {
@@ -11478,8 +11539,8 @@ static inline uintptr_t CResult_CVec_SignatureZNoneZ_clone_ptr(LDKCResult_CVec_S
 }
 uint32_t  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_clone_ptr"))) TS_CResult_CVec_SignatureZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CVec_SignatureZNoneZ* arg_conv = (LDKCResult_CVec_SignatureZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CVec_SignatureZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CVec_SignatureZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CVec_SignatureZNoneZ_clone"))) TS_CResult_CVec_SignatureZNoneZ_clone(uint32_t orig) {
@@ -11513,8 +11574,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_is_ok"))) TS_CResult_ShutdownScriptDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ShutdownScriptDecodeErrorZ* o_conv = (LDKCResult_ShutdownScriptDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownScriptDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownScriptDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_free"))) TS_CResult_ShutdownScriptDecodeErrorZ_free(uint32_t _res) {
@@ -11533,8 +11594,8 @@ static inline uintptr_t CResult_ShutdownScriptDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_clone_ptr"))) TS_CResult_ShutdownScriptDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ShutdownScriptDecodeErrorZ* arg_conv = (LDKCResult_ShutdownScriptDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ShutdownScriptDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ShutdownScriptDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptDecodeErrorZ_clone"))) TS_CResult_ShutdownScriptDecodeErrorZ_clone(uint32_t orig) {
@@ -11568,8 +11629,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownSc
 
 jboolean  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok"))) TS_CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(uint32_t o) {
 	LDKCResult_ShutdownScriptInvalidShutdownScriptZ* o_conv = (LDKCResult_ShutdownScriptInvalidShutdownScriptZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownScriptInvalidShutdownScriptZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownScriptZ_free"))) TS_CResult_ShutdownScriptInvalidShutdownScriptZ_free(uint32_t _res) {
@@ -11588,8 +11649,8 @@ static inline uintptr_t CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(L
 }
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr"))) TS_CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ShutdownScriptInvalidShutdownScriptZ* arg_conv = (LDKCResult_ShutdownScriptInvalidShutdownScriptZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ShutdownScriptInvalidShutdownScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownScriptInvalidShutdownScriptZ_clone"))) TS_CResult_ShutdownScriptInvalidShutdownScriptZ_clone(uint32_t orig) {
@@ -11623,8 +11684,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_is_ok"))) TS_CResult_RouteHopDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteHopDecodeErrorZ* o_conv = (LDKCResult_RouteHopDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHopDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHopDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_free"))) TS_CResult_RouteHopDecodeErrorZ_free(uint32_t _res) {
@@ -11643,8 +11704,8 @@ static inline uintptr_t CResult_RouteHopDecodeErrorZ_clone_ptr(LDKCResult_RouteH
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_clone_ptr"))) TS_CResult_RouteHopDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteHopDecodeErrorZ* arg_conv = (LDKCResult_RouteHopDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteHopDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteHopDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteHopDecodeErrorZ_clone"))) TS_CResult_RouteHopDecodeErrorZ_clone(uint32_t orig) {
@@ -11727,8 +11788,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_err"))) TS_CR
 
 jboolean  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_is_ok"))) TS_CResult_RouteDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteDecodeErrorZ* o_conv = (LDKCResult_RouteDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_free"))) TS_CResult_RouteDecodeErrorZ_free(uint32_t _res) {
@@ -11747,8 +11808,8 @@ static inline uintptr_t CResult_RouteDecodeErrorZ_clone_ptr(LDKCResult_RouteDeco
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_clone_ptr"))) TS_CResult_RouteDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteDecodeErrorZ* arg_conv = (LDKCResult_RouteDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteDecodeErrorZ_clone"))) TS_CResult_RouteDecodeErrorZ_clone(uint32_t orig) {
@@ -11782,8 +11843,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_is_ok"))) TS_CResult_RouteParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteParametersDecodeErrorZ* o_conv = (LDKCResult_RouteParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_free"))) TS_CResult_RouteParametersDecodeErrorZ_free(uint32_t _res) {
@@ -11802,8 +11863,8 @@ static inline uintptr_t CResult_RouteParametersDecodeErrorZ_clone_ptr(LDKCResult
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_clone_ptr"))) TS_CResult_RouteParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteParametersDecodeErrorZ* arg_conv = (LDKCResult_RouteParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteParametersDecodeErrorZ_clone"))) TS_CResult_RouteParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -11863,8 +11924,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_u64Z_clone_ptr"))) TS_COption_u64Z_clone_ptr(uint32_t arg) {
 	LDKCOption_u64Z* arg_conv = (LDKCOption_u64Z*)arg;
-	uint32_t ret_val = COption_u64Z_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_u64Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_u64Z_clone"))) TS_COption_u64Z_clone(uint32_t orig) {
@@ -11899,8 +11960,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_is_ok"))) TS_CResult_PaymentParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentParametersDecodeErrorZ* o_conv = (LDKCResult_PaymentParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_free"))) TS_CResult_PaymentParametersDecodeErrorZ_free(uint32_t _res) {
@@ -11919,8 +11980,8 @@ static inline uintptr_t CResult_PaymentParametersDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_clone_ptr"))) TS_CResult_PaymentParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentParametersDecodeErrorZ* arg_conv = (LDKCResult_PaymentParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentParametersDecodeErrorZ_clone"))) TS_CResult_PaymentParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -11973,8 +12034,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_err"))) T
 
 jboolean  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_is_ok"))) TS_CResult_RouteHintDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteHintDecodeErrorZ* o_conv = (LDKCResult_RouteHintDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHintDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHintDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_free"))) TS_CResult_RouteHintDecodeErrorZ_free(uint32_t _res) {
@@ -11993,8 +12054,8 @@ static inline uintptr_t CResult_RouteHintDecodeErrorZ_clone_ptr(LDKCResult_Route
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_clone_ptr"))) TS_CResult_RouteHintDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteHintDecodeErrorZ* arg_conv = (LDKCResult_RouteHintDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteHintDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteHintDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteHintDecodeErrorZ_clone"))) TS_CResult_RouteHintDecodeErrorZ_clone(uint32_t orig) {
@@ -12028,8 +12089,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_is_ok"))) TS_CResult_RouteHintHopDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteHintHopDecodeErrorZ* o_conv = (LDKCResult_RouteHintHopDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteHintHopDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteHintHopDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_free"))) TS_CResult_RouteHintHopDecodeErrorZ_free(uint32_t _res) {
@@ -12048,8 +12109,8 @@ static inline uintptr_t CResult_RouteHintHopDecodeErrorZ_clone_ptr(LDKCResult_Ro
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_clone_ptr"))) TS_CResult_RouteHintHopDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteHintHopDecodeErrorZ* arg_conv = (LDKCResult_RouteHintHopDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteHintHopDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteHintHopDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteHintHopDecodeErrorZ_clone"))) TS_CResult_RouteHintHopDecodeErrorZ_clone(uint32_t orig) {
@@ -12102,8 +12163,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_is_ok"))) TS_CResult_RouteLightningErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RouteLightningErrorZ* o_conv = (LDKCResult_RouteLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RouteLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RouteLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_free"))) TS_CResult_RouteLightningErrorZ_free(uint32_t _res) {
@@ -12122,8 +12183,8 @@ static inline uintptr_t CResult_RouteLightningErrorZ_clone_ptr(LDKCResult_RouteL
 }
 uint32_t  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_clone_ptr"))) TS_CResult_RouteLightningErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RouteLightningErrorZ* arg_conv = (LDKCResult_RouteLightningErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RouteLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RouteLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RouteLightningErrorZ_clone"))) TS_CResult_RouteLightningErrorZ_clone(uint32_t orig) {
@@ -12152,8 +12213,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_err"))) TS_CR
 
 jboolean  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_is_ok"))) TS_CResult_TxOutAccessErrorZ_is_ok(uint32_t o) {
 	LDKCResult_TxOutAccessErrorZ* o_conv = (LDKCResult_TxOutAccessErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_TxOutAccessErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TxOutAccessErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_free"))) TS_CResult_TxOutAccessErrorZ_free(uint32_t _res) {
@@ -12172,8 +12233,8 @@ static inline uintptr_t CResult_TxOutAccessErrorZ_clone_ptr(LDKCResult_TxOutAcce
 }
 uint32_t  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_clone_ptr"))) TS_CResult_TxOutAccessErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_TxOutAccessErrorZ* arg_conv = (LDKCResult_TxOutAccessErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_TxOutAccessErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_TxOutAccessErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_TxOutAccessErrorZ_clone"))) TS_CResult_TxOutAccessErrorZ_clone(uint32_t orig) {
@@ -12190,8 +12251,8 @@ static inline uintptr_t C2Tuple_usizeTransactionZ_clone_ptr(LDKC2Tuple_usizeTran
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_usizeTransactionZ_clone_ptr"))) TS_C2Tuple_usizeTransactionZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_usizeTransactionZ* arg_conv = (LDKC2Tuple_usizeTransactionZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_usizeTransactionZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_usizeTransactionZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_usizeTransactionZ_clone"))) TS_C2Tuple_usizeTransactionZ_clone(uint32_t orig) {
@@ -12273,8 +12334,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_is_ok"))) TS_CResult_NoneChannelMonitorUpdateErrZ_is_ok(uint32_t o) {
 	LDKCResult_NoneChannelMonitorUpdateErrZ* o_conv = (LDKCResult_NoneChannelMonitorUpdateErrZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneChannelMonitorUpdateErrZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneChannelMonitorUpdateErrZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_free"))) TS_CResult_NoneChannelMonitorUpdateErrZ_free(uint32_t _res) {
@@ -12293,8 +12354,8 @@ static inline uintptr_t CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_clone_ptr"))) TS_CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneChannelMonitorUpdateErrZ* arg_conv = (LDKCResult_NoneChannelMonitorUpdateErrZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneChannelMonitorUpdateErrZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneChannelMonitorUpdateErrZ_clone"))) TS_CResult_NoneChannelMonitorUpdateErrZ_clone(uint32_t orig) {
@@ -12358,8 +12419,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_C2Tuple_usizeTransactionZZ_clone_ptr"))) TS_COption_C2Tuple_usizeTransactionZZ_clone_ptr(uint32_t arg) {
 	LDKCOption_C2Tuple_usizeTransactionZZ* arg_conv = (LDKCOption_C2Tuple_usizeTransactionZZ*)arg;
-	uint32_t ret_val = COption_C2Tuple_usizeTransactionZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_C2Tuple_usizeTransactionZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_C2Tuple_usizeTransactionZZ_clone"))) TS_COption_C2Tuple_usizeTransactionZZ_clone(uint32_t orig) {
@@ -12405,8 +12466,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_ClosureReasonZ_clone_ptr"))) TS_COption_ClosureReasonZ_clone_ptr(uint32_t arg) {
 	LDKCOption_ClosureReasonZ* arg_conv = (LDKCOption_ClosureReasonZ*)arg;
-	uint32_t ret_val = COption_ClosureReasonZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_ClosureReasonZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_ClosureReasonZ_clone"))) TS_COption_ClosureReasonZ_clone(uint32_t orig) {
@@ -12440,8 +12501,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErr
 
 jboolean  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErrorZ_is_ok"))) TS_CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_ClosureReasonZDecodeErrorZ* o_conv = (LDKCResult_COption_ClosureReasonZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_ClosureReasonZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErrorZ_free"))) TS_CResult_COption_ClosureReasonZDecodeErrorZ_free(uint32_t _res) {
@@ -12460,8 +12521,8 @@ static inline uintptr_t CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(LDK
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_ClosureReasonZDecodeErrorZ* arg_conv = (LDKCResult_COption_ClosureReasonZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_ClosureReasonZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_ClosureReasonZDecodeErrorZ_clone"))) TS_CResult_COption_ClosureReasonZDecodeErrorZ_clone(uint32_t orig) {
@@ -12506,8 +12567,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_NetworkUpdateZ_clone_ptr"))) TS_COption_NetworkUpdateZ_clone_ptr(uint32_t arg) {
 	LDKCOption_NetworkUpdateZ* arg_conv = (LDKCOption_NetworkUpdateZ*)arg;
-	uint32_t ret_val = COption_NetworkUpdateZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_NetworkUpdateZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_NetworkUpdateZ_clone"))) TS_COption_NetworkUpdateZ_clone(uint32_t orig) {
@@ -12572,8 +12633,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_EventZ_clone_ptr"))) TS_COption_EventZ_clone_ptr(uint32_t arg) {
 	LDKCOption_EventZ* arg_conv = (LDKCOption_EventZ*)arg;
-	uint32_t ret_val = COption_EventZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_EventZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_EventZ_clone"))) TS_COption_EventZ_clone(uint32_t orig) {
@@ -12607,8 +12668,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_is_ok"))) TS_CResult_COption_EventZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_EventZDecodeErrorZ* o_conv = (LDKCResult_COption_EventZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_EventZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_EventZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_free"))) TS_CResult_COption_EventZDecodeErrorZ_free(uint32_t _res) {
@@ -12627,8 +12688,8 @@ static inline uintptr_t CResult_COption_EventZDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_EventZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_EventZDecodeErrorZ* arg_conv = (LDKCResult_COption_EventZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_EventZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_EventZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_EventZDecodeErrorZ_clone"))) TS_CResult_COption_EventZDecodeErrorZ_clone(uint32_t orig) {
@@ -12681,8 +12742,8 @@ uint32_t  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_
 
 jboolean  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_is_ok"))) TS_CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_FixedPenaltyScorerDecodeErrorZ* o_conv = (LDKCResult_FixedPenaltyScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FixedPenaltyScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_free"))) TS_CResult_FixedPenaltyScorerDecodeErrorZ_free(uint32_t _res) {
@@ -12701,8 +12762,8 @@ static inline uintptr_t CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(LDKCRes
 }
 uint32_t  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr"))) TS_CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_FixedPenaltyScorerDecodeErrorZ* arg_conv = (LDKCResult_FixedPenaltyScorerDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_FixedPenaltyScorerDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_FixedPenaltyScorerDecodeErrorZ_clone"))) TS_CResult_FixedPenaltyScorerDecodeErrorZ_clone(uint32_t orig) {
@@ -12736,8 +12797,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_is_ok"))) TS_CResult_ScoringParametersDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ScoringParametersDecodeErrorZ* o_conv = (LDKCResult_ScoringParametersDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ScoringParametersDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ScoringParametersDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_free"))) TS_CResult_ScoringParametersDecodeErrorZ_free(uint32_t _res) {
@@ -12756,8 +12817,8 @@ static inline uintptr_t CResult_ScoringParametersDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_clone_ptr"))) TS_CResult_ScoringParametersDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ScoringParametersDecodeErrorZ* arg_conv = (LDKCResult_ScoringParametersDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ScoringParametersDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ScoringParametersDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ScoringParametersDecodeErrorZ_clone"))) TS_CResult_ScoringParametersDecodeErrorZ_clone(uint32_t orig) {
@@ -12791,8 +12852,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ScorerDecodeErrorZ_err"))) TS_C
 
 jboolean  __attribute__((export_name("TS_CResult_ScorerDecodeErrorZ_is_ok"))) TS_CResult_ScorerDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ScorerDecodeErrorZ* o_conv = (LDKCResult_ScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ScorerDecodeErrorZ_free"))) TS_CResult_ScorerDecodeErrorZ_free(uint32_t _res) {
@@ -12828,8 +12889,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ProbabilisticScorerDecodeErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_ProbabilisticScorerDecodeErrorZ_is_ok"))) TS_CResult_ProbabilisticScorerDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ProbabilisticScorerDecodeErrorZ* o_conv = (LDKCResult_ProbabilisticScorerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ProbabilisticScorerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ProbabilisticScorerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ProbabilisticScorerDecodeErrorZ_free"))) TS_CResult_ProbabilisticScorerDecodeErrorZ_free(uint32_t _res) {
@@ -12865,8 +12926,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InitFeaturesDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_InitFeaturesDecodeErrorZ_is_ok"))) TS_CResult_InitFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InitFeaturesDecodeErrorZ* o_conv = (LDKCResult_InitFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InitFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InitFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InitFeaturesDecodeErrorZ_free"))) TS_CResult_InitFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -12902,8 +12963,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelFeaturesDecodeErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelFeaturesDecodeErrorZ_is_ok"))) TS_CResult_ChannelFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelFeaturesDecodeErrorZ* o_conv = (LDKCResult_ChannelFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelFeaturesDecodeErrorZ_free"))) TS_CResult_ChannelFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -12939,8 +13000,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeFeaturesDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_NodeFeaturesDecodeErrorZ_is_ok"))) TS_CResult_NodeFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeFeaturesDecodeErrorZ* o_conv = (LDKCResult_NodeFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeFeaturesDecodeErrorZ_free"))) TS_CResult_NodeFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -12976,8 +13037,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InvoiceFeaturesDecodeErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_InvoiceFeaturesDecodeErrorZ_is_ok"))) TS_CResult_InvoiceFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InvoiceFeaturesDecodeErrorZ* o_conv = (LDKCResult_InvoiceFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InvoiceFeaturesDecodeErrorZ_free"))) TS_CResult_InvoiceFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -13013,8 +13074,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelTypeFeaturesDecodeErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok"))) TS_CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelTypeFeaturesDecodeErrorZ* o_conv = (LDKCResult_ChannelTypeFeaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelTypeFeaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelTypeFeaturesDecodeErrorZ_free"))) TS_CResult_ChannelTypeFeaturesDecodeErrorZ_free(uint32_t _res) {
@@ -13050,8 +13111,8 @@ uint32_t  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorD
 
 jboolean  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok"))) TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_free"))) TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_free(uint32_t _res) {
@@ -13070,8 +13131,8 @@ static inline uintptr_t CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone
 }
 uint32_t  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr"))) TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_DelayedPaymentOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone"))) TS_CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_clone(uint32_t orig) {
@@ -13105,8 +13166,8 @@ uint32_t  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDe
 
 jboolean  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok"))) TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_free"))) TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_free(uint32_t _res) {
@@ -13125,8 +13186,8 @@ static inline uintptr_t CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_
 }
 uint32_t  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr"))) TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_StaticPaymentOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone"))) TS_CResult_StaticPaymentOutputDescriptorDecodeErrorZ_clone(uint32_t orig) {
@@ -13159,8 +13220,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecode
 
 jboolean  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok"))) TS_CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SpendableOutputDescriptorDecodeErrorZ* o_conv = (LDKCResult_SpendableOutputDescriptorDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SpendableOutputDescriptorDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecodeErrorZ_free"))) TS_CResult_SpendableOutputDescriptorDecodeErrorZ_free(uint32_t _res) {
@@ -13179,8 +13240,8 @@ static inline uintptr_t CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(
 }
 uint32_t  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr"))) TS_CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SpendableOutputDescriptorDecodeErrorZ* arg_conv = (LDKCResult_SpendableOutputDescriptorDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SpendableOutputDescriptorDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SpendableOutputDescriptorDecodeErrorZ_clone"))) TS_CResult_SpendableOutputDescriptorDecodeErrorZ_clone(uint32_t orig) {
@@ -13215,8 +13276,8 @@ static inline uintptr_t C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(LDKC2Tuple_S
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_SignatureCVec_SignatureZZ_clone_ptr"))) TS_C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_SignatureCVec_SignatureZZ* arg_conv = (LDKC2Tuple_SignatureCVec_SignatureZZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_SignatureCVec_SignatureZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_SignatureCVec_SignatureZZ_clone"))) TS_C2Tuple_SignatureCVec_SignatureZZ_clone(uint32_t orig) {
@@ -13276,8 +13337,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_Signature
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok"))) TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ* o_conv = (LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_free"))) TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_free(uint32_t _res) {
@@ -13296,8 +13357,8 @@ static inline uintptr_t CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr"))) TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ* arg_conv = (LDKCResult_C2Tuple_SignatureCVec_SignatureZZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone"))) TS_CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_clone(uint32_t orig) {
@@ -13324,8 +13385,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SignatureNoneZ_err"))) TS_CResu
 
 jboolean  __attribute__((export_name("TS_CResult_SignatureNoneZ_is_ok"))) TS_CResult_SignatureNoneZ_is_ok(uint32_t o) {
 	LDKCResult_SignatureNoneZ* o_conv = (LDKCResult_SignatureNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_SignatureNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignatureNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SignatureNoneZ_free"))) TS_CResult_SignatureNoneZ_free(uint32_t _res) {
@@ -13344,8 +13405,8 @@ static inline uintptr_t CResult_SignatureNoneZ_clone_ptr(LDKCResult_SignatureNon
 }
 uint32_t  __attribute__((export_name("TS_CResult_SignatureNoneZ_clone_ptr"))) TS_CResult_SignatureNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SignatureNoneZ* arg_conv = (LDKCResult_SignatureNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SignatureNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SignatureNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SignatureNoneZ_clone"))) TS_CResult_SignatureNoneZ_clone(uint32_t orig) {
@@ -13362,8 +13423,8 @@ static inline uintptr_t C2Tuple_SignatureSignatureZ_clone_ptr(LDKC2Tuple_Signatu
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_SignatureSignatureZ_clone_ptr"))) TS_C2Tuple_SignatureSignatureZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_SignatureSignatureZ* arg_conv = (LDKC2Tuple_SignatureSignatureZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_SignatureSignatureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_SignatureSignatureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_SignatureSignatureZ_clone"))) TS_C2Tuple_SignatureSignatureZ_clone(uint32_t orig) {
@@ -13412,8 +13473,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNone
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok"))) TS_CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_SignatureSignatureZNoneZ* o_conv = (LDKCResult_C2Tuple_SignatureSignatureZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_SignatureSignatureZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNoneZ_free"))) TS_CResult_C2Tuple_SignatureSignatureZNoneZ_free(uint32_t _res) {
@@ -13432,8 +13493,8 @@ static inline uintptr_t CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(LDKCR
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr"))) TS_CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_SignatureSignatureZNoneZ* arg_conv = (LDKCResult_C2Tuple_SignatureSignatureZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_SignatureSignatureZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_SignatureSignatureZNoneZ_clone"))) TS_CResult_C2Tuple_SignatureSignatureZNoneZ_clone(uint32_t orig) {
@@ -13460,8 +13521,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_err"))) TS_CResu
 
 jboolean  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_is_ok"))) TS_CResult_SecretKeyNoneZ_is_ok(uint32_t o) {
 	LDKCResult_SecretKeyNoneZ* o_conv = (LDKCResult_SecretKeyNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_SecretKeyNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SecretKeyNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_free"))) TS_CResult_SecretKeyNoneZ_free(uint32_t _res) {
@@ -13480,8 +13541,8 @@ static inline uintptr_t CResult_SecretKeyNoneZ_clone_ptr(LDKCResult_SecretKeyNon
 }
 uint32_t  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_clone_ptr"))) TS_CResult_SecretKeyNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SecretKeyNoneZ* arg_conv = (LDKCResult_SecretKeyNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SecretKeyNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SecretKeyNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SecretKeyNoneZ_clone"))) TS_CResult_SecretKeyNoneZ_clone(uint32_t orig) {
@@ -13517,8 +13578,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_is_ok"))) TS_CResult_SignDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SignDecodeErrorZ* o_conv = (LDKCResult_SignDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SignDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_free"))) TS_CResult_SignDecodeErrorZ_free(uint32_t _res) {
@@ -13537,8 +13598,8 @@ static inline uintptr_t CResult_SignDecodeErrorZ_clone_ptr(LDKCResult_SignDecode
 }
 uint32_t  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_clone_ptr"))) TS_CResult_SignDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SignDecodeErrorZ* arg_conv = (LDKCResult_SignDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SignDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SignDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SignDecodeErrorZ_clone"))) TS_CResult_SignDecodeErrorZ_clone(uint32_t orig) {
@@ -13581,8 +13642,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_is_ok"))) TS_CResult_RecoverableSignatureNoneZ_is_ok(uint32_t o) {
 	LDKCResult_RecoverableSignatureNoneZ* o_conv = (LDKCResult_RecoverableSignatureNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_RecoverableSignatureNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RecoverableSignatureNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_free"))) TS_CResult_RecoverableSignatureNoneZ_free(uint32_t _res) {
@@ -13601,8 +13662,8 @@ static inline uintptr_t CResult_RecoverableSignatureNoneZ_clone_ptr(LDKCResult_R
 }
 uint32_t  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_clone_ptr"))) TS_CResult_RecoverableSignatureNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RecoverableSignatureNoneZ* arg_conv = (LDKCResult_RecoverableSignatureNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RecoverableSignatureNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RecoverableSignatureNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RecoverableSignatureNoneZ_clone"))) TS_CResult_RecoverableSignatureNoneZ_clone(uint32_t orig) {
@@ -13668,8 +13729,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_err"))) TS_
 
 jboolean  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_is_ok"))) TS_CResult_CVec_CVec_u8ZZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_CVec_CVec_u8ZZNoneZ* o_conv = (LDKCResult_CVec_CVec_u8ZZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_CVec_u8ZZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_CVec_u8ZZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_free"))) TS_CResult_CVec_CVec_u8ZZNoneZ_free(uint32_t _res) {
@@ -13688,8 +13749,8 @@ static inline uintptr_t CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(LDKCResult_CVec_CV
 }
 uint32_t  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_clone_ptr"))) TS_CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CVec_CVec_u8ZZNoneZ* arg_conv = (LDKCResult_CVec_CVec_u8ZZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CVec_CVec_u8ZZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CVec_CVec_u8ZZNoneZ_clone"))) TS_CResult_CVec_CVec_u8ZZNoneZ_clone(uint32_t orig) {
@@ -13723,8 +13784,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_is_ok"))) TS_CResult_InMemorySignerDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InMemorySignerDecodeErrorZ* o_conv = (LDKCResult_InMemorySignerDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InMemorySignerDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InMemorySignerDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_free"))) TS_CResult_InMemorySignerDecodeErrorZ_free(uint32_t _res) {
@@ -13743,8 +13804,8 @@ static inline uintptr_t CResult_InMemorySignerDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_clone_ptr"))) TS_CResult_InMemorySignerDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InMemorySignerDecodeErrorZ* arg_conv = (LDKCResult_InMemorySignerDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InMemorySignerDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InMemorySignerDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InMemorySignerDecodeErrorZ_clone"))) TS_CResult_InMemorySignerDecodeErrorZ_clone(uint32_t orig) {
@@ -13792,8 +13853,8 @@ uint32_t  __attribute__((export_name("TS_CResult_TransactionNoneZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_TransactionNoneZ_is_ok"))) TS_CResult_TransactionNoneZ_is_ok(uint32_t o) {
 	LDKCResult_TransactionNoneZ* o_conv = (LDKCResult_TransactionNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_TransactionNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_TransactionNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_TransactionNoneZ_free"))) TS_CResult_TransactionNoneZ_free(uint32_t _res) {
@@ -13812,8 +13873,8 @@ static inline uintptr_t CResult_TransactionNoneZ_clone_ptr(LDKCResult_Transactio
 }
 uint32_t  __attribute__((export_name("TS_CResult_TransactionNoneZ_clone_ptr"))) TS_CResult_TransactionNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_TransactionNoneZ* arg_conv = (LDKCResult_TransactionNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_TransactionNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_TransactionNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_TransactionNoneZ_clone"))) TS_CResult_TransactionNoneZ_clone(uint32_t orig) {
@@ -13854,8 +13915,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_u16Z_clone_ptr"))) TS_COption_u16Z_clone_ptr(uint32_t arg) {
 	LDKCOption_u16Z* arg_conv = (LDKCOption_u16Z*)arg;
-	uint32_t ret_val = COption_u16Z_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_u16Z_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_u16Z_clone"))) TS_COption_u16Z_clone(uint32_t orig) {
@@ -13884,8 +13945,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_err"))) TS_CResul
 
 jboolean  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_is_ok"))) TS_CResult_NoneAPIErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NoneAPIErrorZ* o_conv = (LDKCResult_NoneAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_free"))) TS_CResult_NoneAPIErrorZ_free(uint32_t _res) {
@@ -13904,8 +13965,8 @@ static inline uintptr_t CResult_NoneAPIErrorZ_clone_ptr(LDKCResult_NoneAPIErrorZ
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_clone_ptr"))) TS_CResult_NoneAPIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneAPIErrorZ* arg_conv = (LDKCResult_NoneAPIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneAPIErrorZ_clone"))) TS_CResult_NoneAPIErrorZ_clone(uint32_t orig) {
@@ -13974,8 +14035,8 @@ uint32_t  __attribute__((export_name("TS_CResult__u832APIErrorZ_err"))) TS_CResu
 
 jboolean  __attribute__((export_name("TS_CResult__u832APIErrorZ_is_ok"))) TS_CResult__u832APIErrorZ_is_ok(uint32_t o) {
 	LDKCResult__u832APIErrorZ* o_conv = (LDKCResult__u832APIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult__u832APIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult__u832APIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult__u832APIErrorZ_free"))) TS_CResult__u832APIErrorZ_free(uint32_t _res) {
@@ -13994,8 +14055,8 @@ static inline uintptr_t CResult__u832APIErrorZ_clone_ptr(LDKCResult__u832APIErro
 }
 uint32_t  __attribute__((export_name("TS_CResult__u832APIErrorZ_clone_ptr"))) TS_CResult__u832APIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult__u832APIErrorZ* arg_conv = (LDKCResult__u832APIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult__u832APIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult__u832APIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult__u832APIErrorZ_clone"))) TS_CResult__u832APIErrorZ_clone(uint32_t orig) {
@@ -14026,8 +14087,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_is_ok"))) TS_CResult_PaymentIdPaymentSendFailureZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentIdPaymentSendFailureZ* o_conv = (LDKCResult_PaymentIdPaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentIdPaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentIdPaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_free"))) TS_CResult_PaymentIdPaymentSendFailureZ_free(uint32_t _res) {
@@ -14046,8 +14107,8 @@ static inline uintptr_t CResult_PaymentIdPaymentSendFailureZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_clone_ptr"))) TS_CResult_PaymentIdPaymentSendFailureZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentIdPaymentSendFailureZ* arg_conv = (LDKCResult_PaymentIdPaymentSendFailureZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentIdPaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentIdPaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentSendFailureZ_clone"))) TS_CResult_PaymentIdPaymentSendFailureZ_clone(uint32_t orig) {
@@ -14075,8 +14136,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_err")))
 
 jboolean  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_is_ok"))) TS_CResult_NonePaymentSendFailureZ_is_ok(uint32_t o) {
 	LDKCResult_NonePaymentSendFailureZ* o_conv = (LDKCResult_NonePaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_NonePaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NonePaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_free"))) TS_CResult_NonePaymentSendFailureZ_free(uint32_t _res) {
@@ -14095,8 +14156,8 @@ static inline uintptr_t CResult_NonePaymentSendFailureZ_clone_ptr(LDKCResult_Non
 }
 uint32_t  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_clone_ptr"))) TS_CResult_NonePaymentSendFailureZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NonePaymentSendFailureZ* arg_conv = (LDKCResult_NonePaymentSendFailureZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NonePaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NonePaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NonePaymentSendFailureZ_clone"))) TS_CResult_NonePaymentSendFailureZ_clone(uint32_t orig) {
@@ -14113,8 +14174,8 @@ static inline uintptr_t C2Tuple_PaymentHashPaymentIdZ_clone_ptr(LDKC2Tuple_Payme
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_PaymentHashPaymentIdZ_clone_ptr"))) TS_C2Tuple_PaymentHashPaymentIdZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_PaymentHashPaymentIdZ* arg_conv = (LDKC2Tuple_PaymentHashPaymentIdZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_PaymentHashPaymentIdZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_PaymentHashPaymentIdZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_PaymentHashPaymentIdZ_clone"))) TS_C2Tuple_PaymentHashPaymentIdZ_clone(uint32_t orig) {
@@ -14167,8 +14228,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPa
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok"))) TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_free"))) TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_free(uint32_t _res) {
@@ -14187,8 +14248,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr"))) TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone"))) TS_CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_clone(uint32_t orig) {
@@ -14224,8 +14285,8 @@ static inline uintptr_t C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(LDKC2Tuple_P
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_PaymentHashPaymentSecretZ_clone_ptr"))) TS_C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_PaymentHashPaymentSecretZ* arg_conv = (LDKC2Tuple_PaymentHashPaymentSecretZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_PaymentHashPaymentSecretZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_PaymentHashPaymentSecretZ_clone"))) TS_C2Tuple_PaymentHashPaymentSecretZ_clone(uint32_t orig) {
@@ -14274,8 +14335,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecre
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_free"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_free(uint32_t _res) {
@@ -14294,8 +14355,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_clone(uint32_t orig) {
@@ -14327,8 +14388,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecre
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ* o_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_free"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_free(uint32_t _res) {
@@ -14347,8 +14408,8 @@ static inline uintptr_t CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ* arg_conv = (LDKCResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone"))) TS_CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_clone(uint32_t orig) {
@@ -14375,8 +14436,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_err"))) TS_C
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_is_ok"))) TS_CResult_PaymentSecretNoneZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentSecretNoneZ* o_conv = (LDKCResult_PaymentSecretNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentSecretNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentSecretNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_free"))) TS_CResult_PaymentSecretNoneZ_free(uint32_t _res) {
@@ -14395,8 +14456,8 @@ static inline uintptr_t CResult_PaymentSecretNoneZ_clone_ptr(LDKCResult_PaymentS
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_clone_ptr"))) TS_CResult_PaymentSecretNoneZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentSecretNoneZ* arg_conv = (LDKCResult_PaymentSecretNoneZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentSecretNoneZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentSecretNoneZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretNoneZ_clone"))) TS_CResult_PaymentSecretNoneZ_clone(uint32_t orig) {
@@ -14427,8 +14488,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_err"))) 
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_is_ok"))) TS_CResult_PaymentSecretAPIErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentSecretAPIErrorZ* o_conv = (LDKCResult_PaymentSecretAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentSecretAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentSecretAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_free"))) TS_CResult_PaymentSecretAPIErrorZ_free(uint32_t _res) {
@@ -14447,8 +14508,8 @@ static inline uintptr_t CResult_PaymentSecretAPIErrorZ_clone_ptr(LDKCResult_Paym
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_clone_ptr"))) TS_CResult_PaymentSecretAPIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentSecretAPIErrorZ* arg_conv = (LDKCResult_PaymentSecretAPIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentSecretAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentSecretAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentSecretAPIErrorZ_clone"))) TS_CResult_PaymentSecretAPIErrorZ_clone(uint32_t orig) {
@@ -14479,8 +14540,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_is_ok"))) TS_CResult_PaymentPreimageAPIErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentPreimageAPIErrorZ* o_conv = (LDKCResult_PaymentPreimageAPIErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentPreimageAPIErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentPreimageAPIErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_free"))) TS_CResult_PaymentPreimageAPIErrorZ_free(uint32_t _res) {
@@ -14499,8 +14560,8 @@ static inline uintptr_t CResult_PaymentPreimageAPIErrorZ_clone_ptr(LDKCResult_Pa
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_clone_ptr"))) TS_CResult_PaymentPreimageAPIErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentPreimageAPIErrorZ* arg_conv = (LDKCResult_PaymentPreimageAPIErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentPreimageAPIErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentPreimageAPIErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentPreimageAPIErrorZ_clone"))) TS_CResult_PaymentPreimageAPIErrorZ_clone(uint32_t orig) {
@@ -14534,8 +14595,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecod
 
 jboolean  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok"))) TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CounterpartyForwardingInfoDecodeErrorZ* o_conv = (LDKCResult_CounterpartyForwardingInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CounterpartyForwardingInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_free"))) TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_free(uint32_t _res) {
@@ -14554,8 +14615,8 @@ static inline uintptr_t CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr
 }
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr"))) TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CounterpartyForwardingInfoDecodeErrorZ* arg_conv = (LDKCResult_CounterpartyForwardingInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CounterpartyForwardingInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_clone"))) TS_CResult_CounterpartyForwardingInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -14589,8 +14650,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ_is_ok"))) TS_CResult_ChannelCounterpartyDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelCounterpartyDecodeErrorZ* o_conv = (LDKCResult_ChannelCounterpartyDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelCounterpartyDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelCounterpartyDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ_free"))) TS_CResult_ChannelCounterpartyDecodeErrorZ_free(uint32_t _res) {
@@ -14609,8 +14670,8 @@ static inline uintptr_t CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(LDKCRe
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelCounterpartyDecodeErrorZ* arg_conv = (LDKCResult_ChannelCounterpartyDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelCounterpartyDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelCounterpartyDecodeErrorZ_clone"))) TS_CResult_ChannelCounterpartyDecodeErrorZ_clone(uint32_t orig) {
@@ -14644,8 +14705,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_is_ok"))) TS_CResult_ChannelDetailsDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelDetailsDecodeErrorZ* o_conv = (LDKCResult_ChannelDetailsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelDetailsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelDetailsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_free"))) TS_CResult_ChannelDetailsDecodeErrorZ_free(uint32_t _res) {
@@ -14664,8 +14725,8 @@ static inline uintptr_t CResult_ChannelDetailsDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelDetailsDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelDetailsDecodeErrorZ* arg_conv = (LDKCResult_ChannelDetailsDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelDetailsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelDetailsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelDetailsDecodeErrorZ_clone"))) TS_CResult_ChannelDetailsDecodeErrorZ_clone(uint32_t orig) {
@@ -14699,8 +14760,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_is_ok"))) TS_CResult_PhantomRouteHintsDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PhantomRouteHintsDecodeErrorZ* o_conv = (LDKCResult_PhantomRouteHintsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PhantomRouteHintsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PhantomRouteHintsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_free"))) TS_CResult_PhantomRouteHintsDecodeErrorZ_free(uint32_t _res) {
@@ -14719,8 +14780,8 @@ static inline uintptr_t CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr"))) TS_CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PhantomRouteHintsDecodeErrorZ* arg_conv = (LDKCResult_PhantomRouteHintsDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PhantomRouteHintsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PhantomRouteHintsDecodeErrorZ_clone"))) TS_CResult_PhantomRouteHintsDecodeErrorZ_clone(uint32_t orig) {
@@ -14795,8 +14856,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelManager
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok"))) TS_CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ* o_conv = (LDKCResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_free"))) TS_CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_free(uint32_t _res) {
@@ -14832,8 +14893,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_is_ok"))) TS_CResult_ChannelConfigDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelConfigDecodeErrorZ* o_conv = (LDKCResult_ChannelConfigDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelConfigDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelConfigDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_free"))) TS_CResult_ChannelConfigDecodeErrorZ_free(uint32_t _res) {
@@ -14852,8 +14913,8 @@ static inline uintptr_t CResult_ChannelConfigDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelConfigDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelConfigDecodeErrorZ* arg_conv = (LDKCResult_ChannelConfigDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelConfigDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelConfigDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelConfigDecodeErrorZ_clone"))) TS_CResult_ChannelConfigDecodeErrorZ_clone(uint32_t orig) {
@@ -14887,8 +14948,8 @@ uint32_t  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_is_ok"))) TS_CResult_OutPointDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_OutPointDecodeErrorZ* o_conv = (LDKCResult_OutPointDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_OutPointDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_OutPointDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_free"))) TS_CResult_OutPointDecodeErrorZ_free(uint32_t _res) {
@@ -14907,8 +14968,8 @@ static inline uintptr_t CResult_OutPointDecodeErrorZ_clone_ptr(LDKCResult_OutPoi
 }
 uint32_t  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_clone_ptr"))) TS_CResult_OutPointDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_OutPointDecodeErrorZ* arg_conv = (LDKCResult_OutPointDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_OutPointDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_OutPointDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_OutPointDecodeErrorZ_clone"))) TS_CResult_OutPointDecodeErrorZ_clone(uint32_t orig) {
@@ -14956,8 +15017,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_TypeZ_clone_ptr"))) TS_COption_TypeZ_clone_ptr(uint32_t arg) {
 	LDKCOption_TypeZ* arg_conv = (LDKCOption_TypeZ*)arg;
-	uint32_t ret_val = COption_TypeZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_TypeZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_TypeZ_clone"))) TS_COption_TypeZ_clone(uint32_t orig) {
@@ -14991,8 +15052,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_is_ok"))) TS_CResult_COption_TypeZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_TypeZDecodeErrorZ* o_conv = (LDKCResult_COption_TypeZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_TypeZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_TypeZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_free"))) TS_CResult_COption_TypeZDecodeErrorZ_free(uint32_t _res) {
@@ -15011,8 +15072,8 @@ static inline uintptr_t CResult_COption_TypeZDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_TypeZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_TypeZDecodeErrorZ* arg_conv = (LDKCResult_COption_TypeZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_TypeZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_TypeZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_TypeZDecodeErrorZ_clone"))) TS_CResult_COption_TypeZDecodeErrorZ_clone(uint32_t orig) {
@@ -15043,8 +15104,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_err"))) 
 
 jboolean  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_is_ok"))) TS_CResult_PaymentIdPaymentErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PaymentIdPaymentErrorZ* o_conv = (LDKCResult_PaymentIdPaymentErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PaymentIdPaymentErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PaymentIdPaymentErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_free"))) TS_CResult_PaymentIdPaymentErrorZ_free(uint32_t _res) {
@@ -15063,8 +15124,8 @@ static inline uintptr_t CResult_PaymentIdPaymentErrorZ_clone_ptr(LDKCResult_Paym
 }
 uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_clone_ptr"))) TS_CResult_PaymentIdPaymentErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PaymentIdPaymentErrorZ* arg_conv = (LDKCResult_PaymentIdPaymentErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PaymentIdPaymentErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PaymentIdPaymentErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PaymentIdPaymentErrorZ_clone"))) TS_CResult_PaymentIdPaymentErrorZ_clone(uint32_t orig) {
@@ -15093,8 +15154,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_err"))) TS_
 
 jboolean  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_is_ok"))) TS_CResult_SiPrefixParseErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SiPrefixParseErrorZ* o_conv = (LDKCResult_SiPrefixParseErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SiPrefixParseErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SiPrefixParseErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_free"))) TS_CResult_SiPrefixParseErrorZ_free(uint32_t _res) {
@@ -15113,8 +15174,8 @@ static inline uintptr_t CResult_SiPrefixParseErrorZ_clone_ptr(LDKCResult_SiPrefi
 }
 uint32_t  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_clone_ptr"))) TS_CResult_SiPrefixParseErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SiPrefixParseErrorZ* arg_conv = (LDKCResult_SiPrefixParseErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SiPrefixParseErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SiPrefixParseErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SiPrefixParseErrorZ_clone"))) TS_CResult_SiPrefixParseErrorZ_clone(uint32_t orig) {
@@ -15147,8 +15208,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_is_ok"))) TS_CResult_InvoiceParseOrSemanticErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InvoiceParseOrSemanticErrorZ* o_conv = (LDKCResult_InvoiceParseOrSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceParseOrSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceParseOrSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_free"))) TS_CResult_InvoiceParseOrSemanticErrorZ_free(uint32_t _res) {
@@ -15167,8 +15228,8 @@ static inline uintptr_t CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_clone_ptr"))) TS_CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InvoiceParseOrSemanticErrorZ* arg_conv = (LDKCResult_InvoiceParseOrSemanticErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InvoiceParseOrSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceParseOrSemanticErrorZ_clone"))) TS_CResult_InvoiceParseOrSemanticErrorZ_clone(uint32_t orig) {
@@ -15201,8 +15262,8 @@ uint32_t  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_is_ok"))) TS_CResult_SignedRawInvoiceParseErrorZ_is_ok(uint32_t o) {
 	LDKCResult_SignedRawInvoiceParseErrorZ* o_conv = (LDKCResult_SignedRawInvoiceParseErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_SignedRawInvoiceParseErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_SignedRawInvoiceParseErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_free"))) TS_CResult_SignedRawInvoiceParseErrorZ_free(uint32_t _res) {
@@ -15221,8 +15282,8 @@ static inline uintptr_t CResult_SignedRawInvoiceParseErrorZ_clone_ptr(LDKCResult
 }
 uint32_t  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_clone_ptr"))) TS_CResult_SignedRawInvoiceParseErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_SignedRawInvoiceParseErrorZ* arg_conv = (LDKCResult_SignedRawInvoiceParseErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_SignedRawInvoiceParseErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_SignedRawInvoiceParseErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_SignedRawInvoiceParseErrorZ_clone"))) TS_CResult_SignedRawInvoiceParseErrorZ_clone(uint32_t orig) {
@@ -15239,8 +15300,8 @@ static inline uintptr_t C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(LDKC3
 }
 uint32_t  __attribute__((export_name("TS_C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr"))) TS_C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(uint32_t arg) {
 	LDKC3Tuple_RawInvoice_u832InvoiceSignatureZ* arg_conv = (LDKC3Tuple_RawInvoice_u832InvoiceSignatureZ*)(arg & ~1);
-	uint32_t ret_val = C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone"))) TS_C3Tuple_RawInvoice_u832InvoiceSignatureZ_clone(uint32_t orig) {
@@ -15298,8 +15359,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_err"))) TS_CR
 
 jboolean  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_is_ok"))) TS_CResult_PayeePubKeyErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PayeePubKeyErrorZ* o_conv = (LDKCResult_PayeePubKeyErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PayeePubKeyErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PayeePubKeyErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_free"))) TS_CResult_PayeePubKeyErrorZ_free(uint32_t _res) {
@@ -15318,8 +15379,8 @@ static inline uintptr_t CResult_PayeePubKeyErrorZ_clone_ptr(LDKCResult_PayeePubK
 }
 uint32_t  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_clone_ptr"))) TS_CResult_PayeePubKeyErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PayeePubKeyErrorZ* arg_conv = (LDKCResult_PayeePubKeyErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PayeePubKeyErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PayeePubKeyErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PayeePubKeyErrorZ_clone"))) TS_CResult_PayeePubKeyErrorZ_clone(uint32_t orig) {
@@ -15368,8 +15429,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ_is_ok"))) TS_CResult_PositiveTimestampCreationErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PositiveTimestampCreationErrorZ* o_conv = (LDKCResult_PositiveTimestampCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PositiveTimestampCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PositiveTimestampCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ_free"))) TS_CResult_PositiveTimestampCreationErrorZ_free(uint32_t _res) {
@@ -15388,8 +15449,8 @@ static inline uintptr_t CResult_PositiveTimestampCreationErrorZ_clone_ptr(LDKCRe
 }
 uint32_t  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ_clone_ptr"))) TS_CResult_PositiveTimestampCreationErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PositiveTimestampCreationErrorZ* arg_conv = (LDKCResult_PositiveTimestampCreationErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PositiveTimestampCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PositiveTimestampCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PositiveTimestampCreationErrorZ_clone"))) TS_CResult_PositiveTimestampCreationErrorZ_clone(uint32_t orig) {
@@ -15414,8 +15475,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_err"))) TS_C
 
 jboolean  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_is_ok"))) TS_CResult_NoneSemanticErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NoneSemanticErrorZ* o_conv = (LDKCResult_NoneSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_free"))) TS_CResult_NoneSemanticErrorZ_free(uint32_t _res) {
@@ -15434,8 +15495,8 @@ static inline uintptr_t CResult_NoneSemanticErrorZ_clone_ptr(LDKCResult_NoneSema
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_clone_ptr"))) TS_CResult_NoneSemanticErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneSemanticErrorZ* arg_conv = (LDKCResult_NoneSemanticErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneSemanticErrorZ_clone"))) TS_CResult_NoneSemanticErrorZ_clone(uint32_t orig) {
@@ -15465,8 +15526,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_err"))) T
 
 jboolean  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_is_ok"))) TS_CResult_InvoiceSemanticErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InvoiceSemanticErrorZ* o_conv = (LDKCResult_InvoiceSemanticErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceSemanticErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceSemanticErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_free"))) TS_CResult_InvoiceSemanticErrorZ_free(uint32_t _res) {
@@ -15485,8 +15546,8 @@ static inline uintptr_t CResult_InvoiceSemanticErrorZ_clone_ptr(LDKCResult_Invoi
 }
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_clone_ptr"))) TS_CResult_InvoiceSemanticErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InvoiceSemanticErrorZ* arg_conv = (LDKCResult_InvoiceSemanticErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InvoiceSemanticErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InvoiceSemanticErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceSemanticErrorZ_clone"))) TS_CResult_InvoiceSemanticErrorZ_clone(uint32_t orig) {
@@ -15516,8 +15577,8 @@ uint32_t  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_is_ok"))) TS_CResult_DescriptionCreationErrorZ_is_ok(uint32_t o) {
 	LDKCResult_DescriptionCreationErrorZ* o_conv = (LDKCResult_DescriptionCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_DescriptionCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_DescriptionCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_free"))) TS_CResult_DescriptionCreationErrorZ_free(uint32_t _res) {
@@ -15536,8 +15597,8 @@ static inline uintptr_t CResult_DescriptionCreationErrorZ_clone_ptr(LDKCResult_D
 }
 uint32_t  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_clone_ptr"))) TS_CResult_DescriptionCreationErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_DescriptionCreationErrorZ* arg_conv = (LDKCResult_DescriptionCreationErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_DescriptionCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_DescriptionCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_DescriptionCreationErrorZ_clone"))) TS_CResult_DescriptionCreationErrorZ_clone(uint32_t orig) {
@@ -15567,8 +15628,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_is_ok"))) TS_CResult_PrivateRouteCreationErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PrivateRouteCreationErrorZ* o_conv = (LDKCResult_PrivateRouteCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PrivateRouteCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PrivateRouteCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_free"))) TS_CResult_PrivateRouteCreationErrorZ_free(uint32_t _res) {
@@ -15587,8 +15648,8 @@ static inline uintptr_t CResult_PrivateRouteCreationErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_clone_ptr"))) TS_CResult_PrivateRouteCreationErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PrivateRouteCreationErrorZ* arg_conv = (LDKCResult_PrivateRouteCreationErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PrivateRouteCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PrivateRouteCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PrivateRouteCreationErrorZ_clone"))) TS_CResult_PrivateRouteCreationErrorZ_clone(uint32_t orig) {
@@ -15614,8 +15675,8 @@ uint32_t  __attribute__((export_name("TS_CResult_StringErrorZ_err"))) TS_CResult
 
 jboolean  __attribute__((export_name("TS_CResult_StringErrorZ_is_ok"))) TS_CResult_StringErrorZ_is_ok(uint32_t o) {
 	LDKCResult_StringErrorZ* o_conv = (LDKCResult_StringErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_StringErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_StringErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_StringErrorZ_free"))) TS_CResult_StringErrorZ_free(uint32_t _res) {
@@ -15651,8 +15712,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeError
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok"))) TS_CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelMonitorUpdateDecodeErrorZ* o_conv = (LDKCResult_ChannelMonitorUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelMonitorUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeErrorZ_free"))) TS_CResult_ChannelMonitorUpdateDecodeErrorZ_free(uint32_t _res) {
@@ -15671,8 +15732,8 @@ static inline uintptr_t CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(LDKCR
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelMonitorUpdateDecodeErrorZ* arg_conv = (LDKCResult_ChannelMonitorUpdateDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelMonitorUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelMonitorUpdateDecodeErrorZ_clone"))) TS_CResult_ChannelMonitorUpdateDecodeErrorZ_clone(uint32_t orig) {
@@ -15717,8 +15778,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_MonitorEventZ_clone_ptr"))) TS_COption_MonitorEventZ_clone_ptr(uint32_t arg) {
 	LDKCOption_MonitorEventZ* arg_conv = (LDKCOption_MonitorEventZ*)arg;
-	uint32_t ret_val = COption_MonitorEventZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_MonitorEventZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_MonitorEventZ_clone"))) TS_COption_MonitorEventZ_clone(uint32_t orig) {
@@ -15752,8 +15813,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErrorZ_is_ok"))) TS_CResult_COption_MonitorEventZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* o_conv = (LDKCResult_COption_MonitorEventZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_MonitorEventZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_MonitorEventZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErrorZ_free"))) TS_CResult_COption_MonitorEventZDecodeErrorZ_free(uint32_t _res) {
@@ -15772,8 +15833,8 @@ static inline uintptr_t CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* arg_conv = (LDKCResult_COption_MonitorEventZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_MonitorEventZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_MonitorEventZDecodeErrorZ_clone"))) TS_CResult_COption_MonitorEventZDecodeErrorZ_clone(uint32_t orig) {
@@ -15807,8 +15868,8 @@ uint32_t  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_err"))) 
 
 jboolean  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_is_ok"))) TS_CResult_HTLCUpdateDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_HTLCUpdateDecodeErrorZ* o_conv = (LDKCResult_HTLCUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_HTLCUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_HTLCUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_free"))) TS_CResult_HTLCUpdateDecodeErrorZ_free(uint32_t _res) {
@@ -15827,8 +15888,8 @@ static inline uintptr_t CResult_HTLCUpdateDecodeErrorZ_clone_ptr(LDKCResult_HTLC
 }
 uint32_t  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_clone_ptr"))) TS_CResult_HTLCUpdateDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_HTLCUpdateDecodeErrorZ* arg_conv = (LDKCResult_HTLCUpdateDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_HTLCUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_HTLCUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_HTLCUpdateDecodeErrorZ_clone"))) TS_CResult_HTLCUpdateDecodeErrorZ_clone(uint32_t orig) {
@@ -15845,8 +15906,8 @@ static inline uintptr_t C2Tuple_OutPointScriptZ_clone_ptr(LDKC2Tuple_OutPointScr
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_OutPointScriptZ_clone_ptr"))) TS_C2Tuple_OutPointScriptZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_OutPointScriptZ* arg_conv = (LDKC2Tuple_OutPointScriptZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_OutPointScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_OutPointScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_OutPointScriptZ_clone"))) TS_C2Tuple_OutPointScriptZ_clone(uint32_t orig) {
@@ -15887,8 +15948,8 @@ static inline uintptr_t C2Tuple_u32ScriptZ_clone_ptr(LDKC2Tuple_u32ScriptZ *NONN
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_u32ScriptZ_clone_ptr"))) TS_C2Tuple_u32ScriptZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_u32ScriptZ* arg_conv = (LDKC2Tuple_u32ScriptZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_u32ScriptZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_u32ScriptZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_u32ScriptZ_clone"))) TS_C2Tuple_u32ScriptZ_clone(uint32_t orig) {
@@ -15943,8 +16004,8 @@ static inline uintptr_t C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(LDKC2Tup
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr"))) TS_C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ* arg_conv = (LDKC2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone"))) TS_C2Tuple_TxidCVec_C2Tuple_u32ScriptZZZ_clone(uint32_t orig) {
@@ -16052,8 +16113,8 @@ static inline uintptr_t C2Tuple_u32TxOutZ_clone_ptr(LDKC2Tuple_u32TxOutZ *NONNUL
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_u32TxOutZ_clone_ptr"))) TS_C2Tuple_u32TxOutZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_u32TxOutZ* arg_conv = (LDKC2Tuple_u32TxOutZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_u32TxOutZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_u32TxOutZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_u32TxOutZ_clone"))) TS_C2Tuple_u32TxOutZ_clone(uint32_t orig) {
@@ -16108,8 +16169,8 @@ static inline uintptr_t C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(LDKC2Tupl
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr"))) TS_C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ* arg_conv = (LDKC2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone"))) TS_C2Tuple_TxidCVec_C2Tuple_u32TxOutZZZ_clone(uint32_t orig) {
@@ -16197,8 +16258,8 @@ static inline uintptr_t C2Tuple_BlockHashChannelMonitorZ_clone_ptr(LDKC2Tuple_Bl
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_BlockHashChannelMonitorZ_clone_ptr"))) TS_C2Tuple_BlockHashChannelMonitorZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_BlockHashChannelMonitorZ* arg_conv = (LDKC2Tuple_BlockHashChannelMonitorZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_BlockHashChannelMonitorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_BlockHashChannelMonitorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_BlockHashChannelMonitorZ_clone"))) TS_C2Tuple_BlockHashChannelMonitorZ_clone(uint32_t orig) {
@@ -16254,8 +16315,8 @@ uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitor
 
 jboolean  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok"))) TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ* o_conv = (LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_free"))) TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_free(uint32_t _res) {
@@ -16274,8 +16335,8 @@ static inline uintptr_t CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clo
 }
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr"))) TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ* arg_conv = (LDKCResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone"))) TS_CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_clone(uint32_t orig) {
@@ -16304,8 +16365,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_err"))) TS_
 
 jboolean  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_is_ok"))) TS_CResult_NoneLightningErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NoneLightningErrorZ* o_conv = (LDKCResult_NoneLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NoneLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NoneLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_free"))) TS_CResult_NoneLightningErrorZ_free(uint32_t _res) {
@@ -16324,8 +16385,8 @@ static inline uintptr_t CResult_NoneLightningErrorZ_clone_ptr(LDKCResult_NoneLig
 }
 uint32_t  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_clone_ptr"))) TS_CResult_NoneLightningErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NoneLightningErrorZ* arg_conv = (LDKCResult_NoneLightningErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NoneLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NoneLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NoneLightningErrorZ_clone"))) TS_CResult_NoneLightningErrorZ_clone(uint32_t orig) {
@@ -16342,8 +16403,8 @@ static inline uintptr_t C2Tuple_PublicKeyTypeZ_clone_ptr(LDKC2Tuple_PublicKeyTyp
 }
 uint32_t  __attribute__((export_name("TS_C2Tuple_PublicKeyTypeZ_clone_ptr"))) TS_C2Tuple_PublicKeyTypeZ_clone_ptr(uint32_t arg) {
 	LDKC2Tuple_PublicKeyTypeZ* arg_conv = (LDKC2Tuple_PublicKeyTypeZ*)(arg & ~1);
-	uint32_t ret_val = C2Tuple_PublicKeyTypeZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C2Tuple_PublicKeyTypeZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C2Tuple_PublicKeyTypeZ_clone"))) TS_C2Tuple_PublicKeyTypeZ_clone(uint32_t orig) {
@@ -16416,8 +16477,8 @@ uint32_t  __attribute__((export_name("TS_CResult_boolLightningErrorZ_err"))) TS_
 
 jboolean  __attribute__((export_name("TS_CResult_boolLightningErrorZ_is_ok"))) TS_CResult_boolLightningErrorZ_is_ok(uint32_t o) {
 	LDKCResult_boolLightningErrorZ* o_conv = (LDKCResult_boolLightningErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_boolLightningErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolLightningErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_boolLightningErrorZ_free"))) TS_CResult_boolLightningErrorZ_free(uint32_t _res) {
@@ -16436,8 +16497,8 @@ static inline uintptr_t CResult_boolLightningErrorZ_clone_ptr(LDKCResult_boolLig
 }
 uint32_t  __attribute__((export_name("TS_CResult_boolLightningErrorZ_clone_ptr"))) TS_CResult_boolLightningErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_boolLightningErrorZ* arg_conv = (LDKCResult_boolLightningErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_boolLightningErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_boolLightningErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_boolLightningErrorZ_clone"))) TS_CResult_boolLightningErrorZ_clone(uint32_t orig) {
@@ -16454,8 +16515,8 @@ static inline uintptr_t C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_c
 }
 uint32_t  __attribute__((export_name("TS_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr"))) TS_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(uint32_t arg) {
 	LDKC3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ* arg_conv = (LDKC3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ*)(arg & ~1);
-	uint32_t ret_val = C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone"))) TS_C3Tuple_ChannelAnnouncementChannelUpdateChannelUpdateZ_clone(uint32_t orig) {
@@ -16586,8 +16647,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_NetAddressZ_clone_ptr"))) TS_COption_NetAddressZ_clone_ptr(uint32_t arg) {
 	LDKCOption_NetAddressZ* arg_conv = (LDKCOption_NetAddressZ*)arg;
-	uint32_t ret_val = COption_NetAddressZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_NetAddressZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_NetAddressZ_clone"))) TS_COption_NetAddressZ_clone(uint32_t orig) {
@@ -16621,8 +16682,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_is_ok"))) TS_CResult_CVec_u8ZPeerHandleErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CVec_u8ZPeerHandleErrorZ* o_conv = (LDKCResult_CVec_u8ZPeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CVec_u8ZPeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CVec_u8ZPeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_free"))) TS_CResult_CVec_u8ZPeerHandleErrorZ_free(uint32_t _res) {
@@ -16641,8 +16702,8 @@ static inline uintptr_t CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(LDKCResult_CV
 }
 uint32_t  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr"))) TS_CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CVec_u8ZPeerHandleErrorZ* arg_conv = (LDKCResult_CVec_u8ZPeerHandleErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CVec_u8ZPeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CVec_u8ZPeerHandleErrorZ_clone"))) TS_CResult_CVec_u8ZPeerHandleErrorZ_clone(uint32_t orig) {
@@ -16671,8 +16732,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_is_ok"))) TS_CResult_NonePeerHandleErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NonePeerHandleErrorZ* o_conv = (LDKCResult_NonePeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NonePeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NonePeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_free"))) TS_CResult_NonePeerHandleErrorZ_free(uint32_t _res) {
@@ -16691,8 +16752,8 @@ static inline uintptr_t CResult_NonePeerHandleErrorZ_clone_ptr(LDKCResult_NonePe
 }
 uint32_t  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_clone_ptr"))) TS_CResult_NonePeerHandleErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NonePeerHandleErrorZ* arg_conv = (LDKCResult_NonePeerHandleErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NonePeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NonePeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NonePeerHandleErrorZ_clone"))) TS_CResult_NonePeerHandleErrorZ_clone(uint32_t orig) {
@@ -16721,8 +16782,8 @@ uint32_t  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_is_ok"))) TS_CResult_boolPeerHandleErrorZ_is_ok(uint32_t o) {
 	LDKCResult_boolPeerHandleErrorZ* o_conv = (LDKCResult_boolPeerHandleErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_boolPeerHandleErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_boolPeerHandleErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_free"))) TS_CResult_boolPeerHandleErrorZ_free(uint32_t _res) {
@@ -16741,8 +16802,8 @@ static inline uintptr_t CResult_boolPeerHandleErrorZ_clone_ptr(LDKCResult_boolPe
 }
 uint32_t  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_clone_ptr"))) TS_CResult_boolPeerHandleErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_boolPeerHandleErrorZ* arg_conv = (LDKCResult_boolPeerHandleErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_boolPeerHandleErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_boolPeerHandleErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_boolPeerHandleErrorZ_clone"))) TS_CResult_boolPeerHandleErrorZ_clone(uint32_t orig) {
@@ -16776,8 +16837,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_err"))) TS_C
 
 jboolean  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_is_ok"))) TS_CResult_NodeIdDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeIdDecodeErrorZ* o_conv = (LDKCResult_NodeIdDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeIdDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeIdDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_free"))) TS_CResult_NodeIdDecodeErrorZ_free(uint32_t _res) {
@@ -16796,8 +16857,8 @@ static inline uintptr_t CResult_NodeIdDecodeErrorZ_clone_ptr(LDKCResult_NodeIdDe
 }
 uint32_t  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_clone_ptr"))) TS_CResult_NodeIdDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NodeIdDecodeErrorZ* arg_conv = (LDKCResult_NodeIdDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NodeIdDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NodeIdDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NodeIdDecodeErrorZ_clone"))) TS_CResult_NodeIdDecodeErrorZ_clone(uint32_t orig) {
@@ -16830,8 +16891,8 @@ uint32_t  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErr
 
 jboolean  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok"))) TS_CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_COption_NetworkUpdateZDecodeErrorZ* o_conv = (LDKCResult_COption_NetworkUpdateZDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_COption_NetworkUpdateZDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErrorZ_free"))) TS_CResult_COption_NetworkUpdateZDecodeErrorZ_free(uint32_t _res) {
@@ -16850,8 +16911,8 @@ static inline uintptr_t CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(LDK
 }
 uint32_t  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr"))) TS_CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_COption_NetworkUpdateZDecodeErrorZ* arg_conv = (LDKCResult_COption_NetworkUpdateZDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_COption_NetworkUpdateZDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_COption_NetworkUpdateZDecodeErrorZ_clone"))) TS_CResult_COption_NetworkUpdateZDecodeErrorZ_clone(uint32_t orig) {
@@ -16915,8 +16976,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_is_ok"))) TS_CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelUpdateInfoDecodeErrorZ* o_conv = (LDKCResult_ChannelUpdateInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelUpdateInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_free"))) TS_CResult_ChannelUpdateInfoDecodeErrorZ_free(uint32_t _res) {
@@ -16935,8 +16996,8 @@ static inline uintptr_t CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelUpdateInfoDecodeErrorZ* arg_conv = (LDKCResult_ChannelUpdateInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelUpdateInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateInfoDecodeErrorZ_clone"))) TS_CResult_ChannelUpdateInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -16970,8 +17031,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_err")))
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_is_ok"))) TS_CResult_ChannelInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelInfoDecodeErrorZ* o_conv = (LDKCResult_ChannelInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_free"))) TS_CResult_ChannelInfoDecodeErrorZ_free(uint32_t _res) {
@@ -16990,8 +17051,8 @@ static inline uintptr_t CResult_ChannelInfoDecodeErrorZ_clone_ptr(LDKCResult_Cha
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelInfoDecodeErrorZ* arg_conv = (LDKCResult_ChannelInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelInfoDecodeErrorZ_clone"))) TS_CResult_ChannelInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -17025,8 +17086,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_err")))
 
 jboolean  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_is_ok"))) TS_CResult_RoutingFeesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RoutingFeesDecodeErrorZ* o_conv = (LDKCResult_RoutingFeesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RoutingFeesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RoutingFeesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_free"))) TS_CResult_RoutingFeesDecodeErrorZ_free(uint32_t _res) {
@@ -17045,8 +17106,8 @@ static inline uintptr_t CResult_RoutingFeesDecodeErrorZ_clone_ptr(LDKCResult_Rou
 }
 uint32_t  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_clone_ptr"))) TS_CResult_RoutingFeesDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RoutingFeesDecodeErrorZ* arg_conv = (LDKCResult_RoutingFeesDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RoutingFeesDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RoutingFeesDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RoutingFeesDecodeErrorZ_clone"))) TS_CResult_RoutingFeesDecodeErrorZ_clone(uint32_t orig) {
@@ -17080,8 +17141,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeError
 
 jboolean  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok"))) TS_CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeAnnouncementInfoDecodeErrorZ* o_conv = (LDKCResult_NodeAnnouncementInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeAnnouncementInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeErrorZ_free"))) TS_CResult_NodeAnnouncementInfoDecodeErrorZ_free(uint32_t _res) {
@@ -17100,8 +17161,8 @@ static inline uintptr_t CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(LDKCR
 }
 uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr"))) TS_CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NodeAnnouncementInfoDecodeErrorZ* arg_conv = (LDKCResult_NodeAnnouncementInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NodeAnnouncementInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementInfoDecodeErrorZ_clone"))) TS_CResult_NodeAnnouncementInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -17150,8 +17211,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_is_ok"))) TS_CResult_NodeInfoDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeInfoDecodeErrorZ* o_conv = (LDKCResult_NodeInfoDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeInfoDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeInfoDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_free"))) TS_CResult_NodeInfoDecodeErrorZ_free(uint32_t _res) {
@@ -17170,8 +17231,8 @@ static inline uintptr_t CResult_NodeInfoDecodeErrorZ_clone_ptr(LDKCResult_NodeIn
 }
 uint32_t  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_clone_ptr"))) TS_CResult_NodeInfoDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NodeInfoDecodeErrorZ* arg_conv = (LDKCResult_NodeInfoDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NodeInfoDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NodeInfoDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NodeInfoDecodeErrorZ_clone"))) TS_CResult_NodeInfoDecodeErrorZ_clone(uint32_t orig) {
@@ -17205,8 +17266,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_is_ok"))) TS_CResult_NetworkGraphDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NetworkGraphDecodeErrorZ* o_conv = (LDKCResult_NetworkGraphDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NetworkGraphDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NetworkGraphDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_free"))) TS_CResult_NetworkGraphDecodeErrorZ_free(uint32_t _res) {
@@ -17225,8 +17286,8 @@ static inline uintptr_t CResult_NetworkGraphDecodeErrorZ_clone_ptr(LDKCResult_Ne
 }
 uint32_t  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_clone_ptr"))) TS_CResult_NetworkGraphDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NetworkGraphDecodeErrorZ* arg_conv = (LDKCResult_NetworkGraphDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NetworkGraphDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NetworkGraphDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NetworkGraphDecodeErrorZ_clone"))) TS_CResult_NetworkGraphDecodeErrorZ_clone(uint32_t orig) {
@@ -17282,8 +17343,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_COption_CVec_NetAddressZZ_clone_ptr"))) TS_COption_CVec_NetAddressZZ_clone_ptr(uint32_t arg) {
 	LDKCOption_CVec_NetAddressZZ* arg_conv = (LDKCOption_CVec_NetAddressZZ*)arg;
-	uint32_t ret_val = COption_CVec_NetAddressZZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = COption_CVec_NetAddressZZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_COption_CVec_NetAddressZZ_clone"))) TS_COption_CVec_NetAddressZZ_clone(uint32_t orig) {
@@ -17317,8 +17378,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_err"))) 
 
 jboolean  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_is_ok"))) TS_CResult_NetAddressDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NetAddressDecodeErrorZ* o_conv = (LDKCResult_NetAddressDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NetAddressDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NetAddressDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_free"))) TS_CResult_NetAddressDecodeErrorZ_free(uint32_t _res) {
@@ -17337,8 +17398,8 @@ static inline uintptr_t CResult_NetAddressDecodeErrorZ_clone_ptr(LDKCResult_NetA
 }
 uint32_t  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_clone_ptr"))) TS_CResult_NetAddressDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NetAddressDecodeErrorZ* arg_conv = (LDKCResult_NetAddressDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NetAddressDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NetAddressDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NetAddressDecodeErrorZ_clone"))) TS_CResult_NetAddressDecodeErrorZ_clone(uint32_t orig) {
@@ -17448,8 +17509,8 @@ uint32_t  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_is_ok"))) TS_CResult_AcceptChannelDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_AcceptChannelDecodeErrorZ* o_conv = (LDKCResult_AcceptChannelDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_AcceptChannelDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_AcceptChannelDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_free"))) TS_CResult_AcceptChannelDecodeErrorZ_free(uint32_t _res) {
@@ -17468,8 +17529,8 @@ static inline uintptr_t CResult_AcceptChannelDecodeErrorZ_clone_ptr(LDKCResult_A
 }
 uint32_t  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_clone_ptr"))) TS_CResult_AcceptChannelDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_AcceptChannelDecodeErrorZ* arg_conv = (LDKCResult_AcceptChannelDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_AcceptChannelDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_AcceptChannelDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_AcceptChannelDecodeErrorZ_clone"))) TS_CResult_AcceptChannelDecodeErrorZ_clone(uint32_t orig) {
@@ -17503,8 +17564,8 @@ uint32_t  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErr
 
 jboolean  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErrorZ_is_ok"))) TS_CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_AnnouncementSignaturesDecodeErrorZ* o_conv = (LDKCResult_AnnouncementSignaturesDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_AnnouncementSignaturesDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErrorZ_free"))) TS_CResult_AnnouncementSignaturesDecodeErrorZ_free(uint32_t _res) {
@@ -17523,8 +17584,8 @@ static inline uintptr_t CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(LDK
 }
 uint32_t  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr"))) TS_CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_AnnouncementSignaturesDecodeErrorZ* arg_conv = (LDKCResult_AnnouncementSignaturesDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_AnnouncementSignaturesDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_AnnouncementSignaturesDecodeErrorZ_clone"))) TS_CResult_AnnouncementSignaturesDecodeErrorZ_clone(uint32_t orig) {
@@ -17558,8 +17619,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_is_ok"))) TS_CResult_ChannelReestablishDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelReestablishDecodeErrorZ* o_conv = (LDKCResult_ChannelReestablishDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelReestablishDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelReestablishDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_free"))) TS_CResult_ChannelReestablishDecodeErrorZ_free(uint32_t _res) {
@@ -17578,8 +17639,8 @@ static inline uintptr_t CResult_ChannelReestablishDecodeErrorZ_clone_ptr(LDKCRes
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelReestablishDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelReestablishDecodeErrorZ* arg_conv = (LDKCResult_ChannelReestablishDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelReestablishDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelReestablishDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelReestablishDecodeErrorZ_clone"))) TS_CResult_ChannelReestablishDecodeErrorZ_clone(uint32_t orig) {
@@ -17613,8 +17674,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_is_ok"))) TS_CResult_ClosingSignedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ClosingSignedDecodeErrorZ* o_conv = (LDKCResult_ClosingSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ClosingSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ClosingSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_free"))) TS_CResult_ClosingSignedDecodeErrorZ_free(uint32_t _res) {
@@ -17633,8 +17694,8 @@ static inline uintptr_t CResult_ClosingSignedDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_clone_ptr"))) TS_CResult_ClosingSignedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ClosingSignedDecodeErrorZ* arg_conv = (LDKCResult_ClosingSignedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ClosingSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ClosingSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedDecodeErrorZ_clone"))) TS_CResult_ClosingSignedDecodeErrorZ_clone(uint32_t orig) {
@@ -17668,8 +17729,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok"))) TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ClosingSignedFeeRangeDecodeErrorZ* o_conv = (LDKCResult_ClosingSignedFeeRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ClosingSignedFeeRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_free"))) TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_free(uint32_t _res) {
@@ -17688,8 +17749,8 @@ static inline uintptr_t CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr"))) TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ClosingSignedFeeRangeDecodeErrorZ* arg_conv = (LDKCResult_ClosingSignedFeeRangeDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ClosingSignedFeeRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_clone"))) TS_CResult_ClosingSignedFeeRangeDecodeErrorZ_clone(uint32_t orig) {
@@ -17723,8 +17784,8 @@ uint32_t  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_is_ok"))) TS_CResult_CommitmentSignedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_CommitmentSignedDecodeErrorZ* o_conv = (LDKCResult_CommitmentSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_CommitmentSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_CommitmentSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_free"))) TS_CResult_CommitmentSignedDecodeErrorZ_free(uint32_t _res) {
@@ -17743,8 +17804,8 @@ static inline uintptr_t CResult_CommitmentSignedDecodeErrorZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_clone_ptr"))) TS_CResult_CommitmentSignedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_CommitmentSignedDecodeErrorZ* arg_conv = (LDKCResult_CommitmentSignedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_CommitmentSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_CommitmentSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_CommitmentSignedDecodeErrorZ_clone"))) TS_CResult_CommitmentSignedDecodeErrorZ_clone(uint32_t orig) {
@@ -17778,8 +17839,8 @@ uint32_t  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_is_ok"))) TS_CResult_FundingCreatedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_FundingCreatedDecodeErrorZ* o_conv = (LDKCResult_FundingCreatedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingCreatedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingCreatedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_free"))) TS_CResult_FundingCreatedDecodeErrorZ_free(uint32_t _res) {
@@ -17798,8 +17859,8 @@ static inline uintptr_t CResult_FundingCreatedDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_clone_ptr"))) TS_CResult_FundingCreatedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_FundingCreatedDecodeErrorZ* arg_conv = (LDKCResult_FundingCreatedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_FundingCreatedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_FundingCreatedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_FundingCreatedDecodeErrorZ_clone"))) TS_CResult_FundingCreatedDecodeErrorZ_clone(uint32_t orig) {
@@ -17833,8 +17894,8 @@ uint32_t  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_is_ok"))) TS_CResult_FundingSignedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_FundingSignedDecodeErrorZ* o_conv = (LDKCResult_FundingSignedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingSignedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingSignedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_free"))) TS_CResult_FundingSignedDecodeErrorZ_free(uint32_t _res) {
@@ -17853,8 +17914,8 @@ static inline uintptr_t CResult_FundingSignedDecodeErrorZ_clone_ptr(LDKCResult_F
 }
 uint32_t  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_clone_ptr"))) TS_CResult_FundingSignedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_FundingSignedDecodeErrorZ* arg_conv = (LDKCResult_FundingSignedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_FundingSignedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_FundingSignedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_FundingSignedDecodeErrorZ_clone"))) TS_CResult_FundingSignedDecodeErrorZ_clone(uint32_t orig) {
@@ -17888,8 +17949,8 @@ uint32_t  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_is_ok"))) TS_CResult_FundingLockedDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_FundingLockedDecodeErrorZ* o_conv = (LDKCResult_FundingLockedDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_FundingLockedDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_FundingLockedDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_free"))) TS_CResult_FundingLockedDecodeErrorZ_free(uint32_t _res) {
@@ -17908,8 +17969,8 @@ static inline uintptr_t CResult_FundingLockedDecodeErrorZ_clone_ptr(LDKCResult_F
 }
 uint32_t  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_clone_ptr"))) TS_CResult_FundingLockedDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_FundingLockedDecodeErrorZ* arg_conv = (LDKCResult_FundingLockedDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_FundingLockedDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_FundingLockedDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_FundingLockedDecodeErrorZ_clone"))) TS_CResult_FundingLockedDecodeErrorZ_clone(uint32_t orig) {
@@ -17943,8 +18004,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_is_ok"))) TS_CResult_InitDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InitDecodeErrorZ* o_conv = (LDKCResult_InitDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InitDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InitDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_free"))) TS_CResult_InitDecodeErrorZ_free(uint32_t _res) {
@@ -17963,8 +18024,8 @@ static inline uintptr_t CResult_InitDecodeErrorZ_clone_ptr(LDKCResult_InitDecode
 }
 uint32_t  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_clone_ptr"))) TS_CResult_InitDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InitDecodeErrorZ* arg_conv = (LDKCResult_InitDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InitDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InitDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InitDecodeErrorZ_clone"))) TS_CResult_InitDecodeErrorZ_clone(uint32_t orig) {
@@ -17998,8 +18059,8 @@ uint32_t  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_err")))
 
 jboolean  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_is_ok"))) TS_CResult_OpenChannelDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_OpenChannelDecodeErrorZ* o_conv = (LDKCResult_OpenChannelDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_OpenChannelDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_OpenChannelDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_free"))) TS_CResult_OpenChannelDecodeErrorZ_free(uint32_t _res) {
@@ -18018,8 +18079,8 @@ static inline uintptr_t CResult_OpenChannelDecodeErrorZ_clone_ptr(LDKCResult_Ope
 }
 uint32_t  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_clone_ptr"))) TS_CResult_OpenChannelDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_OpenChannelDecodeErrorZ* arg_conv = (LDKCResult_OpenChannelDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_OpenChannelDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_OpenChannelDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_OpenChannelDecodeErrorZ_clone"))) TS_CResult_OpenChannelDecodeErrorZ_clone(uint32_t orig) {
@@ -18053,8 +18114,8 @@ uint32_t  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_is_ok"))) TS_CResult_RevokeAndACKDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_RevokeAndACKDecodeErrorZ* o_conv = (LDKCResult_RevokeAndACKDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_RevokeAndACKDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_RevokeAndACKDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_free"))) TS_CResult_RevokeAndACKDecodeErrorZ_free(uint32_t _res) {
@@ -18073,8 +18134,8 @@ static inline uintptr_t CResult_RevokeAndACKDecodeErrorZ_clone_ptr(LDKCResult_Re
 }
 uint32_t  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_clone_ptr"))) TS_CResult_RevokeAndACKDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_RevokeAndACKDecodeErrorZ* arg_conv = (LDKCResult_RevokeAndACKDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_RevokeAndACKDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_RevokeAndACKDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_RevokeAndACKDecodeErrorZ_clone"))) TS_CResult_RevokeAndACKDecodeErrorZ_clone(uint32_t orig) {
@@ -18108,8 +18169,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_err"))) TS
 
 jboolean  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_is_ok"))) TS_CResult_ShutdownDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ShutdownDecodeErrorZ* o_conv = (LDKCResult_ShutdownDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ShutdownDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ShutdownDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_free"))) TS_CResult_ShutdownDecodeErrorZ_free(uint32_t _res) {
@@ -18128,8 +18189,8 @@ static inline uintptr_t CResult_ShutdownDecodeErrorZ_clone_ptr(LDKCResult_Shutdo
 }
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_clone_ptr"))) TS_CResult_ShutdownDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ShutdownDecodeErrorZ* arg_conv = (LDKCResult_ShutdownDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ShutdownDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ShutdownDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ShutdownDecodeErrorZ_clone"))) TS_CResult_ShutdownDecodeErrorZ_clone(uint32_t orig) {
@@ -18163,8 +18224,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_is_ok"))) TS_CResult_UpdateFailHTLCDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateFailHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFailHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFailHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFailHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_free"))) TS_CResult_UpdateFailHTLCDecodeErrorZ_free(uint32_t _res) {
@@ -18183,8 +18244,8 @@ static inline uintptr_t CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateFailHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFailHTLCDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateFailHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFailHTLCDecodeErrorZ_clone"))) TS_CResult_UpdateFailHTLCDecodeErrorZ_clone(uint32_t orig) {
@@ -18218,8 +18279,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeEr
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok"))) TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFailMalformedHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_free"))) TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_free(uint32_t _res) {
@@ -18238,8 +18299,8 @@ static inline uintptr_t CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(LD
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFailMalformedHTLCDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone"))) TS_CResult_UpdateFailMalformedHTLCDecodeErrorZ_clone(uint32_t orig) {
@@ -18273,8 +18334,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_err"))) T
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_is_ok"))) TS_CResult_UpdateFeeDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateFeeDecodeErrorZ* o_conv = (LDKCResult_UpdateFeeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFeeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFeeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_free"))) TS_CResult_UpdateFeeDecodeErrorZ_free(uint32_t _res) {
@@ -18293,8 +18354,8 @@ static inline uintptr_t CResult_UpdateFeeDecodeErrorZ_clone_ptr(LDKCResult_Updat
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateFeeDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateFeeDecodeErrorZ* arg_conv = (LDKCResult_UpdateFeeDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateFeeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateFeeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFeeDecodeErrorZ_clone"))) TS_CResult_UpdateFeeDecodeErrorZ_clone(uint32_t orig) {
@@ -18328,8 +18389,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok"))) TS_CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateFulfillHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateFulfillHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateFulfillHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_free"))) TS_CResult_UpdateFulfillHTLCDecodeErrorZ_free(uint32_t _res) {
@@ -18348,8 +18409,8 @@ static inline uintptr_t CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateFulfillHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateFulfillHTLCDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateFulfillHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateFulfillHTLCDecodeErrorZ_clone"))) TS_CResult_UpdateFulfillHTLCDecodeErrorZ_clone(uint32_t orig) {
@@ -18383,8 +18444,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_is_ok"))) TS_CResult_UpdateAddHTLCDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UpdateAddHTLCDecodeErrorZ* o_conv = (LDKCResult_UpdateAddHTLCDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UpdateAddHTLCDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UpdateAddHTLCDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_free"))) TS_CResult_UpdateAddHTLCDecodeErrorZ_free(uint32_t _res) {
@@ -18403,8 +18464,8 @@ static inline uintptr_t CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(LDKCResult_U
 }
 uint32_t  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr"))) TS_CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UpdateAddHTLCDecodeErrorZ* arg_conv = (LDKCResult_UpdateAddHTLCDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UpdateAddHTLCDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UpdateAddHTLCDecodeErrorZ_clone"))) TS_CResult_UpdateAddHTLCDecodeErrorZ_clone(uint32_t orig) {
@@ -18438,8 +18499,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_is_ok"))) TS_CResult_PingDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PingDecodeErrorZ* o_conv = (LDKCResult_PingDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PingDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PingDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_free"))) TS_CResult_PingDecodeErrorZ_free(uint32_t _res) {
@@ -18458,8 +18519,8 @@ static inline uintptr_t CResult_PingDecodeErrorZ_clone_ptr(LDKCResult_PingDecode
 }
 uint32_t  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_clone_ptr"))) TS_CResult_PingDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PingDecodeErrorZ* arg_conv = (LDKCResult_PingDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PingDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PingDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PingDecodeErrorZ_clone"))) TS_CResult_PingDecodeErrorZ_clone(uint32_t orig) {
@@ -18493,8 +18554,8 @@ uint32_t  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_err"))) TS_CRe
 
 jboolean  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_is_ok"))) TS_CResult_PongDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_PongDecodeErrorZ* o_conv = (LDKCResult_PongDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_PongDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_PongDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_free"))) TS_CResult_PongDecodeErrorZ_free(uint32_t _res) {
@@ -18513,8 +18574,8 @@ static inline uintptr_t CResult_PongDecodeErrorZ_clone_ptr(LDKCResult_PongDecode
 }
 uint32_t  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_clone_ptr"))) TS_CResult_PongDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_PongDecodeErrorZ* arg_conv = (LDKCResult_PongDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_PongDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_PongDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_PongDecodeErrorZ_clone"))) TS_CResult_PongDecodeErrorZ_clone(uint32_t orig) {
@@ -18548,8 +18609,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDeco
 
 jboolean  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok"))) TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ* o_conv = (LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_free"))) TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_free(uint32_t _res) {
@@ -18568,8 +18629,8 @@ static inline uintptr_t CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_pt
 }
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr"))) TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_UnsignedChannelAnnouncementDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone"))) TS_CResult_UnsignedChannelAnnouncementDecodeErrorZ_clone(uint32_t orig) {
@@ -18603,8 +18664,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ_is_ok"))) TS_CResult_ChannelAnnouncementDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelAnnouncementDecodeErrorZ* o_conv = (LDKCResult_ChannelAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ_free"))) TS_CResult_ChannelAnnouncementDecodeErrorZ_free(uint32_t _res) {
@@ -18623,8 +18684,8 @@ static inline uintptr_t CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(LDKCRe
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_ChannelAnnouncementDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelAnnouncementDecodeErrorZ_clone"))) TS_CResult_ChannelAnnouncementDecodeErrorZ_clone(uint32_t orig) {
@@ -18658,8 +18719,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok"))) TS_CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UnsignedChannelUpdateDecodeErrorZ* o_conv = (LDKCResult_UnsignedChannelUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedChannelUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErrorZ_free"))) TS_CResult_UnsignedChannelUpdateDecodeErrorZ_free(uint32_t _res) {
@@ -18678,8 +18739,8 @@ static inline uintptr_t CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr"))) TS_CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UnsignedChannelUpdateDecodeErrorZ* arg_conv = (LDKCResult_UnsignedChannelUpdateDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UnsignedChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedChannelUpdateDecodeErrorZ_clone"))) TS_CResult_UnsignedChannelUpdateDecodeErrorZ_clone(uint32_t orig) {
@@ -18713,8 +18774,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_is_ok"))) TS_CResult_ChannelUpdateDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ChannelUpdateDecodeErrorZ* o_conv = (LDKCResult_ChannelUpdateDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ChannelUpdateDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ChannelUpdateDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_free"))) TS_CResult_ChannelUpdateDecodeErrorZ_free(uint32_t _res) {
@@ -18733,8 +18794,8 @@ static inline uintptr_t CResult_ChannelUpdateDecodeErrorZ_clone_ptr(LDKCResult_C
 }
 uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_clone_ptr"))) TS_CResult_ChannelUpdateDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ChannelUpdateDecodeErrorZ* arg_conv = (LDKCResult_ChannelUpdateDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ChannelUpdateDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ChannelUpdateDecodeErrorZ_clone"))) TS_CResult_ChannelUpdateDecodeErrorZ_clone(uint32_t orig) {
@@ -18768,8 +18829,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_err"))
 
 jboolean  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_is_ok"))) TS_CResult_ErrorMessageDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ErrorMessageDecodeErrorZ* o_conv = (LDKCResult_ErrorMessageDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ErrorMessageDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ErrorMessageDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_free"))) TS_CResult_ErrorMessageDecodeErrorZ_free(uint32_t _res) {
@@ -18788,8 +18849,8 @@ static inline uintptr_t CResult_ErrorMessageDecodeErrorZ_clone_ptr(LDKCResult_Er
 }
 uint32_t  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_clone_ptr"))) TS_CResult_ErrorMessageDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ErrorMessageDecodeErrorZ* arg_conv = (LDKCResult_ErrorMessageDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ErrorMessageDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ErrorMessageDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ErrorMessageDecodeErrorZ_clone"))) TS_CResult_ErrorMessageDecodeErrorZ_clone(uint32_t orig) {
@@ -18823,8 +18884,8 @@ uint32_t  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_err"
 
 jboolean  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_is_ok"))) TS_CResult_WarningMessageDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_WarningMessageDecodeErrorZ* o_conv = (LDKCResult_WarningMessageDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_WarningMessageDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_WarningMessageDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_free"))) TS_CResult_WarningMessageDecodeErrorZ_free(uint32_t _res) {
@@ -18843,8 +18904,8 @@ static inline uintptr_t CResult_WarningMessageDecodeErrorZ_clone_ptr(LDKCResult_
 }
 uint32_t  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_clone_ptr"))) TS_CResult_WarningMessageDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_WarningMessageDecodeErrorZ* arg_conv = (LDKCResult_WarningMessageDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_WarningMessageDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_WarningMessageDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_WarningMessageDecodeErrorZ_clone"))) TS_CResult_WarningMessageDecodeErrorZ_clone(uint32_t orig) {
@@ -18878,8 +18939,8 @@ uint32_t  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeE
 
 jboolean  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok"))) TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* o_conv = (LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_UnsignedNodeAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_free"))) TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_free(uint32_t _res) {
@@ -18898,8 +18959,8 @@ static inline uintptr_t CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(L
 }
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr"))) TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone"))) TS_CResult_UnsignedNodeAnnouncementDecodeErrorZ_clone(uint32_t orig) {
@@ -18933,8 +18994,8 @@ uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_er
 
 jboolean  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_is_ok"))) TS_CResult_NodeAnnouncementDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_NodeAnnouncementDecodeErrorZ* o_conv = (LDKCResult_NodeAnnouncementDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_NodeAnnouncementDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_NodeAnnouncementDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_free"))) TS_CResult_NodeAnnouncementDecodeErrorZ_free(uint32_t _res) {
@@ -18953,8 +19014,8 @@ static inline uintptr_t CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(LDKCResul
 }
 uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_clone_ptr"))) TS_CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_NodeAnnouncementDecodeErrorZ* arg_conv = (LDKCResult_NodeAnnouncementDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_NodeAnnouncementDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_NodeAnnouncementDecodeErrorZ_clone"))) TS_CResult_NodeAnnouncementDecodeErrorZ_clone(uint32_t orig) {
@@ -18988,8 +19049,8 @@ uint32_t  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeError
 
 jboolean  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeErrorZ_is_ok"))) TS_CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_QueryShortChannelIdsDecodeErrorZ* o_conv = (LDKCResult_QueryShortChannelIdsDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_QueryShortChannelIdsDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeErrorZ_free"))) TS_CResult_QueryShortChannelIdsDecodeErrorZ_free(uint32_t _res) {
@@ -19008,8 +19069,8 @@ static inline uintptr_t CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(LDKCR
 }
 uint32_t  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr"))) TS_CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_QueryShortChannelIdsDecodeErrorZ* arg_conv = (LDKCResult_QueryShortChannelIdsDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_QueryShortChannelIdsDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_QueryShortChannelIdsDecodeErrorZ_clone"))) TS_CResult_QueryShortChannelIdsDecodeErrorZ_clone(uint32_t orig) {
@@ -19043,8 +19104,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeEr
 
 jboolean  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok"))) TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ* o_conv = (LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ReplyShortChannelIdsEndDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_free"))) TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_free(uint32_t _res) {
@@ -19063,8 +19124,8 @@ static inline uintptr_t CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(LD
 }
 uint32_t  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr"))) TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ* arg_conv = (LDKCResult_ReplyShortChannelIdsEndDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone"))) TS_CResult_ReplyShortChannelIdsEndDecodeErrorZ_clone(uint32_t orig) {
@@ -19098,8 +19159,8 @@ uint32_t  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_is_ok"))) TS_CResult_QueryChannelRangeDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_QueryChannelRangeDecodeErrorZ* o_conv = (LDKCResult_QueryChannelRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_QueryChannelRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_QueryChannelRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_free"))) TS_CResult_QueryChannelRangeDecodeErrorZ_free(uint32_t _res) {
@@ -19118,8 +19179,8 @@ static inline uintptr_t CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_clone_ptr"))) TS_CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_QueryChannelRangeDecodeErrorZ* arg_conv = (LDKCResult_QueryChannelRangeDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_QueryChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_QueryChannelRangeDecodeErrorZ_clone"))) TS_CResult_QueryChannelRangeDecodeErrorZ_clone(uint32_t orig) {
@@ -19153,8 +19214,8 @@ uint32_t  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_e
 
 jboolean  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_is_ok"))) TS_CResult_ReplyChannelRangeDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_ReplyChannelRangeDecodeErrorZ* o_conv = (LDKCResult_ReplyChannelRangeDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_ReplyChannelRangeDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_ReplyChannelRangeDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_free"))) TS_CResult_ReplyChannelRangeDecodeErrorZ_free(uint32_t _res) {
@@ -19173,8 +19234,8 @@ static inline uintptr_t CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(LDKCResu
 }
 uint32_t  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr"))) TS_CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_ReplyChannelRangeDecodeErrorZ* arg_conv = (LDKCResult_ReplyChannelRangeDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_ReplyChannelRangeDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_ReplyChannelRangeDecodeErrorZ_clone"))) TS_CResult_ReplyChannelRangeDecodeErrorZ_clone(uint32_t orig) {
@@ -19208,8 +19269,8 @@ uint32_t  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErro
 
 jboolean  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErrorZ_is_ok"))) TS_CResult_GossipTimestampFilterDecodeErrorZ_is_ok(uint32_t o) {
 	LDKCResult_GossipTimestampFilterDecodeErrorZ* o_conv = (LDKCResult_GossipTimestampFilterDecodeErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_GossipTimestampFilterDecodeErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_GossipTimestampFilterDecodeErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErrorZ_free"))) TS_CResult_GossipTimestampFilterDecodeErrorZ_free(uint32_t _res) {
@@ -19228,8 +19289,8 @@ static inline uintptr_t CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(LDKC
 }
 uint32_t  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr"))) TS_CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_GossipTimestampFilterDecodeErrorZ* arg_conv = (LDKCResult_GossipTimestampFilterDecodeErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_GossipTimestampFilterDecodeErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_GossipTimestampFilterDecodeErrorZ_clone"))) TS_CResult_GossipTimestampFilterDecodeErrorZ_clone(uint32_t orig) {
@@ -19262,8 +19323,8 @@ uint32_t  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_err
 
 jboolean  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_is_ok"))) TS_CResult_InvoiceSignOrCreationErrorZ_is_ok(uint32_t o) {
 	LDKCResult_InvoiceSignOrCreationErrorZ* o_conv = (LDKCResult_InvoiceSignOrCreationErrorZ*)(o & ~1);
-	jboolean ret_val = CResult_InvoiceSignOrCreationErrorZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_InvoiceSignOrCreationErrorZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_free"))) TS_CResult_InvoiceSignOrCreationErrorZ_free(uint32_t _res) {
@@ -19282,8 +19343,8 @@ static inline uintptr_t CResult_InvoiceSignOrCreationErrorZ_clone_ptr(LDKCResult
 }
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_clone_ptr"))) TS_CResult_InvoiceSignOrCreationErrorZ_clone_ptr(uint32_t arg) {
 	LDKCResult_InvoiceSignOrCreationErrorZ* arg_conv = (LDKCResult_InvoiceSignOrCreationErrorZ*)(arg & ~1);
-	uint32_t ret_val = CResult_InvoiceSignOrCreationErrorZ_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CResult_InvoiceSignOrCreationErrorZ_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CResult_InvoiceSignOrCreationErrorZ_clone"))) TS_CResult_InvoiceSignOrCreationErrorZ_clone(uint32_t orig) {
@@ -19342,8 +19403,8 @@ uint32_t  __attribute__((export_name("TS_CResult_LockedChannelMonitorNoneZ_err")
 
 jboolean  __attribute__((export_name("TS_CResult_LockedChannelMonitorNoneZ_is_ok"))) TS_CResult_LockedChannelMonitorNoneZ_is_ok(uint32_t o) {
 	LDKCResult_LockedChannelMonitorNoneZ* o_conv = (LDKCResult_LockedChannelMonitorNoneZ*)(o & ~1);
-	jboolean ret_val = CResult_LockedChannelMonitorNoneZ_is_ok(o_conv);
-	return ret_val;
+	jboolean ret_conv = CResult_LockedChannelMonitorNoneZ_is_ok(o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CResult_LockedChannelMonitorNoneZ_free"))) TS_CResult_LockedChannelMonitorNoneZ_free(uint32_t _res) {
@@ -19391,8 +19452,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_PaymentPurpose_clone_ptr"))) TS_PaymentPurpose_clone_ptr(uint32_t arg) {
 	LDKPaymentPurpose* arg_conv = (LDKPaymentPurpose*)arg;
-	uint32_t ret_val = PaymentPurpose_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PaymentPurpose_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PaymentPurpose_clone"))) TS_PaymentPurpose_clone(uint32_t orig) {
@@ -19443,8 +19504,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_ClosureReason_clone_ptr"))) TS_ClosureReason_clone_ptr(uint32_t arg) {
 	LDKClosureReason* arg_conv = (LDKClosureReason*)arg;
-	uint32_t ret_val = ClosureReason_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ClosureReason_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosureReason_clone"))) TS_ClosureReason_clone(uint32_t orig) {
@@ -19548,8 +19609,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_Event_clone_ptr"))) TS_Event_clone_ptr(uint32_t arg) {
 	LDKEvent* arg_conv = (LDKEvent*)arg;
-	uint32_t ret_val = Event_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Event_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Event_clone"))) TS_Event_clone(uint32_t orig) {
@@ -19814,8 +19875,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_MessageSendEvent_clone_ptr"))) TS_MessageSendEvent_clone_ptr(uint32_t arg) {
 	LDKMessageSendEvent* arg_conv = (LDKMessageSendEvent*)arg;
-	uint32_t ret_val = MessageSendEvent_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = MessageSendEvent_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_MessageSendEvent_clone"))) TS_MessageSendEvent_clone(uint32_t orig) {
@@ -20165,8 +20226,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_APIError_clone_ptr"))) TS_APIError_clone_ptr(uint32_t arg) {
 	LDKAPIError* arg_conv = (LDKAPIError*)arg;
-	uint32_t ret_val = APIError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = APIError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_APIError_clone"))) TS_APIError_clone(uint32_t orig) {
@@ -20259,8 +20320,8 @@ jboolean  __attribute__((export_name("TS_verify"))) TS_verify(int8_tArray msg, j
 	LDKPublicKey pk_ref;
 	CHECK(pk->arr_len == 33);
 	memcpy(pk_ref.compressed_form, pk->elems, 33); FREE(pk);
-	jboolean ret_val = verify(msg_ref, sig_conv, pk_ref);
-	return ret_val;
+	jboolean ret_conv = verify(msg_ref, sig_conv, pk_ref);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_construct_invoice_preimage"))) TS_construct_invoice_preimage(int8_tArray hrp_bytes, ptrArray data_without_signature) {
@@ -20325,14 +20386,14 @@ uint32_t  __attribute__((export_name("TS_Level_error"))) TS_Level_error() {
 jboolean  __attribute__((export_name("TS_Level_eq"))) TS_Level_eq(uint32_t a, uint32_t b) {
 	LDKLevel* a_conv = (LDKLevel*)(a & ~1);
 	LDKLevel* b_conv = (LDKLevel*)(b & ~1);
-	jboolean ret_val = Level_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Level_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_Level_hash"))) TS_Level_hash(uint32_t o) {
 	LDKLevel* o_conv = (LDKLevel*)(o & ~1);
-	int64_t ret_val = Level_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Level_hash(o_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Level_max"))) TS_Level_max() {
@@ -20431,8 +20492,8 @@ int32_t  __attribute__((export_name("TS_Record_get_line"))) TS_Record_get_line(u
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = Record_get_line(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = Record_get_line(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Record_set_line"))) TS_Record_set_line(uint32_t this_ptr, int32_t val) {
@@ -20460,8 +20521,8 @@ uint32_t  __attribute__((export_name("TS_Record_clone_ptr"))) TS_Record_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Record_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Record_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Record_clone"))) TS_Record_clone(uint32_t orig) {
@@ -20503,8 +20564,8 @@ int32_t  __attribute__((export_name("TS_ChannelHandshakeConfig_get_minimum_depth
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelHandshakeConfig_get_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelHandshakeConfig_get_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeConfig_set_minimum_depth"))) TS_ChannelHandshakeConfig_set_minimum_depth(uint32_t this_ptr, int32_t val) {
@@ -20520,8 +20581,8 @@ int16_t  __attribute__((export_name("TS_ChannelHandshakeConfig_get_our_to_self_d
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeConfig_get_our_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeConfig_get_our_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeConfig_set_our_to_self_delay"))) TS_ChannelHandshakeConfig_set_our_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -20537,8 +20598,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeConfig_get_our_htlc_mini
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeConfig_get_our_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeConfig_get_our_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeConfig_set_our_htlc_minimum_msat"))) TS_ChannelHandshakeConfig_set_our_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -20554,8 +20615,8 @@ jboolean  __attribute__((export_name("TS_ChannelHandshakeConfig_get_negotiate_sc
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelHandshakeConfig_get_negotiate_scid_privacy(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelHandshakeConfig_get_negotiate_scid_privacy(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeConfig_set_negotiate_scid_privacy"))) TS_ChannelHandshakeConfig_set_negotiate_scid_privacy(uint32_t this_ptr, jboolean val) {
@@ -20596,8 +20657,8 @@ uint32_t  __attribute__((export_name("TS_ChannelHandshakeConfig_clone_ptr"))) TS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelHandshakeConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelHandshakeConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelHandshakeConfig_clone"))) TS_ChannelHandshakeConfig_clone(uint32_t orig) {
@@ -20643,8 +20704,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_min_funding_s
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_min_funding_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_min_funding_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_min_funding_satoshis"))) TS_ChannelHandshakeLimits_set_min_funding_satoshis(uint32_t this_ptr, int64_t val) {
@@ -20660,8 +20721,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_max_htlc_mini
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_max_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_max_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_max_htlc_minimum_msat"))) TS_ChannelHandshakeLimits_set_max_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -20677,8 +20738,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_min_max_htlc_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_min_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_min_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_min_max_htlc_value_in_flight_msat"))) TS_ChannelHandshakeLimits_set_min_max_htlc_value_in_flight_msat(uint32_t this_ptr, int64_t val) {
@@ -20694,8 +20755,8 @@ int64_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_max_channel_r
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelHandshakeLimits_get_max_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelHandshakeLimits_get_max_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_max_channel_reserve_satoshis"))) TS_ChannelHandshakeLimits_set_max_channel_reserve_satoshis(uint32_t this_ptr, int64_t val) {
@@ -20711,8 +20772,8 @@ int16_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_min_max_accep
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeLimits_get_min_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeLimits_get_min_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_min_max_accepted_htlcs"))) TS_ChannelHandshakeLimits_set_min_max_accepted_htlcs(uint32_t this_ptr, int16_t val) {
@@ -20728,8 +20789,8 @@ int32_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_max_minimum_d
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelHandshakeLimits_get_max_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelHandshakeLimits_get_max_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_max_minimum_depth"))) TS_ChannelHandshakeLimits_set_max_minimum_depth(uint32_t this_ptr, int32_t val) {
@@ -20745,8 +20806,8 @@ jboolean  __attribute__((export_name("TS_ChannelHandshakeLimits_get_force_announ
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelHandshakeLimits_get_force_announced_channel_preference(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelHandshakeLimits_get_force_announced_channel_preference(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_force_announced_channel_preference"))) TS_ChannelHandshakeLimits_set_force_announced_channel_preference(uint32_t this_ptr, jboolean val) {
@@ -20762,8 +20823,8 @@ int16_t  __attribute__((export_name("TS_ChannelHandshakeLimits_get_their_to_self
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelHandshakeLimits_get_their_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelHandshakeLimits_get_their_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelHandshakeLimits_set_their_to_self_delay"))) TS_ChannelHandshakeLimits_set_their_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -20804,8 +20865,8 @@ uint32_t  __attribute__((export_name("TS_ChannelHandshakeLimits_clone_ptr"))) TS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelHandshakeLimits_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelHandshakeLimits_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelHandshakeLimits_clone"))) TS_ChannelHandshakeLimits_clone(uint32_t orig) {
@@ -20851,8 +20912,8 @@ int32_t  __attribute__((export_name("TS_ChannelConfig_get_forwarding_fee_proport
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelConfig_get_forwarding_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelConfig_get_forwarding_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_forwarding_fee_proportional_millionths"))) TS_ChannelConfig_set_forwarding_fee_proportional_millionths(uint32_t this_ptr, int32_t val) {
@@ -20868,8 +20929,8 @@ int32_t  __attribute__((export_name("TS_ChannelConfig_get_forwarding_fee_base_ms
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelConfig_get_forwarding_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelConfig_get_forwarding_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_forwarding_fee_base_msat"))) TS_ChannelConfig_set_forwarding_fee_base_msat(uint32_t this_ptr, int32_t val) {
@@ -20885,8 +20946,8 @@ int16_t  __attribute__((export_name("TS_ChannelConfig_get_cltv_expiry_delta"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelConfig_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelConfig_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_cltv_expiry_delta"))) TS_ChannelConfig_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -20902,8 +20963,8 @@ jboolean  __attribute__((export_name("TS_ChannelConfig_get_announced_channel")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelConfig_get_announced_channel(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelConfig_get_announced_channel(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_announced_channel"))) TS_ChannelConfig_set_announced_channel(uint32_t this_ptr, jboolean val) {
@@ -20919,8 +20980,8 @@ jboolean  __attribute__((export_name("TS_ChannelConfig_get_commit_upfront_shutdo
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelConfig_get_commit_upfront_shutdown_pubkey(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelConfig_get_commit_upfront_shutdown_pubkey(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_commit_upfront_shutdown_pubkey"))) TS_ChannelConfig_set_commit_upfront_shutdown_pubkey(uint32_t this_ptr, jboolean val) {
@@ -20936,8 +20997,8 @@ int64_t  __attribute__((export_name("TS_ChannelConfig_get_max_dust_htlc_exposure
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelConfig_get_max_dust_htlc_exposure_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_get_max_dust_htlc_exposure_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_max_dust_htlc_exposure_msat"))) TS_ChannelConfig_set_max_dust_htlc_exposure_msat(uint32_t this_ptr, int64_t val) {
@@ -20953,8 +21014,8 @@ int64_t  __attribute__((export_name("TS_ChannelConfig_get_force_close_avoidance_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelConfig_get_force_close_avoidance_max_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelConfig_get_force_close_avoidance_max_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelConfig_set_force_close_avoidance_max_fee_satoshis"))) TS_ChannelConfig_set_force_close_avoidance_max_fee_satoshis(uint32_t this_ptr, int64_t val) {
@@ -20995,8 +21056,8 @@ uint32_t  __attribute__((export_name("TS_ChannelConfig_clone_ptr"))) TS_ChannelC
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelConfig_clone"))) TS_ChannelConfig_clone(uint32_t orig) {
@@ -21153,8 +21214,8 @@ jboolean  __attribute__((export_name("TS_UserConfig_get_accept_forwards_to_priv_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_accept_forwards_to_priv_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_accept_forwards_to_priv_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UserConfig_set_accept_forwards_to_priv_channels"))) TS_UserConfig_set_accept_forwards_to_priv_channels(uint32_t this_ptr, jboolean val) {
@@ -21170,8 +21231,8 @@ jboolean  __attribute__((export_name("TS_UserConfig_get_accept_inbound_channels"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_accept_inbound_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_accept_inbound_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UserConfig_set_accept_inbound_channels"))) TS_UserConfig_set_accept_inbound_channels(uint32_t this_ptr, jboolean val) {
@@ -21187,8 +21248,8 @@ jboolean  __attribute__((export_name("TS_UserConfig_get_manually_accept_inbound_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = UserConfig_get_manually_accept_inbound_channels(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = UserConfig_get_manually_accept_inbound_channels(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UserConfig_set_manually_accept_inbound_channels"))) TS_UserConfig_set_manually_accept_inbound_channels(uint32_t this_ptr, jboolean val) {
@@ -21244,8 +21305,8 @@ uint32_t  __attribute__((export_name("TS_UserConfig_clone_ptr"))) TS_UserConfig_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UserConfig_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UserConfig_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UserConfig_clone"))) TS_UserConfig_clone(uint32_t orig) {
@@ -21303,8 +21364,8 @@ uint32_t  __attribute__((export_name("TS_BestBlock_clone_ptr"))) TS_BestBlock_cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = BestBlock_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = BestBlock_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_BestBlock_clone"))) TS_BestBlock_clone(uint32_t orig) {
@@ -21369,8 +21430,8 @@ int32_t  __attribute__((export_name("TS_BestBlock_height"))) TS_BestBlock_height
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = BestBlock_height(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = BestBlock_height(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_AccessError_clone"))) TS_AccessError_clone(uint32_t orig) {
@@ -21574,8 +21635,8 @@ uint32_t  __attribute__((export_name("TS_WatchedOutput_clone_ptr"))) TS_WatchedO
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = WatchedOutput_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = WatchedOutput_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_WatchedOutput_clone"))) TS_WatchedOutput_clone(uint32_t orig) {
@@ -21600,8 +21661,8 @@ int64_t  __attribute__((export_name("TS_WatchedOutput_hash"))) TS_WatchedOutput_
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = WatchedOutput_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = WatchedOutput_hash(&o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_BroadcasterInterface_free"))) TS_BroadcasterInterface_free(uint32_t this_ptr) {
@@ -21637,8 +21698,8 @@ uint32_t  __attribute__((export_name("TS_ConfirmationTarget_high_priority"))) TS
 jboolean  __attribute__((export_name("TS_ConfirmationTarget_eq"))) TS_ConfirmationTarget_eq(uint32_t a, uint32_t b) {
 	LDKConfirmationTarget* a_conv = (LDKConfirmationTarget*)(a & ~1);
 	LDKConfirmationTarget* b_conv = (LDKConfirmationTarget*)(b & ~1);
-	jboolean ret_val = ConfirmationTarget_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = ConfirmationTarget_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_FeeEstimator_free"))) TS_FeeEstimator_free(uint32_t this_ptr) {
@@ -21675,8 +21736,8 @@ uint32_t  __attribute__((export_name("TS_MonitorUpdateId_clone_ptr"))) TS_Monito
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = MonitorUpdateId_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = MonitorUpdateId_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_MonitorUpdateId_clone"))) TS_MonitorUpdateId_clone(uint32_t orig) {
@@ -21701,8 +21762,8 @@ int64_t  __attribute__((export_name("TS_MonitorUpdateId_hash"))) TS_MonitorUpdat
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = MonitorUpdateId_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = MonitorUpdateId_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_MonitorUpdateId_eq"))) TS_MonitorUpdateId_eq(uint32_t a, uint32_t b) {
@@ -21714,8 +21775,8 @@ jboolean  __attribute__((export_name("TS_MonitorUpdateId_eq"))) TS_MonitorUpdate
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = MonitorUpdateId_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = MonitorUpdateId_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Persist_free"))) TS_Persist_free(uint32_t this_ptr) {
@@ -21945,8 +22006,8 @@ int64_t  __attribute__((export_name("TS_ChannelMonitorUpdate_get_update_id"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelMonitorUpdate_get_update_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitorUpdate_get_update_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelMonitorUpdate_set_update_id"))) TS_ChannelMonitorUpdate_set_update_id(uint32_t this_ptr, int64_t val) {
@@ -21974,8 +22035,8 @@ uint32_t  __attribute__((export_name("TS_ChannelMonitorUpdate_clone_ptr"))) TS_C
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelMonitorUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelMonitorUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelMonitorUpdate_clone"))) TS_ChannelMonitorUpdate_clone(uint32_t orig) {
@@ -22033,8 +22094,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_MonitorEvent_clone_ptr"))) TS_MonitorEvent_clone_ptr(uint32_t arg) {
 	LDKMonitorEvent* arg_conv = (LDKMonitorEvent*)arg;
-	uint32_t ret_val = MonitorEvent_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = MonitorEvent_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_MonitorEvent_clone"))) TS_MonitorEvent_clone(uint32_t orig) {
@@ -22136,8 +22197,8 @@ uint32_t  __attribute__((export_name("TS_HTLCUpdate_clone_ptr"))) TS_HTLCUpdate_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = HTLCUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = HTLCUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_HTLCUpdate_clone"))) TS_HTLCUpdate_clone(uint32_t orig) {
@@ -22195,8 +22256,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_Balance_clone_ptr"))) TS_Balance_clone_ptr(uint32_t arg) {
 	LDKBalance* arg_conv = (LDKBalance*)arg;
-	uint32_t ret_val = Balance_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Balance_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Balance_clone"))) TS_Balance_clone(uint32_t orig) {
@@ -22238,8 +22299,8 @@ uint32_t  __attribute__((export_name("TS_Balance_maybe_claimable_htlcawaiting_ti
 jboolean  __attribute__((export_name("TS_Balance_eq"))) TS_Balance_eq(uint32_t a, uint32_t b) {
 	LDKBalance* a_conv = (LDKBalance*)a;
 	LDKBalance* b_conv = (LDKBalance*)b;
-	jboolean ret_val = Balance_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Balance_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelMonitor_free"))) TS_ChannelMonitor_free(uint32_t this_obj) {
@@ -22267,8 +22328,8 @@ uint32_t  __attribute__((export_name("TS_ChannelMonitor_clone_ptr"))) TS_Channel
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelMonitor_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelMonitor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelMonitor_clone"))) TS_ChannelMonitor_clone(uint32_t orig) {
@@ -22328,8 +22389,8 @@ int64_t  __attribute__((export_name("TS_ChannelMonitor_get_latest_update_id"))) 
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ChannelMonitor_get_latest_update_id(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelMonitor_get_latest_update_id(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelMonitor_get_funding_txo"))) TS_ChannelMonitor_get_funding_txo(uint32_t this_arg) {
@@ -22766,8 +22827,8 @@ int16_t  __attribute__((export_name("TS_OutPoint_get_index"))) TS_OutPoint_get_i
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OutPoint_get_index(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OutPoint_get_index(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OutPoint_set_index"))) TS_OutPoint_set_index(uint32_t this_ptr, int16_t val) {
@@ -22811,8 +22872,8 @@ uint32_t  __attribute__((export_name("TS_OutPoint_clone_ptr"))) TS_OutPoint_clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = OutPoint_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = OutPoint_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_OutPoint_clone"))) TS_OutPoint_clone(uint32_t orig) {
@@ -22841,8 +22902,8 @@ jboolean  __attribute__((export_name("TS_OutPoint_eq"))) TS_OutPoint_eq(uint32_t
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = OutPoint_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = OutPoint_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_OutPoint_hash"))) TS_OutPoint_hash(uint32_t o) {
@@ -22850,8 +22911,8 @@ int64_t  __attribute__((export_name("TS_OutPoint_hash"))) TS_OutPoint_hash(uint3
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = OutPoint_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = OutPoint_hash(&o_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_OutPoint_to_channel_id"))) TS_OutPoint_to_channel_id(uint32_t this_arg) {
@@ -22949,8 +23010,8 @@ int16_t  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_get_to_se
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = DelayedPaymentOutputDescriptor_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = DelayedPaymentOutputDescriptor_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_set_to_self_delay"))) TS_DelayedPaymentOutputDescriptor_set_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -23020,8 +23081,8 @@ int64_t  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_get_chann
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = DelayedPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = DelayedPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_set_channel_value_satoshis"))) TS_DelayedPaymentOutputDescriptor_set_channel_value_satoshis(uint32_t this_ptr, int64_t val) {
@@ -23080,8 +23141,8 @@ uint32_t  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = DelayedPaymentOutputDescriptor_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = DelayedPaymentOutputDescriptor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DelayedPaymentOutputDescriptor_clone"))) TS_DelayedPaymentOutputDescriptor_clone(uint32_t orig) {
@@ -23198,8 +23259,8 @@ int64_t  __attribute__((export_name("TS_StaticPaymentOutputDescriptor_get_channe
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = StaticPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = StaticPaymentOutputDescriptor_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_StaticPaymentOutputDescriptor_set_channel_value_satoshis"))) TS_StaticPaymentOutputDescriptor_set_channel_value_satoshis(uint32_t this_ptr, int64_t val) {
@@ -23252,8 +23313,8 @@ uint32_t  __attribute__((export_name("TS_StaticPaymentOutputDescriptor_clone_ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = StaticPaymentOutputDescriptor_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = StaticPaymentOutputDescriptor_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_StaticPaymentOutputDescriptor_clone"))) TS_StaticPaymentOutputDescriptor_clone(uint32_t orig) {
@@ -23311,8 +23372,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_SpendableOutputDescriptor_clone_ptr"))) TS_SpendableOutputDescriptor_clone_ptr(uint32_t arg) {
 	LDKSpendableOutputDescriptor* arg_conv = (LDKSpendableOutputDescriptor*)arg;
-	uint32_t ret_val = SpendableOutputDescriptor_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = SpendableOutputDescriptor_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SpendableOutputDescriptor_clone"))) TS_SpendableOutputDescriptor_clone(uint32_t orig) {
@@ -23399,8 +23460,8 @@ uint32_t  __attribute__((export_name("TS_Sign_clone_ptr"))) TS_Sign_clone_ptr(ui
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKSign* arg_conv = (LDKSign*)arg_ptr;
-	uint32_t ret_val = Sign_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Sign_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Sign_clone"))) TS_Sign_clone(uint32_t orig) {
@@ -23597,8 +23658,8 @@ uint32_t  __attribute__((export_name("TS_InMemorySigner_clone_ptr"))) TS_InMemor
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InMemorySigner_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InMemorySigner_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InMemorySigner_clone"))) TS_InMemorySigner_clone(uint32_t orig) {
@@ -23677,8 +23738,8 @@ int16_t  __attribute__((export_name("TS_InMemorySigner_counterparty_selected_con
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = InMemorySigner_counterparty_selected_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = InMemorySigner_counterparty_selected_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 int16_t  __attribute__((export_name("TS_InMemorySigner_holder_selected_contest_delay"))) TS_InMemorySigner_holder_selected_contest_delay(uint32_t this_arg) {
@@ -23686,8 +23747,8 @@ int16_t  __attribute__((export_name("TS_InMemorySigner_holder_selected_contest_d
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = InMemorySigner_holder_selected_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = InMemorySigner_holder_selected_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_InMemorySigner_is_outbound"))) TS_InMemorySigner_is_outbound(uint32_t this_arg) {
@@ -23695,8 +23756,8 @@ jboolean  __attribute__((export_name("TS_InMemorySigner_is_outbound"))) TS_InMem
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InMemorySigner_is_outbound(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InMemorySigner_is_outbound(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InMemorySigner_funding_outpoint"))) TS_InMemorySigner_funding_outpoint(uint32_t this_arg) {
@@ -23738,8 +23799,8 @@ jboolean  __attribute__((export_name("TS_InMemorySigner_opt_anchors"))) TS_InMem
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InMemorySigner_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InMemorySigner_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InMemorySigner_sign_counterparty_payment_input"))) TS_InMemorySigner_sign_counterparty_payment_input(uint32_t this_arg, int8_tArray spend_tx, uint32_t input_idx, uint32_t descriptor) {
@@ -24128,8 +24189,8 @@ uint32_t  __attribute__((export_name("TS_ChainParameters_clone_ptr"))) TS_ChainP
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChainParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChainParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChainParameters_clone"))) TS_ChainParameters_clone(uint32_t orig) {
@@ -24162,8 +24223,8 @@ int32_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_get_fee_base_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = CounterpartyForwardingInfo_get_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = CounterpartyForwardingInfo_get_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CounterpartyForwardingInfo_set_fee_base_msat"))) TS_CounterpartyForwardingInfo_set_fee_base_msat(uint32_t this_ptr, int32_t val) {
@@ -24179,8 +24240,8 @@ int32_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_get_fee_propo
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = CounterpartyForwardingInfo_get_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = CounterpartyForwardingInfo_get_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CounterpartyForwardingInfo_set_fee_proportional_millionths"))) TS_CounterpartyForwardingInfo_set_fee_proportional_millionths(uint32_t this_ptr, int32_t val) {
@@ -24196,8 +24257,8 @@ int16_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_get_cltv_expi
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = CounterpartyForwardingInfo_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = CounterpartyForwardingInfo_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CounterpartyForwardingInfo_set_cltv_expiry_delta"))) TS_CounterpartyForwardingInfo_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -24238,8 +24299,8 @@ uint32_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_clone_ptr"))
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CounterpartyForwardingInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CounterpartyForwardingInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CounterpartyForwardingInfo_clone"))) TS_CounterpartyForwardingInfo_clone(uint32_t orig) {
@@ -24323,8 +24384,8 @@ int64_t  __attribute__((export_name("TS_ChannelCounterparty_get_unspendable_puni
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelCounterparty_get_unspendable_punishment_reserve(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelCounterparty_get_unspendable_punishment_reserve(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelCounterparty_set_unspendable_punishment_reserve"))) TS_ChannelCounterparty_set_unspendable_punishment_reserve(uint32_t this_ptr, int64_t val) {
@@ -24410,8 +24471,8 @@ uint32_t  __attribute__((export_name("TS_ChannelCounterparty_clone_ptr"))) TS_Ch
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelCounterparty_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelCounterparty_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelCounterparty_clone"))) TS_ChannelCounterparty_clone(uint32_t orig) {
@@ -24605,8 +24666,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_channel_value_satoshi
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_channel_value_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_channel_value_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_channel_value_satoshis"))) TS_ChannelDetails_set_channel_value_satoshis(uint32_t this_ptr, int64_t val) {
@@ -24645,8 +24706,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_user_channel_id"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_user_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_user_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_user_channel_id"))) TS_ChannelDetails_set_user_channel_id(uint32_t this_ptr, int64_t val) {
@@ -24662,8 +24723,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_balance_msat"))) TS_C
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_balance_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_balance_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_balance_msat"))) TS_ChannelDetails_set_balance_msat(uint32_t this_ptr, int64_t val) {
@@ -24679,8 +24740,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_outbound_capacity_msa
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_outbound_capacity_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_outbound_capacity_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_outbound_capacity_msat"))) TS_ChannelDetails_set_outbound_capacity_msat(uint32_t this_ptr, int64_t val) {
@@ -24696,8 +24757,8 @@ int64_t  __attribute__((export_name("TS_ChannelDetails_get_inbound_capacity_msat
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelDetails_get_inbound_capacity_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelDetails_get_inbound_capacity_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_inbound_capacity_msat"))) TS_ChannelDetails_set_inbound_capacity_msat(uint32_t this_ptr, int64_t val) {
@@ -24759,8 +24820,8 @@ jboolean  __attribute__((export_name("TS_ChannelDetails_get_is_outbound"))) TS_C
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_outbound(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_outbound(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_is_outbound"))) TS_ChannelDetails_set_is_outbound(uint32_t this_ptr, jboolean val) {
@@ -24776,8 +24837,8 @@ jboolean  __attribute__((export_name("TS_ChannelDetails_get_is_funding_locked"))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_funding_locked(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_funding_locked(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_is_funding_locked"))) TS_ChannelDetails_set_is_funding_locked(uint32_t this_ptr, jboolean val) {
@@ -24793,8 +24854,8 @@ jboolean  __attribute__((export_name("TS_ChannelDetails_get_is_usable"))) TS_Cha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_usable(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_usable(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_is_usable"))) TS_ChannelDetails_set_is_usable(uint32_t this_ptr, jboolean val) {
@@ -24810,8 +24871,8 @@ jboolean  __attribute__((export_name("TS_ChannelDetails_get_is_public"))) TS_Cha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelDetails_get_is_public(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelDetails_get_is_public(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelDetails_set_is_public"))) TS_ChannelDetails_set_is_public(uint32_t this_ptr, jboolean val) {
@@ -24889,8 +24950,8 @@ uint32_t  __attribute__((export_name("TS_ChannelDetails_clone_ptr"))) TS_Channel
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelDetails_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelDetails_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelDetails_clone"))) TS_ChannelDetails_clone(uint32_t orig) {
@@ -24938,8 +24999,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_PaymentSendFailure_clone_ptr"))) TS_PaymentSendFailure_clone_ptr(uint32_t arg) {
 	LDKPaymentSendFailure* arg_conv = (LDKPaymentSendFailure*)arg;
-	uint32_t ret_val = PaymentSendFailure_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PaymentSendFailure_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PaymentSendFailure_clone"))) TS_PaymentSendFailure_clone(uint32_t orig) {
@@ -25097,8 +25158,8 @@ int64_t  __attribute__((export_name("TS_PhantomRouteHints_get_phantom_scid"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = PhantomRouteHints_get_phantom_scid(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = PhantomRouteHints_get_phantom_scid(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PhantomRouteHints_set_phantom_scid"))) TS_PhantomRouteHints_set_phantom_scid(uint32_t this_ptr, int64_t val) {
@@ -25179,8 +25240,8 @@ uint32_t  __attribute__((export_name("TS_PhantomRouteHints_clone_ptr"))) TS_Phan
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PhantomRouteHints_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PhantomRouteHints_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PhantomRouteHints_clone"))) TS_PhantomRouteHints_clone(uint32_t orig) {
@@ -25532,8 +25593,8 @@ jboolean  __attribute__((export_name("TS_ChannelManager_fail_htlc_backwards"))) 
 	CHECK(payment_hash->arr_len == 32);
 	memcpy(payment_hash_arr, payment_hash->elems, 32); FREE(payment_hash);
 	unsigned char (*payment_hash_ref)[32] = &payment_hash_arr;
-	jboolean ret_val = ChannelManager_fail_htlc_backwards(&this_arg_conv, payment_hash_ref);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_fail_htlc_backwards(&this_arg_conv, payment_hash_ref);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_ChannelManager_claim_funds"))) TS_ChannelManager_claim_funds(uint32_t this_arg, int8_tArray payment_preimage) {
@@ -25544,8 +25605,8 @@ jboolean  __attribute__((export_name("TS_ChannelManager_claim_funds"))) TS_Chann
 	LDKThirtyTwoBytes payment_preimage_ref;
 	CHECK(payment_preimage->arr_len == 32);
 	memcpy(payment_preimage_ref.data, payment_preimage->elems, 32); FREE(payment_preimage);
-	jboolean ret_val = ChannelManager_claim_funds(&this_arg_conv, payment_preimage_ref);
-	return ret_val;
+	jboolean ret_conv = ChannelManager_claim_funds(&this_arg_conv, payment_preimage_ref);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_ChannelManager_get_our_node_id"))) TS_ChannelManager_get_our_node_id(uint32_t this_arg) {
@@ -25655,8 +25716,8 @@ int64_t  __attribute__((export_name("TS_ChannelManager_get_phantom_scid"))) TS_C
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ChannelManager_get_phantom_scid(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelManager_get_phantom_scid(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelManager_get_phantom_route_hints"))) TS_ChannelManager_get_phantom_route_hints(uint32_t this_arg) {
@@ -26117,8 +26178,8 @@ uint32_t  __attribute__((export_name("TS_DecodeError_clone_ptr"))) TS_DecodeErro
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = DecodeError_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = DecodeError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DecodeError_clone"))) TS_DecodeError_clone(uint32_t orig) {
@@ -26237,8 +26298,8 @@ uint32_t  __attribute__((export_name("TS_Init_clone_ptr"))) TS_Init_clone_ptr(ui
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Init_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Init_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Init_clone"))) TS_Init_clone(uint32_t orig) {
@@ -26341,8 +26402,8 @@ uint32_t  __attribute__((export_name("TS_ErrorMessage_clone_ptr"))) TS_ErrorMess
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ErrorMessage_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ErrorMessage_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ErrorMessage_clone"))) TS_ErrorMessage_clone(uint32_t orig) {
@@ -26445,8 +26506,8 @@ uint32_t  __attribute__((export_name("TS_WarningMessage_clone_ptr"))) TS_Warning
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = WarningMessage_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = WarningMessage_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_WarningMessage_clone"))) TS_WarningMessage_clone(uint32_t orig) {
@@ -26479,8 +26540,8 @@ int16_t  __attribute__((export_name("TS_Ping_get_ponglen"))) TS_Ping_get_ponglen
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Ping_get_ponglen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Ping_get_ponglen(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Ping_set_ponglen"))) TS_Ping_set_ponglen(uint32_t this_ptr, int16_t val) {
@@ -26496,8 +26557,8 @@ int16_t  __attribute__((export_name("TS_Ping_get_byteslen"))) TS_Ping_get_bytesl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Ping_get_byteslen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Ping_get_byteslen(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Ping_set_byteslen"))) TS_Ping_set_byteslen(uint32_t this_ptr, int16_t val) {
@@ -26538,8 +26599,8 @@ uint32_t  __attribute__((export_name("TS_Ping_clone_ptr"))) TS_Ping_clone_ptr(ui
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Ping_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Ping_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Ping_clone"))) TS_Ping_clone(uint32_t orig) {
@@ -26572,8 +26633,8 @@ int16_t  __attribute__((export_name("TS_Pong_get_byteslen"))) TS_Pong_get_bytesl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = Pong_get_byteslen(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = Pong_get_byteslen(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Pong_set_byteslen"))) TS_Pong_set_byteslen(uint32_t this_ptr, int16_t val) {
@@ -26614,8 +26675,8 @@ uint32_t  __attribute__((export_name("TS_Pong_clone_ptr"))) TS_Pong_clone_ptr(ui
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Pong_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Pong_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Pong_clone"))) TS_Pong_clone(uint32_t orig) {
@@ -26690,8 +26751,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_funding_satoshis"))) TS_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_funding_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_funding_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_funding_satoshis"))) TS_OpenChannel_set_funding_satoshis(uint32_t this_ptr, int64_t val) {
@@ -26707,8 +26768,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_push_msat"))) TS_OpenCha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_push_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_push_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_push_msat"))) TS_OpenChannel_set_push_msat(uint32_t this_ptr, int64_t val) {
@@ -26724,8 +26785,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_dust_limit_satoshis"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_dust_limit_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_dust_limit_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_dust_limit_satoshis"))) TS_OpenChannel_set_dust_limit_satoshis(uint32_t this_ptr, int64_t val) {
@@ -26741,8 +26802,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_max_htlc_value_in_flight
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_max_htlc_value_in_flight_msat"))) TS_OpenChannel_set_max_htlc_value_in_flight_msat(uint32_t this_ptr, int64_t val) {
@@ -26758,8 +26819,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_channel_reserve_satoshis
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_channel_reserve_satoshis"))) TS_OpenChannel_set_channel_reserve_satoshis(uint32_t this_ptr, int64_t val) {
@@ -26775,8 +26836,8 @@ int64_t  __attribute__((export_name("TS_OpenChannel_get_htlc_minimum_msat"))) TS
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = OpenChannel_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = OpenChannel_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_htlc_minimum_msat"))) TS_OpenChannel_set_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -26792,8 +26853,8 @@ int32_t  __attribute__((export_name("TS_OpenChannel_get_feerate_per_kw"))) TS_Op
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = OpenChannel_get_feerate_per_kw(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = OpenChannel_get_feerate_per_kw(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_feerate_per_kw"))) TS_OpenChannel_set_feerate_per_kw(uint32_t this_ptr, int32_t val) {
@@ -26809,8 +26870,8 @@ int16_t  __attribute__((export_name("TS_OpenChannel_get_to_self_delay"))) TS_Ope
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OpenChannel_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OpenChannel_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_to_self_delay"))) TS_OpenChannel_set_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -26826,8 +26887,8 @@ int16_t  __attribute__((export_name("TS_OpenChannel_get_max_accepted_htlcs"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = OpenChannel_get_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = OpenChannel_get_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_max_accepted_htlcs"))) TS_OpenChannel_set_max_accepted_htlcs(uint32_t this_ptr, int16_t val) {
@@ -26969,8 +27030,8 @@ int8_t  __attribute__((export_name("TS_OpenChannel_get_channel_flags"))) TS_Open
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int8_t ret_val = OpenChannel_get_channel_flags(&this_ptr_conv);
-	return ret_val;
+	int8_t ret_conv = OpenChannel_get_channel_flags(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_OpenChannel_set_channel_flags"))) TS_OpenChannel_set_channel_flags(uint32_t this_ptr, int8_t val) {
@@ -27030,8 +27091,8 @@ uint32_t  __attribute__((export_name("TS_OpenChannel_clone_ptr"))) TS_OpenChanne
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = OpenChannel_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = OpenChannel_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_OpenChannel_clone"))) TS_OpenChannel_clone(uint32_t orig) {
@@ -27085,8 +27146,8 @@ int64_t  __attribute__((export_name("TS_AcceptChannel_get_dust_limit_satoshis"))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_dust_limit_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_dust_limit_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_dust_limit_satoshis"))) TS_AcceptChannel_set_dust_limit_satoshis(uint32_t this_ptr, int64_t val) {
@@ -27102,8 +27163,8 @@ int64_t  __attribute__((export_name("TS_AcceptChannel_get_max_htlc_value_in_flig
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_max_htlc_value_in_flight_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_max_htlc_value_in_flight_msat"))) TS_AcceptChannel_set_max_htlc_value_in_flight_msat(uint32_t this_ptr, int64_t val) {
@@ -27119,8 +27180,8 @@ int64_t  __attribute__((export_name("TS_AcceptChannel_get_channel_reserve_satosh
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_channel_reserve_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_channel_reserve_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_channel_reserve_satoshis"))) TS_AcceptChannel_set_channel_reserve_satoshis(uint32_t this_ptr, int64_t val) {
@@ -27136,8 +27197,8 @@ int64_t  __attribute__((export_name("TS_AcceptChannel_get_htlc_minimum_msat"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AcceptChannel_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AcceptChannel_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_htlc_minimum_msat"))) TS_AcceptChannel_set_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -27153,8 +27214,8 @@ int32_t  __attribute__((export_name("TS_AcceptChannel_get_minimum_depth"))) TS_A
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = AcceptChannel_get_minimum_depth(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = AcceptChannel_get_minimum_depth(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_minimum_depth"))) TS_AcceptChannel_set_minimum_depth(uint32_t this_ptr, int32_t val) {
@@ -27170,8 +27231,8 @@ int16_t  __attribute__((export_name("TS_AcceptChannel_get_to_self_delay"))) TS_A
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = AcceptChannel_get_to_self_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = AcceptChannel_get_to_self_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_to_self_delay"))) TS_AcceptChannel_set_to_self_delay(uint32_t this_ptr, int16_t val) {
@@ -27187,8 +27248,8 @@ int16_t  __attribute__((export_name("TS_AcceptChannel_get_max_accepted_htlcs")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = AcceptChannel_get_max_accepted_htlcs(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = AcceptChannel_get_max_accepted_htlcs(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AcceptChannel_set_max_accepted_htlcs"))) TS_AcceptChannel_set_max_accepted_htlcs(uint32_t this_ptr, int16_t val) {
@@ -27374,8 +27435,8 @@ uint32_t  __attribute__((export_name("TS_AcceptChannel_clone_ptr"))) TS_AcceptCh
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = AcceptChannel_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = AcceptChannel_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_AcceptChannel_clone"))) TS_AcceptChannel_clone(uint32_t orig) {
@@ -27450,8 +27511,8 @@ int16_t  __attribute__((export_name("TS_FundingCreated_get_funding_output_index"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = FundingCreated_get_funding_output_index(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = FundingCreated_get_funding_output_index(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_FundingCreated_set_funding_output_index"))) TS_FundingCreated_set_funding_output_index(uint32_t this_ptr, int16_t val) {
@@ -27522,8 +27583,8 @@ uint32_t  __attribute__((export_name("TS_FundingCreated_clone_ptr"))) TS_Funding
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = FundingCreated_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = FundingCreated_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_FundingCreated_clone"))) TS_FundingCreated_clone(uint32_t orig) {
@@ -27629,8 +27690,8 @@ uint32_t  __attribute__((export_name("TS_FundingSigned_clone_ptr"))) TS_FundingS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = FundingSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = FundingSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_FundingSigned_clone"))) TS_FundingSigned_clone(uint32_t orig) {
@@ -27763,8 +27824,8 @@ uint32_t  __attribute__((export_name("TS_FundingLocked_clone_ptr"))) TS_FundingL
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = FundingLocked_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = FundingLocked_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_FundingLocked_clone"))) TS_FundingLocked_clone(uint32_t orig) {
@@ -27873,8 +27934,8 @@ uint32_t  __attribute__((export_name("TS_Shutdown_clone_ptr"))) TS_Shutdown_clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Shutdown_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Shutdown_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Shutdown_clone"))) TS_Shutdown_clone(uint32_t orig) {
@@ -27907,8 +27968,8 @@ int64_t  __attribute__((export_name("TS_ClosingSignedFeeRange_get_min_fee_satosh
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSignedFeeRange_get_min_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_get_min_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ClosingSignedFeeRange_set_min_fee_satoshis"))) TS_ClosingSignedFeeRange_set_min_fee_satoshis(uint32_t this_ptr, int64_t val) {
@@ -27924,8 +27985,8 @@ int64_t  __attribute__((export_name("TS_ClosingSignedFeeRange_get_max_fee_satosh
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSignedFeeRange_get_max_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSignedFeeRange_get_max_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ClosingSignedFeeRange_set_max_fee_satoshis"))) TS_ClosingSignedFeeRange_set_max_fee_satoshis(uint32_t this_ptr, int64_t val) {
@@ -27966,8 +28027,8 @@ uint32_t  __attribute__((export_name("TS_ClosingSignedFeeRange_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ClosingSignedFeeRange_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ClosingSignedFeeRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosingSignedFeeRange_clone"))) TS_ClosingSignedFeeRange_clone(uint32_t orig) {
@@ -28021,8 +28082,8 @@ int64_t  __attribute__((export_name("TS_ClosingSigned_get_fee_satoshis"))) TS_Cl
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ClosingSigned_get_fee_satoshis(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingSigned_get_fee_satoshis(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ClosingSigned_set_fee_satoshis"))) TS_ClosingSigned_set_fee_satoshis(uint32_t this_ptr, int64_t val) {
@@ -28127,8 +28188,8 @@ uint32_t  __attribute__((export_name("TS_ClosingSigned_clone_ptr"))) TS_ClosingS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ClosingSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ClosingSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosingSigned_clone"))) TS_ClosingSigned_clone(uint32_t orig) {
@@ -28182,8 +28243,8 @@ int64_t  __attribute__((export_name("TS_UpdateAddHTLC_get_htlc_id"))) TS_UpdateA
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateAddHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateAddHTLC_set_htlc_id"))) TS_UpdateAddHTLC_set_htlc_id(uint32_t this_ptr, int64_t val) {
@@ -28199,8 +28260,8 @@ int64_t  __attribute__((export_name("TS_UpdateAddHTLC_get_amount_msat"))) TS_Upd
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateAddHTLC_get_amount_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateAddHTLC_get_amount_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateAddHTLC_set_amount_msat"))) TS_UpdateAddHTLC_set_amount_msat(uint32_t this_ptr, int64_t val) {
@@ -28237,8 +28298,8 @@ int32_t  __attribute__((export_name("TS_UpdateAddHTLC_get_cltv_expiry"))) TS_Upd
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UpdateAddHTLC_get_cltv_expiry(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UpdateAddHTLC_get_cltv_expiry(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateAddHTLC_set_cltv_expiry"))) TS_UpdateAddHTLC_set_cltv_expiry(uint32_t this_ptr, int32_t val) {
@@ -28266,8 +28327,8 @@ uint32_t  __attribute__((export_name("TS_UpdateAddHTLC_clone_ptr"))) TS_UpdateAd
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateAddHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateAddHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateAddHTLC_clone"))) TS_UpdateAddHTLC_clone(uint32_t orig) {
@@ -28321,8 +28382,8 @@ int64_t  __attribute__((export_name("TS_UpdateFulfillHTLC_get_htlc_id"))) TS_Upd
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFulfillHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFulfillHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFulfillHTLC_set_htlc_id"))) TS_UpdateFulfillHTLC_set_htlc_id(uint32_t this_ptr, int64_t val) {
@@ -28390,8 +28451,8 @@ uint32_t  __attribute__((export_name("TS_UpdateFulfillHTLC_clone_ptr"))) TS_Upda
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateFulfillHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateFulfillHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateFulfillHTLC_clone"))) TS_UpdateFulfillHTLC_clone(uint32_t orig) {
@@ -28445,8 +28506,8 @@ int64_t  __attribute__((export_name("TS_UpdateFailHTLC_get_htlc_id"))) TS_Update
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFailHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFailHTLC_set_htlc_id"))) TS_UpdateFailHTLC_set_htlc_id(uint32_t this_ptr, int64_t val) {
@@ -28474,8 +28535,8 @@ uint32_t  __attribute__((export_name("TS_UpdateFailHTLC_clone_ptr"))) TS_UpdateF
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateFailHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateFailHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateFailHTLC_clone"))) TS_UpdateFailHTLC_clone(uint32_t orig) {
@@ -28529,8 +28590,8 @@ int64_t  __attribute__((export_name("TS_UpdateFailMalformedHTLC_get_htlc_id"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UpdateFailMalformedHTLC_get_htlc_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UpdateFailMalformedHTLC_get_htlc_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFailMalformedHTLC_set_htlc_id"))) TS_UpdateFailMalformedHTLC_set_htlc_id(uint32_t this_ptr, int64_t val) {
@@ -28546,8 +28607,8 @@ int16_t  __attribute__((export_name("TS_UpdateFailMalformedHTLC_get_failure_code
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = UpdateFailMalformedHTLC_get_failure_code(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = UpdateFailMalformedHTLC_get_failure_code(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFailMalformedHTLC_set_failure_code"))) TS_UpdateFailMalformedHTLC_set_failure_code(uint32_t this_ptr, int16_t val) {
@@ -28575,8 +28636,8 @@ uint32_t  __attribute__((export_name("TS_UpdateFailMalformedHTLC_clone_ptr"))) T
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateFailMalformedHTLC_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateFailMalformedHTLC_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateFailMalformedHTLC_clone"))) TS_UpdateFailMalformedHTLC_clone(uint32_t orig) {
@@ -28718,8 +28779,8 @@ uint32_t  __attribute__((export_name("TS_CommitmentSigned_clone_ptr"))) TS_Commi
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CommitmentSigned_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CommitmentSigned_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CommitmentSigned_clone"))) TS_CommitmentSigned_clone(uint32_t orig) {
@@ -28849,8 +28910,8 @@ uint32_t  __attribute__((export_name("TS_RevokeAndACK_clone_ptr"))) TS_RevokeAnd
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RevokeAndACK_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RevokeAndACK_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RevokeAndACK_clone"))) TS_RevokeAndACK_clone(uint32_t orig) {
@@ -28904,8 +28965,8 @@ int32_t  __attribute__((export_name("TS_UpdateFee_get_feerate_per_kw"))) TS_Upda
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UpdateFee_get_feerate_per_kw(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UpdateFee_get_feerate_per_kw(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UpdateFee_set_feerate_per_kw"))) TS_UpdateFee_set_feerate_per_kw(uint32_t this_ptr, int32_t val) {
@@ -28949,8 +29010,8 @@ uint32_t  __attribute__((export_name("TS_UpdateFee_clone_ptr"))) TS_UpdateFee_cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UpdateFee_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UpdateFee_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UpdateFee_clone"))) TS_UpdateFee_clone(uint32_t orig) {
@@ -29056,8 +29117,8 @@ uint32_t  __attribute__((export_name("TS_DataLossProtect_clone_ptr"))) TS_DataLo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = DataLossProtect_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = DataLossProtect_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DataLossProtect_clone"))) TS_DataLossProtect_clone(uint32_t orig) {
@@ -29111,8 +29172,8 @@ int64_t  __attribute__((export_name("TS_ChannelReestablish_get_next_local_commit
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelReestablish_get_next_local_commitment_number(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_get_next_local_commitment_number(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelReestablish_set_next_local_commitment_number"))) TS_ChannelReestablish_set_next_local_commitment_number(uint32_t this_ptr, int64_t val) {
@@ -29128,8 +29189,8 @@ int64_t  __attribute__((export_name("TS_ChannelReestablish_get_next_remote_commi
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelReestablish_get_next_remote_commitment_number(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelReestablish_get_next_remote_commitment_number(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelReestablish_set_next_remote_commitment_number"))) TS_ChannelReestablish_set_next_remote_commitment_number(uint32_t this_ptr, int64_t val) {
@@ -29157,8 +29218,8 @@ uint32_t  __attribute__((export_name("TS_ChannelReestablish_clone_ptr"))) TS_Cha
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelReestablish_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelReestablish_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelReestablish_clone"))) TS_ChannelReestablish_clone(uint32_t orig) {
@@ -29212,8 +29273,8 @@ int64_t  __attribute__((export_name("TS_AnnouncementSignatures_get_short_channel
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = AnnouncementSignatures_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = AnnouncementSignatures_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_AnnouncementSignatures_set_short_channel_id"))) TS_AnnouncementSignatures_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -29305,8 +29366,8 @@ uint32_t  __attribute__((export_name("TS_AnnouncementSignatures_clone_ptr"))) TS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = AnnouncementSignatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = AnnouncementSignatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_AnnouncementSignatures_clone"))) TS_AnnouncementSignatures_clone(uint32_t orig) {
@@ -29343,8 +29404,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_NetAddress_clone_ptr"))) TS_NetAddress_clone_ptr(uint32_t arg) {
 	LDKNetAddress* arg_conv = (LDKNetAddress*)arg;
-	uint32_t ret_val = NetAddress_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NetAddress_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NetAddress_clone"))) TS_NetAddress_clone(uint32_t orig) {
@@ -29456,8 +29517,8 @@ int32_t  __attribute__((export_name("TS_UnsignedNodeAnnouncement_get_timestamp")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedNodeAnnouncement_get_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedNodeAnnouncement_get_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedNodeAnnouncement_set_timestamp"))) TS_UnsignedNodeAnnouncement_set_timestamp(uint32_t this_ptr, int32_t val) {
@@ -29571,8 +29632,8 @@ uint32_t  __attribute__((export_name("TS_UnsignedNodeAnnouncement_clone_ptr"))) 
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UnsignedNodeAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UnsignedNodeAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UnsignedNodeAnnouncement_clone"))) TS_UnsignedNodeAnnouncement_clone(uint32_t orig) {
@@ -29689,8 +29750,8 @@ uint32_t  __attribute__((export_name("TS_NodeAnnouncement_clone_ptr"))) TS_NodeA
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeAnnouncement_clone"))) TS_NodeAnnouncement_clone(uint32_t orig) {
@@ -29774,8 +29835,8 @@ int64_t  __attribute__((export_name("TS_UnsignedChannelAnnouncement_get_short_ch
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelAnnouncement_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelAnnouncement_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelAnnouncement_set_short_channel_id"))) TS_UnsignedChannelAnnouncement_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -29887,8 +29948,8 @@ uint32_t  __attribute__((export_name("TS_UnsignedChannelAnnouncement_clone_ptr")
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UnsignedChannelAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UnsignedChannelAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UnsignedChannelAnnouncement_clone"))) TS_UnsignedChannelAnnouncement_clone(uint32_t orig) {
@@ -30077,8 +30138,8 @@ uint32_t  __attribute__((export_name("TS_ChannelAnnouncement_clone_ptr"))) TS_Ch
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelAnnouncement_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelAnnouncement_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelAnnouncement_clone"))) TS_ChannelAnnouncement_clone(uint32_t orig) {
@@ -30132,8 +30193,8 @@ int64_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_short_channel_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelUpdate_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_short_channel_id"))) TS_UnsignedChannelUpdate_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -30149,8 +30210,8 @@ int32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_timestamp"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_timestamp"))) TS_UnsignedChannelUpdate_set_timestamp(uint32_t this_ptr, int32_t val) {
@@ -30166,8 +30227,8 @@ int8_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_flags"))) TS_Un
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int8_t ret_val = UnsignedChannelUpdate_get_flags(&this_ptr_conv);
-	return ret_val;
+	int8_t ret_conv = UnsignedChannelUpdate_get_flags(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_flags"))) TS_UnsignedChannelUpdate_set_flags(uint32_t this_ptr, int8_t val) {
@@ -30183,8 +30244,8 @@ int16_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_cltv_expiry_de
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = UnsignedChannelUpdate_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = UnsignedChannelUpdate_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_cltv_expiry_delta"))) TS_UnsignedChannelUpdate_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -30200,8 +30261,8 @@ int64_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_htlc_minimum_m
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = UnsignedChannelUpdate_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = UnsignedChannelUpdate_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_htlc_minimum_msat"))) TS_UnsignedChannelUpdate_set_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -30217,8 +30278,8 @@ int32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_fee_base_msat"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_fee_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_fee_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_fee_base_msat"))) TS_UnsignedChannelUpdate_set_fee_base_msat(uint32_t this_ptr, int32_t val) {
@@ -30234,8 +30295,8 @@ int32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_get_fee_proportion
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = UnsignedChannelUpdate_get_fee_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = UnsignedChannelUpdate_get_fee_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_UnsignedChannelUpdate_set_fee_proportional_millionths"))) TS_UnsignedChannelUpdate_set_fee_proportional_millionths(uint32_t this_ptr, int32_t val) {
@@ -30263,8 +30324,8 @@ uint32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = UnsignedChannelUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = UnsignedChannelUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_UnsignedChannelUpdate_clone"))) TS_UnsignedChannelUpdate_clone(uint32_t orig) {
@@ -30381,8 +30442,8 @@ uint32_t  __attribute__((export_name("TS_ChannelUpdate_clone_ptr"))) TS_ChannelU
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelUpdate_clone"))) TS_ChannelUpdate_clone(uint32_t orig) {
@@ -30436,8 +30497,8 @@ int32_t  __attribute__((export_name("TS_QueryChannelRange_get_first_blocknum")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = QueryChannelRange_get_first_blocknum(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_get_first_blocknum(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_QueryChannelRange_set_first_blocknum"))) TS_QueryChannelRange_set_first_blocknum(uint32_t this_ptr, int32_t val) {
@@ -30453,8 +30514,8 @@ int32_t  __attribute__((export_name("TS_QueryChannelRange_get_number_of_blocks")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = QueryChannelRange_get_number_of_blocks(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_get_number_of_blocks(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_QueryChannelRange_set_number_of_blocks"))) TS_QueryChannelRange_set_number_of_blocks(uint32_t this_ptr, int32_t val) {
@@ -30498,8 +30559,8 @@ uint32_t  __attribute__((export_name("TS_QueryChannelRange_clone_ptr"))) TS_Quer
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = QueryChannelRange_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = QueryChannelRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_QueryChannelRange_clone"))) TS_QueryChannelRange_clone(uint32_t orig) {
@@ -30553,8 +30614,8 @@ int32_t  __attribute__((export_name("TS_ReplyChannelRange_get_first_blocknum")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ReplyChannelRange_get_first_blocknum(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ReplyChannelRange_get_first_blocknum(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ReplyChannelRange_set_first_blocknum"))) TS_ReplyChannelRange_set_first_blocknum(uint32_t this_ptr, int32_t val) {
@@ -30570,8 +30631,8 @@ int32_t  __attribute__((export_name("TS_ReplyChannelRange_get_number_of_blocks")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ReplyChannelRange_get_number_of_blocks(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ReplyChannelRange_get_number_of_blocks(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ReplyChannelRange_set_number_of_blocks"))) TS_ReplyChannelRange_set_number_of_blocks(uint32_t this_ptr, int32_t val) {
@@ -30587,8 +30648,8 @@ jboolean  __attribute__((export_name("TS_ReplyChannelRange_get_sync_complete")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ReplyChannelRange_get_sync_complete(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ReplyChannelRange_get_sync_complete(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ReplyChannelRange_set_sync_complete"))) TS_ReplyChannelRange_set_sync_complete(uint32_t this_ptr, jboolean val) {
@@ -30662,8 +30723,8 @@ uint32_t  __attribute__((export_name("TS_ReplyChannelRange_clone_ptr"))) TS_Repl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ReplyChannelRange_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ReplyChannelRange_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ReplyChannelRange_clone"))) TS_ReplyChannelRange_clone(uint32_t orig) {
@@ -30775,8 +30836,8 @@ uint32_t  __attribute__((export_name("TS_QueryShortChannelIds_clone_ptr"))) TS_Q
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = QueryShortChannelIds_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = QueryShortChannelIds_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_QueryShortChannelIds_clone"))) TS_QueryShortChannelIds_clone(uint32_t orig) {
@@ -30830,8 +30891,8 @@ jboolean  __attribute__((export_name("TS_ReplyShortChannelIdsEnd_get_full_inform
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ReplyShortChannelIdsEnd_get_full_information(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ReplyShortChannelIdsEnd_get_full_information(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ReplyShortChannelIdsEnd_set_full_information"))) TS_ReplyShortChannelIdsEnd_set_full_information(uint32_t this_ptr, jboolean val) {
@@ -30875,8 +30936,8 @@ uint32_t  __attribute__((export_name("TS_ReplyShortChannelIdsEnd_clone_ptr"))) T
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ReplyShortChannelIdsEnd_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ReplyShortChannelIdsEnd_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ReplyShortChannelIdsEnd_clone"))) TS_ReplyShortChannelIdsEnd_clone(uint32_t orig) {
@@ -30930,8 +30991,8 @@ int32_t  __attribute__((export_name("TS_GossipTimestampFilter_get_first_timestam
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = GossipTimestampFilter_get_first_timestamp(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = GossipTimestampFilter_get_first_timestamp(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_GossipTimestampFilter_set_first_timestamp"))) TS_GossipTimestampFilter_set_first_timestamp(uint32_t this_ptr, int32_t val) {
@@ -30947,8 +31008,8 @@ int32_t  __attribute__((export_name("TS_GossipTimestampFilter_get_timestamp_rang
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = GossipTimestampFilter_get_timestamp_range(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = GossipTimestampFilter_get_timestamp_range(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_GossipTimestampFilter_set_timestamp_range"))) TS_GossipTimestampFilter_set_timestamp_range(uint32_t this_ptr, int32_t val) {
@@ -30992,8 +31053,8 @@ uint32_t  __attribute__((export_name("TS_GossipTimestampFilter_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = GossipTimestampFilter_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = GossipTimestampFilter_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_GossipTimestampFilter_clone"))) TS_GossipTimestampFilter_clone(uint32_t orig) {
@@ -31030,8 +31091,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_ErrorAction_clone_ptr"))) TS_ErrorAction_clone_ptr(uint32_t arg) {
 	LDKErrorAction* arg_conv = (LDKErrorAction*)arg;
-	uint32_t ret_val = ErrorAction_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ErrorAction_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ErrorAction_clone"))) TS_ErrorAction_clone(uint32_t orig) {
@@ -31187,8 +31248,8 @@ uint32_t  __attribute__((export_name("TS_LightningError_clone_ptr"))) TS_Lightni
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = LightningError_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = LightningError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_LightningError_clone"))) TS_LightningError_clone(uint32_t orig) {
@@ -31582,8 +31643,8 @@ uint32_t  __attribute__((export_name("TS_CommitmentUpdate_clone_ptr"))) TS_Commi
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CommitmentUpdate_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CommitmentUpdate_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CommitmentUpdate_clone"))) TS_CommitmentUpdate_clone(uint32_t orig) {
@@ -32256,8 +32317,8 @@ int32_t  __attribute__((export_name("TS_QueryChannelRange_end_blocknum"))) TS_Qu
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = QueryChannelRange_end_blocknum(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = QueryChannelRange_end_blocknum(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_QueryChannelRange_write"))) TS_QueryChannelRange_write(uint32_t obj) {
@@ -32528,8 +32589,8 @@ uint32_t  __attribute__((export_name("TS_SocketDescriptor_clone_ptr"))) TS_Socke
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKSocketDescriptor* arg_conv = (LDKSocketDescriptor*)arg_ptr;
-	uint32_t ret_val = SocketDescriptor_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = SocketDescriptor_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SocketDescriptor_clone"))) TS_SocketDescriptor_clone(uint32_t orig) {
@@ -32563,8 +32624,8 @@ jboolean  __attribute__((export_name("TS_PeerHandleError_get_no_connection_possi
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = PeerHandleError_get_no_connection_possible(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = PeerHandleError_get_no_connection_possible(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PeerHandleError_set_no_connection_possible"))) TS_PeerHandleError_set_no_connection_possible(uint32_t this_ptr, jboolean val) {
@@ -32605,8 +32666,8 @@ uint32_t  __attribute__((export_name("TS_PeerHandleError_clone_ptr"))) TS_PeerHa
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PeerHandleError_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PeerHandleError_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PeerHandleError_clone"))) TS_PeerHandleError_clone(uint32_t orig) {
@@ -32811,13 +32872,13 @@ void  __attribute__((export_name("TS_PeerManager_timer_tick_occurred"))) TS_Peer
 }
 
 int64_t  __attribute__((export_name("TS_htlc_success_tx_weight"))) TS_htlc_success_tx_weight(jboolean opt_anchors) {
-	int64_t ret_val = htlc_success_tx_weight(opt_anchors);
-	return ret_val;
+	int64_t ret_conv = htlc_success_tx_weight(opt_anchors);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_htlc_timeout_tx_weight"))) TS_htlc_timeout_tx_weight(jboolean opt_anchors) {
-	int64_t ret_val = htlc_timeout_tx_weight(opt_anchors);
-	return ret_val;
+	int64_t ret_conv = htlc_timeout_tx_weight(opt_anchors);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_build_commitment_secret"))) TS_build_commitment_secret(int8_tArray commitment_seed, int64_t idx) {
@@ -32876,8 +32937,8 @@ uint32_t  __attribute__((export_name("TS_CounterpartyCommitmentSecrets_clone_ptr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CounterpartyCommitmentSecrets_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CounterpartyCommitmentSecrets_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CounterpartyCommitmentSecrets_clone"))) TS_CounterpartyCommitmentSecrets_clone(uint32_t orig) {
@@ -32915,8 +32976,8 @@ int64_t  __attribute__((export_name("TS_CounterpartyCommitmentSecrets_get_min_se
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CounterpartyCommitmentSecrets_get_min_seen_secret(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CounterpartyCommitmentSecrets_get_min_seen_secret(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CounterpartyCommitmentSecrets_provide_secret"))) TS_CounterpartyCommitmentSecrets_provide_secret(uint32_t this_arg, int64_t idx, int8_tArray secret) {
@@ -33172,8 +33233,8 @@ uint32_t  __attribute__((export_name("TS_TxCreationKeys_clone_ptr"))) TS_TxCreat
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = TxCreationKeys_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = TxCreationKeys_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_TxCreationKeys_clone"))) TS_TxCreationKeys_clone(uint32_t orig) {
@@ -33372,8 +33433,8 @@ uint32_t  __attribute__((export_name("TS_ChannelPublicKeys_clone_ptr"))) TS_Chan
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelPublicKeys_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelPublicKeys_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelPublicKeys_clone"))) TS_ChannelPublicKeys_clone(uint32_t orig) {
@@ -33479,8 +33540,8 @@ jboolean  __attribute__((export_name("TS_HTLCOutputInCommitment_get_offered"))) 
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = HTLCOutputInCommitment_get_offered(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = HTLCOutputInCommitment_get_offered(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_HTLCOutputInCommitment_set_offered"))) TS_HTLCOutputInCommitment_set_offered(uint32_t this_ptr, jboolean val) {
@@ -33496,8 +33557,8 @@ int64_t  __attribute__((export_name("TS_HTLCOutputInCommitment_get_amount_msat")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = HTLCOutputInCommitment_get_amount_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = HTLCOutputInCommitment_get_amount_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_HTLCOutputInCommitment_set_amount_msat"))) TS_HTLCOutputInCommitment_set_amount_msat(uint32_t this_ptr, int64_t val) {
@@ -33513,8 +33574,8 @@ int32_t  __attribute__((export_name("TS_HTLCOutputInCommitment_get_cltv_expiry")
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = HTLCOutputInCommitment_get_cltv_expiry(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = HTLCOutputInCommitment_get_cltv_expiry(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_HTLCOutputInCommitment_set_cltv_expiry"))) TS_HTLCOutputInCommitment_set_cltv_expiry(uint32_t this_ptr, int32_t val) {
@@ -33606,8 +33667,8 @@ uint32_t  __attribute__((export_name("TS_HTLCOutputInCommitment_clone_ptr"))) TS
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = HTLCOutputInCommitment_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = HTLCOutputInCommitment_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_HTLCOutputInCommitment_clone"))) TS_HTLCOutputInCommitment_clone(uint32_t orig) {
@@ -33754,8 +33815,8 @@ int16_t  __attribute__((export_name("TS_ChannelTransactionParameters_get_holder_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelTransactionParameters_get_holder_selected_contest_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelTransactionParameters_get_holder_selected_contest_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelTransactionParameters_set_holder_selected_contest_delay"))) TS_ChannelTransactionParameters_set_holder_selected_contest_delay(uint32_t this_ptr, int16_t val) {
@@ -33771,8 +33832,8 @@ jboolean  __attribute__((export_name("TS_ChannelTransactionParameters_get_is_out
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelTransactionParameters_get_is_outbound_from_holder(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTransactionParameters_get_is_outbound_from_holder(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelTransactionParameters_set_is_outbound_from_holder"))) TS_ChannelTransactionParameters_set_is_outbound_from_holder(uint32_t this_ptr, jboolean val) {
@@ -33911,8 +33972,8 @@ uint32_t  __attribute__((export_name("TS_ChannelTransactionParameters_clone_ptr"
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelTransactionParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelTransactionParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelTransactionParameters_clone"))) TS_ChannelTransactionParameters_clone(uint32_t orig) {
@@ -33975,8 +34036,8 @@ int16_t  __attribute__((export_name("TS_CounterpartyChannelTransactionParameters
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = CounterpartyChannelTransactionParameters_get_selected_contest_delay(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = CounterpartyChannelTransactionParameters_get_selected_contest_delay(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CounterpartyChannelTransactionParameters_set_selected_contest_delay"))) TS_CounterpartyChannelTransactionParameters_set_selected_contest_delay(uint32_t this_ptr, int16_t val) {
@@ -34022,8 +34083,8 @@ uint32_t  __attribute__((export_name("TS_CounterpartyChannelTransactionParameter
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CounterpartyChannelTransactionParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CounterpartyChannelTransactionParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CounterpartyChannelTransactionParameters_clone"))) TS_CounterpartyChannelTransactionParameters_clone(uint32_t orig) {
@@ -34048,8 +34109,8 @@ jboolean  __attribute__((export_name("TS_ChannelTransactionParameters_is_populat
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelTransactionParameters_is_populated(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTransactionParameters_is_populated(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelTransactionParameters_as_holder_broadcastable"))) TS_ChannelTransactionParameters_as_holder_broadcastable(uint32_t this_arg) {
@@ -34175,8 +34236,8 @@ int16_t  __attribute__((export_name("TS_DirectedChannelTransactionParameters_con
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int16_t ret_val = DirectedChannelTransactionParameters_contest_delay(&this_arg_conv);
-	return ret_val;
+	int16_t ret_conv = DirectedChannelTransactionParameters_contest_delay(&this_arg_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_DirectedChannelTransactionParameters_is_outbound"))) TS_DirectedChannelTransactionParameters_is_outbound(uint32_t this_arg) {
@@ -34184,8 +34245,8 @@ jboolean  __attribute__((export_name("TS_DirectedChannelTransactionParameters_is
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = DirectedChannelTransactionParameters_is_outbound(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = DirectedChannelTransactionParameters_is_outbound(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DirectedChannelTransactionParameters_funding_outpoint"))) TS_DirectedChannelTransactionParameters_funding_outpoint(uint32_t this_arg) {
@@ -34210,8 +34271,8 @@ jboolean  __attribute__((export_name("TS_DirectedChannelTransactionParameters_op
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = DirectedChannelTransactionParameters_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = DirectedChannelTransactionParameters_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_HolderCommitmentTransaction_free"))) TS_HolderCommitmentTransaction_free(uint32_t this_obj) {
@@ -34282,8 +34343,8 @@ uint32_t  __attribute__((export_name("TS_HolderCommitmentTransaction_clone_ptr")
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = HolderCommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = HolderCommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_HolderCommitmentTransaction_clone"))) TS_HolderCommitmentTransaction_clone(uint32_t orig) {
@@ -34457,8 +34518,8 @@ uint32_t  __attribute__((export_name("TS_BuiltCommitmentTransaction_clone_ptr"))
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = BuiltCommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = BuiltCommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_BuiltCommitmentTransaction_clone"))) TS_BuiltCommitmentTransaction_clone(uint32_t orig) {
@@ -34554,8 +34615,8 @@ uint32_t  __attribute__((export_name("TS_ClosingTransaction_clone_ptr"))) TS_Clo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ClosingTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ClosingTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosingTransaction_clone"))) TS_ClosingTransaction_clone(uint32_t orig) {
@@ -34580,8 +34641,8 @@ int64_t  __attribute__((export_name("TS_ClosingTransaction_hash"))) TS_ClosingTr
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = ClosingTransaction_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_hash(&o_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ClosingTransaction_new"))) TS_ClosingTransaction_new(int64_t to_holder_value_sat, int64_t to_counterparty_value_sat, int8_tArray to_holder_script, int8_tArray to_counterparty_script, uint32_t funding_outpoint) {
@@ -34647,8 +34708,8 @@ int64_t  __attribute__((export_name("TS_ClosingTransaction_to_holder_value_sat")
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ClosingTransaction_to_holder_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_to_holder_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_ClosingTransaction_to_counterparty_value_sat"))) TS_ClosingTransaction_to_counterparty_value_sat(uint32_t this_arg) {
@@ -34656,8 +34717,8 @@ int64_t  __attribute__((export_name("TS_ClosingTransaction_to_counterparty_value
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ClosingTransaction_to_counterparty_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ClosingTransaction_to_counterparty_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_ClosingTransaction_to_holder_script"))) TS_ClosingTransaction_to_holder_script(uint32_t this_arg) {
@@ -34757,8 +34818,8 @@ uint32_t  __attribute__((export_name("TS_CommitmentTransaction_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = CommitmentTransaction_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = CommitmentTransaction_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CommitmentTransaction_clone"))) TS_CommitmentTransaction_clone(uint32_t orig) {
@@ -34804,8 +34865,8 @@ int64_t  __attribute__((export_name("TS_CommitmentTransaction_commitment_number"
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_commitment_number(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_commitment_number(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_CommitmentTransaction_to_broadcaster_value_sat"))) TS_CommitmentTransaction_to_broadcaster_value_sat(uint32_t this_arg) {
@@ -34813,8 +34874,8 @@ int64_t  __attribute__((export_name("TS_CommitmentTransaction_to_broadcaster_val
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_to_broadcaster_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_to_broadcaster_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_CommitmentTransaction_to_countersignatory_value_sat"))) TS_CommitmentTransaction_to_countersignatory_value_sat(uint32_t this_arg) {
@@ -34822,8 +34883,8 @@ int64_t  __attribute__((export_name("TS_CommitmentTransaction_to_countersignator
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = CommitmentTransaction_to_countersignatory_value_sat(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = CommitmentTransaction_to_countersignatory_value_sat(&this_arg_conv);
+	return ret_conv;
 }
 
 int32_t  __attribute__((export_name("TS_CommitmentTransaction_feerate_per_kw"))) TS_CommitmentTransaction_feerate_per_kw(uint32_t this_arg) {
@@ -34831,8 +34892,8 @@ int32_t  __attribute__((export_name("TS_CommitmentTransaction_feerate_per_kw")))
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int32_t ret_val = CommitmentTransaction_feerate_per_kw(&this_arg_conv);
-	return ret_val;
+	int32_t ret_conv = CommitmentTransaction_feerate_per_kw(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_CommitmentTransaction_trust"))) TS_CommitmentTransaction_trust(uint32_t this_arg) {
@@ -34931,8 +34992,8 @@ jboolean  __attribute__((export_name("TS_TrustedCommitmentTransaction_opt_anchor
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = TrustedCommitmentTransaction_opt_anchors(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = TrustedCommitmentTransaction_opt_anchors(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_TrustedCommitmentTransaction_get_htlc_sigs"))) TS_TrustedCommitmentTransaction_get_htlc_sigs(uint32_t this_arg, int8_tArray htlc_base_key, uint32_t channel_parameters) {
@@ -34960,8 +35021,8 @@ int64_t  __attribute__((export_name("TS_get_commitment_transaction_number_obscur
 	LDKPublicKey countersignatory_payment_basepoint_ref;
 	CHECK(countersignatory_payment_basepoint->arr_len == 33);
 	memcpy(countersignatory_payment_basepoint_ref.compressed_form, countersignatory_payment_basepoint->elems, 33); FREE(countersignatory_payment_basepoint);
-	int64_t ret_val = get_commitment_transaction_number_obscure_factor(broadcaster_payment_basepoint_ref, countersignatory_payment_basepoint_ref, outbound_from_broadcaster);
-	return ret_val;
+	int64_t ret_conv = get_commitment_transaction_number_obscure_factor(broadcaster_payment_basepoint_ref, countersignatory_payment_basepoint_ref, outbound_from_broadcaster);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_InitFeatures_eq"))) TS_InitFeatures_eq(uint32_t a, uint32_t b) {
@@ -34973,8 +35034,8 @@ jboolean  __attribute__((export_name("TS_InitFeatures_eq"))) TS_InitFeatures_eq(
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InitFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InitFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_NodeFeatures_eq"))) TS_NodeFeatures_eq(uint32_t a, uint32_t b) {
@@ -34986,8 +35047,8 @@ jboolean  __attribute__((export_name("TS_NodeFeatures_eq"))) TS_NodeFeatures_eq(
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = NodeFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = NodeFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_ChannelFeatures_eq"))) TS_ChannelFeatures_eq(uint32_t a, uint32_t b) {
@@ -34999,8 +35060,8 @@ jboolean  __attribute__((export_name("TS_ChannelFeatures_eq"))) TS_ChannelFeatur
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ChannelFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_InvoiceFeatures_eq"))) TS_InvoiceFeatures_eq(uint32_t a, uint32_t b) {
@@ -35012,8 +35073,8 @@ jboolean  __attribute__((export_name("TS_InvoiceFeatures_eq"))) TS_InvoiceFeatur
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InvoiceFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_ChannelTypeFeatures_eq"))) TS_ChannelTypeFeatures_eq(uint32_t a, uint32_t b) {
@@ -35025,8 +35086,8 @@ jboolean  __attribute__((export_name("TS_ChannelTypeFeatures_eq"))) TS_ChannelTy
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ChannelTypeFeatures_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTypeFeatures_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t InitFeatures_clone_ptr(LDKInitFeatures *NONNULL_PTR arg) {
@@ -35046,8 +35107,8 @@ uint32_t  __attribute__((export_name("TS_InitFeatures_clone_ptr"))) TS_InitFeatu
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InitFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InitFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InitFeatures_clone"))) TS_InitFeatures_clone(uint32_t orig) {
@@ -35084,8 +35145,8 @@ uint32_t  __attribute__((export_name("TS_NodeFeatures_clone_ptr"))) TS_NodeFeatu
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeFeatures_clone"))) TS_NodeFeatures_clone(uint32_t orig) {
@@ -35122,8 +35183,8 @@ uint32_t  __attribute__((export_name("TS_ChannelFeatures_clone_ptr"))) TS_Channe
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelFeatures_clone"))) TS_ChannelFeatures_clone(uint32_t orig) {
@@ -35160,8 +35221,8 @@ uint32_t  __attribute__((export_name("TS_InvoiceFeatures_clone_ptr"))) TS_Invoic
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InvoiceFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InvoiceFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InvoiceFeatures_clone"))) TS_InvoiceFeatures_clone(uint32_t orig) {
@@ -35198,8 +35259,8 @@ uint32_t  __attribute__((export_name("TS_ChannelTypeFeatures_clone_ptr"))) TS_Ch
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelTypeFeatures_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelTypeFeatures_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelTypeFeatures_clone"))) TS_ChannelTypeFeatures_clone(uint32_t orig) {
@@ -35290,8 +35351,8 @@ jboolean  __attribute__((export_name("TS_InitFeatures_requires_unknown_bits"))) 
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InitFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InitFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeFeatures_empty"))) TS_NodeFeatures_empty() {
@@ -35325,8 +35386,8 @@ jboolean  __attribute__((export_name("TS_NodeFeatures_requires_unknown_bits"))) 
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = NodeFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = NodeFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelFeatures_empty"))) TS_ChannelFeatures_empty() {
@@ -35360,8 +35421,8 @@ jboolean  __attribute__((export_name("TS_ChannelFeatures_requires_unknown_bits")
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InvoiceFeatures_empty"))) TS_InvoiceFeatures_empty() {
@@ -35395,8 +35456,8 @@ jboolean  __attribute__((export_name("TS_InvoiceFeatures_requires_unknown_bits")
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = InvoiceFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelTypeFeatures_empty"))) TS_ChannelTypeFeatures_empty() {
@@ -35430,8 +35491,8 @@ jboolean  __attribute__((export_name("TS_ChannelTypeFeatures_requires_unknown_bi
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = ChannelTypeFeatures_requires_unknown_bits(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelTypeFeatures_requires_unknown_bits(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_InitFeatures_write"))) TS_InitFeatures_write(uint32_t obj) {
@@ -35564,8 +35625,8 @@ uint32_t  __attribute__((export_name("TS_ShutdownScript_clone_ptr"))) TS_Shutdow
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ShutdownScript_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ShutdownScript_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ShutdownScript_clone"))) TS_ShutdownScript_clone(uint32_t orig) {
@@ -35650,8 +35711,8 @@ uint32_t  __attribute__((export_name("TS_InvalidShutdownScript_clone_ptr"))) TS_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InvalidShutdownScript_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InvalidShutdownScript_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InvalidShutdownScript_clone"))) TS_InvalidShutdownScript_clone(uint32_t orig) {
@@ -35767,8 +35828,8 @@ jboolean  __attribute__((export_name("TS_ShutdownScript_is_compatible"))) TS_Shu
 	features_conv.inner = (void*)(features & (~1));
 	features_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(features_conv);
-	jboolean ret_val = ShutdownScript_is_compatible(&this_arg_conv, &features_conv);
-	return ret_val;
+	jboolean ret_conv = ShutdownScript_is_compatible(&this_arg_conv, &features_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_CustomMessageReader_free"))) TS_CustomMessageReader_free(uint32_t this_ptr) {
@@ -35789,8 +35850,8 @@ uint32_t  __attribute__((export_name("TS_Type_clone_ptr"))) TS_Type_clone_ptr(ui
 	void* arg_ptr = (void*)(((uintptr_t)arg) & ~1);
 	if (!(arg & 1)) { CHECK_ACCESS(arg_ptr); }
 	LDKType* arg_conv = (LDKType*)arg_ptr;
-	uint32_t ret_val = Type_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Type_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Type_clone"))) TS_Type_clone(uint32_t orig) {
@@ -35836,8 +35897,8 @@ uint32_t  __attribute__((export_name("TS_NodeId_clone_ptr"))) TS_NodeId_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeId_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeId_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeId_clone"))) TS_NodeId_clone(uint32_t orig) {
@@ -35889,8 +35950,8 @@ int64_t  __attribute__((export_name("TS_NodeId_hash"))) TS_NodeId_hash(uint32_t 
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = NodeId_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = NodeId_hash(&o_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_NodeId_write"))) TS_NodeId_write(uint32_t obj) {
@@ -35939,8 +36000,8 @@ uint32_t  __attribute__((export_name("TS_NetworkGraph_clone_ptr"))) TS_NetworkGr
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NetworkGraph_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NetworkGraph_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NetworkGraph_clone"))) TS_NetworkGraph_clone(uint32_t orig) {
@@ -35985,8 +36046,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_NetworkUpdate_clone_ptr"))) TS_NetworkUpdate_clone_ptr(uint32_t arg) {
 	LDKNetworkUpdate* arg_conv = (LDKNetworkUpdate*)arg;
-	uint32_t ret_val = NetworkUpdate_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NetworkUpdate_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NetworkUpdate_clone"))) TS_NetworkUpdate_clone(uint32_t orig) {
@@ -36149,8 +36210,8 @@ int32_t  __attribute__((export_name("TS_ChannelUpdateInfo_get_last_update"))) TS
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = ChannelUpdateInfo_get_last_update(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = ChannelUpdateInfo_get_last_update(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelUpdateInfo_set_last_update"))) TS_ChannelUpdateInfo_set_last_update(uint32_t this_ptr, int32_t val) {
@@ -36166,8 +36227,8 @@ jboolean  __attribute__((export_name("TS_ChannelUpdateInfo_get_enabled"))) TS_Ch
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	jboolean ret_val = ChannelUpdateInfo_get_enabled(&this_ptr_conv);
-	return ret_val;
+	jboolean ret_conv = ChannelUpdateInfo_get_enabled(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelUpdateInfo_set_enabled"))) TS_ChannelUpdateInfo_set_enabled(uint32_t this_ptr, jboolean val) {
@@ -36183,8 +36244,8 @@ int16_t  __attribute__((export_name("TS_ChannelUpdateInfo_get_cltv_expiry_delta"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ChannelUpdateInfo_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ChannelUpdateInfo_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelUpdateInfo_set_cltv_expiry_delta"))) TS_ChannelUpdateInfo_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -36200,8 +36261,8 @@ int64_t  __attribute__((export_name("TS_ChannelUpdateInfo_get_htlc_minimum_msat"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ChannelUpdateInfo_get_htlc_minimum_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ChannelUpdateInfo_get_htlc_minimum_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ChannelUpdateInfo_set_htlc_minimum_msat"))) TS_ChannelUpdateInfo_set_htlc_minimum_msat(uint32_t this_ptr, int64_t val) {
@@ -36341,8 +36402,8 @@ uint32_t  __attribute__((export_name("TS_ChannelUpdateInfo_clone_ptr"))) TS_Chan
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelUpdateInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelUpdateInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelUpdateInfo_clone"))) TS_ChannelUpdateInfo_clone(uint32_t orig) {
@@ -36617,8 +36678,8 @@ uint32_t  __attribute__((export_name("TS_ChannelInfo_clone_ptr"))) TS_ChannelInf
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ChannelInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ChannelInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ChannelInfo_clone"))) TS_ChannelInfo_clone(uint32_t orig) {
@@ -36684,8 +36745,8 @@ uint32_t  __attribute__((export_name("TS_DirectedChannelInfo_clone_ptr"))) TS_Di
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = DirectedChannelInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = DirectedChannelInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_DirectedChannelInfo_clone"))) TS_DirectedChannelInfo_clone(uint32_t orig) {
@@ -36769,8 +36830,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_EffectiveCapacity_clone_ptr"))) TS_EffectiveCapacity_clone_ptr(uint32_t arg) {
 	LDKEffectiveCapacity* arg_conv = (LDKEffectiveCapacity*)arg;
-	uint32_t ret_val = EffectiveCapacity_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = EffectiveCapacity_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_EffectiveCapacity_clone"))) TS_EffectiveCapacity_clone(uint32_t orig) {
@@ -36818,8 +36879,8 @@ uint32_t  __attribute__((export_name("TS_EffectiveCapacity_unknown"))) TS_Effect
 
 int64_t  __attribute__((export_name("TS_EffectiveCapacity_as_msat"))) TS_EffectiveCapacity_as_msat(uint32_t this_arg) {
 	LDKEffectiveCapacity* this_arg_conv = (LDKEffectiveCapacity*)this_arg;
-	int64_t ret_val = EffectiveCapacity_as_msat(this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = EffectiveCapacity_as_msat(this_arg_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RoutingFees_free"))) TS_RoutingFees_free(uint32_t this_obj) {
@@ -36835,8 +36896,8 @@ int32_t  __attribute__((export_name("TS_RoutingFees_get_base_msat"))) TS_Routing
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RoutingFees_get_base_msat(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RoutingFees_get_base_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RoutingFees_set_base_msat"))) TS_RoutingFees_set_base_msat(uint32_t this_ptr, int32_t val) {
@@ -36852,8 +36913,8 @@ int32_t  __attribute__((export_name("TS_RoutingFees_get_proportional_millionths"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RoutingFees_get_proportional_millionths(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RoutingFees_get_proportional_millionths(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RoutingFees_set_proportional_millionths"))) TS_RoutingFees_set_proportional_millionths(uint32_t this_ptr, int32_t val) {
@@ -36886,8 +36947,8 @@ jboolean  __attribute__((export_name("TS_RoutingFees_eq"))) TS_RoutingFees_eq(ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RoutingFees_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RoutingFees_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RoutingFees_clone_ptr(LDKRoutingFees *NONNULL_PTR arg) {
@@ -36907,8 +36968,8 @@ uint32_t  __attribute__((export_name("TS_RoutingFees_clone_ptr"))) TS_RoutingFee
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RoutingFees_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RoutingFees_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RoutingFees_clone"))) TS_RoutingFees_clone(uint32_t orig) {
@@ -36933,8 +36994,8 @@ int64_t  __attribute__((export_name("TS_RoutingFees_hash"))) TS_RoutingFees_hash
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RoutingFees_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RoutingFees_hash(&o_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RoutingFees_write"))) TS_RoutingFees_write(uint32_t obj) {
@@ -37001,8 +37062,8 @@ int32_t  __attribute__((export_name("TS_NodeAnnouncementInfo_get_last_update")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = NodeAnnouncementInfo_get_last_update(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = NodeAnnouncementInfo_get_last_update(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_NodeAnnouncementInfo_set_last_update"))) TS_NodeAnnouncementInfo_set_last_update(uint32_t this_ptr, int32_t val) {
@@ -37170,8 +37231,8 @@ uint32_t  __attribute__((export_name("TS_NodeAnnouncementInfo_clone_ptr"))) TS_N
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeAnnouncementInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeAnnouncementInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeAnnouncementInfo_clone"))) TS_NodeAnnouncementInfo_clone(uint32_t orig) {
@@ -37354,8 +37415,8 @@ uint32_t  __attribute__((export_name("TS_NodeInfo_clone_ptr"))) TS_NodeInfo_clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = NodeInfo_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = NodeInfo_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_NodeInfo_clone"))) TS_NodeInfo_clone(uint32_t orig) {
@@ -37661,8 +37722,8 @@ int64_t  __attribute__((export_name("TS_RouteHop_get_short_channel_id"))) TS_Rou
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHop_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHop_set_short_channel_id"))) TS_RouteHop_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -37708,8 +37769,8 @@ int64_t  __attribute__((export_name("TS_RouteHop_get_fee_msat"))) TS_RouteHop_ge
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHop_get_fee_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_get_fee_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHop_set_fee_msat"))) TS_RouteHop_set_fee_msat(uint32_t this_ptr, int64_t val) {
@@ -37725,8 +37786,8 @@ int32_t  __attribute__((export_name("TS_RouteHop_get_cltv_expiry_delta"))) TS_Ro
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RouteHop_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RouteHop_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHop_set_cltv_expiry_delta"))) TS_RouteHop_set_cltv_expiry_delta(uint32_t this_ptr, int32_t val) {
@@ -37780,8 +37841,8 @@ uint32_t  __attribute__((export_name("TS_RouteHop_clone_ptr"))) TS_RouteHop_clon
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RouteHop_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RouteHop_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RouteHop_clone"))) TS_RouteHop_clone(uint32_t orig) {
@@ -37806,8 +37867,8 @@ int64_t  __attribute__((export_name("TS_RouteHop_hash"))) TS_RouteHop_hash(uint3
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHop_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHop_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_RouteHop_eq"))) TS_RouteHop_eq(uint32_t a, uint32_t b) {
@@ -37819,8 +37880,8 @@ jboolean  __attribute__((export_name("TS_RouteHop_eq"))) TS_RouteHop_eq(uint32_t
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHop_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHop_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RouteHop_write"))) TS_RouteHop_write(uint32_t obj) {
@@ -38016,8 +38077,8 @@ uint32_t  __attribute__((export_name("TS_Route_clone_ptr"))) TS_Route_clone_ptr(
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Route_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Route_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Route_clone"))) TS_Route_clone(uint32_t orig) {
@@ -38042,8 +38103,8 @@ int64_t  __attribute__((export_name("TS_Route_hash"))) TS_Route_hash(uint32_t o)
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Route_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Route_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Route_eq"))) TS_Route_eq(uint32_t a, uint32_t b) {
@@ -38055,8 +38116,8 @@ jboolean  __attribute__((export_name("TS_Route_eq"))) TS_Route_eq(uint32_t a, ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Route_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Route_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_Route_get_total_fees"))) TS_Route_get_total_fees(uint32_t this_arg) {
@@ -38064,8 +38125,8 @@ int64_t  __attribute__((export_name("TS_Route_get_total_fees"))) TS_Route_get_to
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Route_get_total_fees(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_get_total_fees(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_Route_get_total_amount"))) TS_Route_get_total_amount(uint32_t this_arg) {
@@ -38073,8 +38134,8 @@ int64_t  __attribute__((export_name("TS_Route_get_total_amount"))) TS_Route_get_
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Route_get_total_amount(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Route_get_total_amount(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_Route_write"))) TS_Route_write(uint32_t obj) {
@@ -38141,8 +38202,8 @@ int64_t  __attribute__((export_name("TS_RouteParameters_get_final_value_msat")))
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteParameters_get_final_value_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteParameters_get_final_value_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteParameters_set_final_value_msat"))) TS_RouteParameters_set_final_value_msat(uint32_t this_ptr, int64_t val) {
@@ -38158,8 +38219,8 @@ int32_t  __attribute__((export_name("TS_RouteParameters_get_final_cltv_expiry_de
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = RouteParameters_get_final_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = RouteParameters_get_final_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteParameters_set_final_cltv_expiry_delta"))) TS_RouteParameters_set_final_cltv_expiry_delta(uint32_t this_ptr, int32_t val) {
@@ -38205,8 +38266,8 @@ uint32_t  __attribute__((export_name("TS_RouteParameters_clone_ptr"))) TS_RouteP
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RouteParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RouteParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RouteParameters_clone"))) TS_RouteParameters_clone(uint32_t orig) {
@@ -38386,8 +38447,8 @@ int32_t  __attribute__((export_name("TS_PaymentParameters_get_max_total_cltv_exp
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int32_t ret_val = PaymentParameters_get_max_total_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int32_t ret_conv = PaymentParameters_get_max_total_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PaymentParameters_set_max_total_cltv_expiry_delta"))) TS_PaymentParameters_set_max_total_cltv_expiry_delta(uint32_t this_ptr, int32_t val) {
@@ -38456,8 +38517,8 @@ uint32_t  __attribute__((export_name("TS_PaymentParameters_clone_ptr"))) TS_Paym
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PaymentParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PaymentParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PaymentParameters_clone"))) TS_PaymentParameters_clone(uint32_t orig) {
@@ -38482,8 +38543,8 @@ int64_t  __attribute__((export_name("TS_PaymentParameters_hash"))) TS_PaymentPar
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PaymentParameters_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PaymentParameters_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_PaymentParameters_eq"))) TS_PaymentParameters_eq(uint32_t a, uint32_t b) {
@@ -38495,8 +38556,8 @@ jboolean  __attribute__((export_name("TS_PaymentParameters_eq"))) TS_PaymentPara
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PaymentParameters_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PaymentParameters_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_PaymentParameters_write"))) TS_PaymentParameters_write(uint32_t obj) {
@@ -38656,8 +38717,8 @@ uint32_t  __attribute__((export_name("TS_RouteHint_clone_ptr"))) TS_RouteHint_cl
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RouteHint_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RouteHint_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RouteHint_clone"))) TS_RouteHint_clone(uint32_t orig) {
@@ -38682,8 +38743,8 @@ int64_t  __attribute__((export_name("TS_RouteHint_hash"))) TS_RouteHint_hash(uin
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHint_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHint_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_RouteHint_eq"))) TS_RouteHint_eq(uint32_t a, uint32_t b) {
@@ -38695,8 +38756,8 @@ jboolean  __attribute__((export_name("TS_RouteHint_eq"))) TS_RouteHint_eq(uint32
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHint_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHint_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RouteHint_write"))) TS_RouteHint_write(uint32_t obj) {
@@ -38754,8 +38815,8 @@ int64_t  __attribute__((export_name("TS_RouteHintHop_get_short_channel_id"))) TS
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = RouteHintHop_get_short_channel_id(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_get_short_channel_id(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHintHop_set_short_channel_id"))) TS_RouteHintHop_set_short_channel_id(uint32_t this_ptr, int64_t val) {
@@ -38801,8 +38862,8 @@ int16_t  __attribute__((export_name("TS_RouteHintHop_get_cltv_expiry_delta"))) T
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = RouteHintHop_get_cltv_expiry_delta(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = RouteHintHop_get_cltv_expiry_delta(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RouteHintHop_set_cltv_expiry_delta"))) TS_RouteHintHop_set_cltv_expiry_delta(uint32_t this_ptr, int16_t val) {
@@ -38905,8 +38966,8 @@ uint32_t  __attribute__((export_name("TS_RouteHintHop_clone_ptr"))) TS_RouteHint
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RouteHintHop_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RouteHintHop_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RouteHintHop_clone"))) TS_RouteHintHop_clone(uint32_t orig) {
@@ -38931,8 +38992,8 @@ int64_t  __attribute__((export_name("TS_RouteHintHop_hash"))) TS_RouteHintHop_ha
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RouteHintHop_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RouteHintHop_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_RouteHintHop_eq"))) TS_RouteHintHop_eq(uint32_t a, uint32_t b) {
@@ -38944,8 +39005,8 @@ jboolean  __attribute__((export_name("TS_RouteHintHop_eq"))) TS_RouteHintHop_eq(
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RouteHintHop_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RouteHintHop_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RouteHintHop_write"))) TS_RouteHintHop_write(uint32_t obj) {
@@ -39091,8 +39152,8 @@ uint32_t  __attribute__((export_name("TS_FixedPenaltyScorer_clone_ptr"))) TS_Fix
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = FixedPenaltyScorer_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = FixedPenaltyScorer_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_FixedPenaltyScorer_clone"))) TS_FixedPenaltyScorer_clone(uint32_t orig) {
@@ -39177,8 +39238,8 @@ int64_t  __attribute__((export_name("TS_ScoringParameters_get_base_penalty_msat"
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_base_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_base_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_base_penalty_msat"))) TS_ScoringParameters_set_base_penalty_msat(uint32_t this_ptr, int64_t val) {
@@ -39194,8 +39255,8 @@ int64_t  __attribute__((export_name("TS_ScoringParameters_get_failure_penalty_ms
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_failure_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_failure_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_failure_penalty_msat"))) TS_ScoringParameters_set_failure_penalty_msat(uint32_t this_ptr, int64_t val) {
@@ -39211,8 +39272,8 @@ int16_t  __attribute__((export_name("TS_ScoringParameters_get_overuse_penalty_st
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int16_t ret_val = ScoringParameters_get_overuse_penalty_start_1024th(&this_ptr_conv);
-	return ret_val;
+	int16_t ret_conv = ScoringParameters_get_overuse_penalty_start_1024th(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_overuse_penalty_start_1024th"))) TS_ScoringParameters_set_overuse_penalty_start_1024th(uint32_t this_ptr, int16_t val) {
@@ -39228,8 +39289,8 @@ int64_t  __attribute__((export_name("TS_ScoringParameters_get_overuse_penalty_ms
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_overuse_penalty_msat_per_1024th(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_overuse_penalty_msat_per_1024th(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_overuse_penalty_msat_per_1024th"))) TS_ScoringParameters_set_overuse_penalty_msat_per_1024th(uint32_t this_ptr, int64_t val) {
@@ -39245,8 +39306,8 @@ int64_t  __attribute__((export_name("TS_ScoringParameters_get_failure_penalty_ha
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ScoringParameters_get_failure_penalty_half_life(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ScoringParameters_get_failure_penalty_half_life(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ScoringParameters_set_failure_penalty_half_life"))) TS_ScoringParameters_set_failure_penalty_half_life(uint32_t this_ptr, int64_t val) {
@@ -39287,8 +39348,8 @@ uint32_t  __attribute__((export_name("TS_ScoringParameters_clone_ptr"))) TS_Scor
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ScoringParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ScoringParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ScoringParameters_clone"))) TS_ScoringParameters_clone(uint32_t orig) {
@@ -39425,8 +39486,8 @@ int64_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_get_base_
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_base_penalty_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_base_penalty_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ProbabilisticScoringParameters_set_base_penalty_msat"))) TS_ProbabilisticScoringParameters_set_base_penalty_msat(uint32_t this_ptr, int64_t val) {
@@ -39442,8 +39503,8 @@ int64_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_get_liqui
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_liquidity_penalty_multiplier_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_liquidity_penalty_multiplier_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ProbabilisticScoringParameters_set_liquidity_penalty_multiplier_msat"))) TS_ProbabilisticScoringParameters_set_liquidity_penalty_multiplier_msat(uint32_t this_ptr, int64_t val) {
@@ -39459,8 +39520,8 @@ int64_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_get_liqui
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_liquidity_offset_half_life(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_liquidity_offset_half_life(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ProbabilisticScoringParameters_set_liquidity_offset_half_life"))) TS_ProbabilisticScoringParameters_set_liquidity_offset_half_life(uint32_t this_ptr, int64_t val) {
@@ -39476,8 +39537,8 @@ int64_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_get_amoun
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = ProbabilisticScoringParameters_get_amount_penalty_multiplier_msat(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = ProbabilisticScoringParameters_get_amount_penalty_multiplier_msat(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ProbabilisticScoringParameters_set_amount_penalty_multiplier_msat"))) TS_ProbabilisticScoringParameters_set_amount_penalty_multiplier_msat(uint32_t this_ptr, int64_t val) {
@@ -39518,8 +39579,8 @@ uint32_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ProbabilisticScoringParameters_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ProbabilisticScoringParameters_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ProbabilisticScoringParameters_clone"))) TS_ProbabilisticScoringParameters_clone(uint32_t orig) {
@@ -39631,8 +39692,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_ParseError_clone_ptr"))) TS_ParseError_clone_ptr(uint32_t arg) {
 	LDKParseError* arg_conv = (LDKParseError*)arg;
-	uint32_t ret_val = ParseError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ParseError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ParseError_clone"))) TS_ParseError_clone(uint32_t orig) {
@@ -39794,8 +39855,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_ParseOrSemanticError_clone_ptr"))) TS_ParseOrSemanticError_clone_ptr(uint32_t arg) {
 	LDKParseOrSemanticError* arg_conv = (LDKParseOrSemanticError*)arg;
-	uint32_t ret_val = ParseOrSemanticError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ParseOrSemanticError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ParseOrSemanticError_clone"))) TS_ParseOrSemanticError_clone(uint32_t orig) {
@@ -39842,8 +39903,8 @@ jboolean  __attribute__((export_name("TS_Invoice_eq"))) TS_Invoice_eq(uint32_t a
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Invoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Invoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t Invoice_clone_ptr(LDKInvoice *NONNULL_PTR arg) {
@@ -39863,8 +39924,8 @@ uint32_t  __attribute__((export_name("TS_Invoice_clone_ptr"))) TS_Invoice_clone_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Invoice_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Invoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Invoice_clone"))) TS_Invoice_clone(uint32_t orig) {
@@ -39901,8 +39962,8 @@ jboolean  __attribute__((export_name("TS_SignedRawInvoice_eq"))) TS_SignedRawInv
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = SignedRawInvoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = SignedRawInvoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t SignedRawInvoice_clone_ptr(LDKSignedRawInvoice *NONNULL_PTR arg) {
@@ -39922,8 +39983,8 @@ uint32_t  __attribute__((export_name("TS_SignedRawInvoice_clone_ptr"))) TS_Signe
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = SignedRawInvoice_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = SignedRawInvoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SignedRawInvoice_clone"))) TS_SignedRawInvoice_clone(uint32_t orig) {
@@ -39990,8 +40051,8 @@ jboolean  __attribute__((export_name("TS_RawInvoice_eq"))) TS_RawInvoice_eq(uint
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RawInvoice_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RawInvoice_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RawInvoice_clone_ptr(LDKRawInvoice *NONNULL_PTR arg) {
@@ -40011,8 +40072,8 @@ uint32_t  __attribute__((export_name("TS_RawInvoice_clone_ptr"))) TS_RawInvoice_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RawInvoice_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RawInvoice_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RawInvoice_clone"))) TS_RawInvoice_clone(uint32_t orig) {
@@ -40079,8 +40140,8 @@ jboolean  __attribute__((export_name("TS_RawDataPart_eq"))) TS_RawDataPart_eq(ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RawDataPart_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RawDataPart_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t RawDataPart_clone_ptr(LDKRawDataPart *NONNULL_PTR arg) {
@@ -40100,8 +40161,8 @@ uint32_t  __attribute__((export_name("TS_RawDataPart_clone_ptr"))) TS_RawDataPar
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RawDataPart_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RawDataPart_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RawDataPart_clone"))) TS_RawDataPart_clone(uint32_t orig) {
@@ -40138,8 +40199,8 @@ jboolean  __attribute__((export_name("TS_PositiveTimestamp_eq"))) TS_PositiveTim
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PositiveTimestamp_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PositiveTimestamp_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 static inline uintptr_t PositiveTimestamp_clone_ptr(LDKPositiveTimestamp *NONNULL_PTR arg) {
@@ -40159,8 +40220,8 @@ uint32_t  __attribute__((export_name("TS_PositiveTimestamp_clone_ptr"))) TS_Posi
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PositiveTimestamp_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PositiveTimestamp_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PositiveTimestamp_clone"))) TS_PositiveTimestamp_clone(uint32_t orig) {
@@ -40209,14 +40270,14 @@ uint32_t  __attribute__((export_name("TS_SiPrefix_pico"))) TS_SiPrefix_pico() {
 jboolean  __attribute__((export_name("TS_SiPrefix_eq"))) TS_SiPrefix_eq(uint32_t a, uint32_t b) {
 	LDKSiPrefix* a_conv = (LDKSiPrefix*)(a & ~1);
 	LDKSiPrefix* b_conv = (LDKSiPrefix*)(b & ~1);
-	jboolean ret_val = SiPrefix_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SiPrefix_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_SiPrefix_multiplier"))) TS_SiPrefix_multiplier(uint32_t this_arg) {
 	LDKSiPrefix* this_arg_conv = (LDKSiPrefix*)(this_arg & ~1);
-	int64_t ret_val = SiPrefix_multiplier(this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = SiPrefix_multiplier(this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Currency_clone"))) TS_Currency_clone(uint32_t orig) {
@@ -40252,15 +40313,15 @@ uint32_t  __attribute__((export_name("TS_Currency_signet"))) TS_Currency_signet(
 
 int64_t  __attribute__((export_name("TS_Currency_hash"))) TS_Currency_hash(uint32_t o) {
 	LDKCurrency* o_conv = (LDKCurrency*)(o & ~1);
-	int64_t ret_val = Currency_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Currency_hash(o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Currency_eq"))) TS_Currency_eq(uint32_t a, uint32_t b) {
 	LDKCurrency* a_conv = (LDKCurrency*)(a & ~1);
 	LDKCurrency* b_conv = (LDKCurrency*)(b & ~1);
-	jboolean ret_val = Currency_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Currency_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Sha256_free"))) TS_Sha256_free(uint32_t this_obj) {
@@ -40288,8 +40349,8 @@ uint32_t  __attribute__((export_name("TS_Sha256_clone_ptr"))) TS_Sha256_clone_pt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Sha256_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Sha256_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Sha256_clone"))) TS_Sha256_clone(uint32_t orig) {
@@ -40314,8 +40375,8 @@ int64_t  __attribute__((export_name("TS_Sha256_hash"))) TS_Sha256_hash(uint32_t 
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Sha256_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Sha256_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Sha256_eq"))) TS_Sha256_eq(uint32_t a, uint32_t b) {
@@ -40327,8 +40388,8 @@ jboolean  __attribute__((export_name("TS_Sha256_eq"))) TS_Sha256_eq(uint32_t a, 
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Sha256_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Sha256_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Description_free"))) TS_Description_free(uint32_t this_obj) {
@@ -40356,8 +40417,8 @@ uint32_t  __attribute__((export_name("TS_Description_clone_ptr"))) TS_Descriptio
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = Description_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Description_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Description_clone"))) TS_Description_clone(uint32_t orig) {
@@ -40382,8 +40443,8 @@ int64_t  __attribute__((export_name("TS_Description_hash"))) TS_Description_hash
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = Description_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = Description_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Description_eq"))) TS_Description_eq(uint32_t a, uint32_t b) {
@@ -40395,8 +40456,8 @@ jboolean  __attribute__((export_name("TS_Description_eq"))) TS_Description_eq(ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = Description_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = Description_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PayeePubKey_free"))) TS_PayeePubKey_free(uint32_t this_obj) {
@@ -40461,8 +40522,8 @@ uint32_t  __attribute__((export_name("TS_PayeePubKey_clone_ptr"))) TS_PayeePubKe
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PayeePubKey_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PayeePubKey_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PayeePubKey_clone"))) TS_PayeePubKey_clone(uint32_t orig) {
@@ -40487,8 +40548,8 @@ int64_t  __attribute__((export_name("TS_PayeePubKey_hash"))) TS_PayeePubKey_hash
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PayeePubKey_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PayeePubKey_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_PayeePubKey_eq"))) TS_PayeePubKey_eq(uint32_t a, uint32_t b) {
@@ -40500,8 +40561,8 @@ jboolean  __attribute__((export_name("TS_PayeePubKey_eq"))) TS_PayeePubKey_eq(ui
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PayeePubKey_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PayeePubKey_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_ExpiryTime_free"))) TS_ExpiryTime_free(uint32_t this_obj) {
@@ -40529,8 +40590,8 @@ uint32_t  __attribute__((export_name("TS_ExpiryTime_clone_ptr"))) TS_ExpiryTime_
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = ExpiryTime_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = ExpiryTime_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_ExpiryTime_clone"))) TS_ExpiryTime_clone(uint32_t orig) {
@@ -40555,8 +40616,8 @@ int64_t  __attribute__((export_name("TS_ExpiryTime_hash"))) TS_ExpiryTime_hash(u
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = ExpiryTime_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_ExpiryTime_eq"))) TS_ExpiryTime_eq(uint32_t a, uint32_t b) {
@@ -40568,8 +40629,8 @@ jboolean  __attribute__((export_name("TS_ExpiryTime_eq"))) TS_ExpiryTime_eq(uint
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = ExpiryTime_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = ExpiryTime_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_MinFinalCltvExpiry_free"))) TS_MinFinalCltvExpiry_free(uint32_t this_obj) {
@@ -40585,8 +40646,8 @@ int64_t  __attribute__((export_name("TS_MinFinalCltvExpiry_get_a"))) TS_MinFinal
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	int64_t ret_val = MinFinalCltvExpiry_get_a(&this_ptr_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_get_a(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_MinFinalCltvExpiry_set_a"))) TS_MinFinalCltvExpiry_set_a(uint32_t this_ptr, int64_t val) {
@@ -40627,8 +40688,8 @@ uint32_t  __attribute__((export_name("TS_MinFinalCltvExpiry_clone_ptr"))) TS_Min
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = MinFinalCltvExpiry_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = MinFinalCltvExpiry_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_MinFinalCltvExpiry_clone"))) TS_MinFinalCltvExpiry_clone(uint32_t orig) {
@@ -40653,8 +40714,8 @@ int64_t  __attribute__((export_name("TS_MinFinalCltvExpiry_hash"))) TS_MinFinalC
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = MinFinalCltvExpiry_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = MinFinalCltvExpiry_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_MinFinalCltvExpiry_eq"))) TS_MinFinalCltvExpiry_eq(uint32_t a, uint32_t b) {
@@ -40666,8 +40727,8 @@ jboolean  __attribute__((export_name("TS_MinFinalCltvExpiry_eq"))) TS_MinFinalCl
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = MinFinalCltvExpiry_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = MinFinalCltvExpiry_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_Fallback_free"))) TS_Fallback_free(uint32_t this_ptr) {
@@ -40687,8 +40748,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_Fallback_clone_ptr"))) TS_Fallback_clone_ptr(uint32_t arg) {
 	LDKFallback* arg_conv = (LDKFallback*)arg;
-	uint32_t ret_val = Fallback_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = Fallback_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Fallback_clone"))) TS_Fallback_clone(uint32_t orig) {
@@ -40733,15 +40794,15 @@ uint32_t  __attribute__((export_name("TS_Fallback_script_hash"))) TS_Fallback_sc
 
 int64_t  __attribute__((export_name("TS_Fallback_hash"))) TS_Fallback_hash(uint32_t o) {
 	LDKFallback* o_conv = (LDKFallback*)o;
-	int64_t ret_val = Fallback_hash(o_conv);
-	return ret_val;
+	int64_t ret_conv = Fallback_hash(o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Fallback_eq"))) TS_Fallback_eq(uint32_t a, uint32_t b) {
 	LDKFallback* a_conv = (LDKFallback*)a;
 	LDKFallback* b_conv = (LDKFallback*)b;
-	jboolean ret_val = Fallback_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = Fallback_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_InvoiceSignature_free"))) TS_InvoiceSignature_free(uint32_t this_obj) {
@@ -40769,8 +40830,8 @@ uint32_t  __attribute__((export_name("TS_InvoiceSignature_clone_ptr"))) TS_Invoi
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = InvoiceSignature_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = InvoiceSignature_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_InvoiceSignature_clone"))) TS_InvoiceSignature_clone(uint32_t orig) {
@@ -40799,8 +40860,8 @@ jboolean  __attribute__((export_name("TS_InvoiceSignature_eq"))) TS_InvoiceSigna
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = InvoiceSignature_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = InvoiceSignature_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PrivateRoute_free"))) TS_PrivateRoute_free(uint32_t this_obj) {
@@ -40828,8 +40889,8 @@ uint32_t  __attribute__((export_name("TS_PrivateRoute_clone_ptr"))) TS_PrivateRo
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = PrivateRoute_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PrivateRoute_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PrivateRoute_clone"))) TS_PrivateRoute_clone(uint32_t orig) {
@@ -40854,8 +40915,8 @@ int64_t  __attribute__((export_name("TS_PrivateRoute_hash"))) TS_PrivateRoute_ha
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = PrivateRoute_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = PrivateRoute_hash(&o_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_PrivateRoute_eq"))) TS_PrivateRoute_eq(uint32_t a, uint32_t b) {
@@ -40867,8 +40928,8 @@ jboolean  __attribute__((export_name("TS_PrivateRoute_eq"))) TS_PrivateRoute_eq(
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = PrivateRoute_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = PrivateRoute_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SignedRawInvoice_into_parts"))) TS_SignedRawInvoice_into_parts(uint32_t this_arg) {
@@ -40941,8 +41002,8 @@ jboolean  __attribute__((export_name("TS_SignedRawInvoice_check_signature"))) TS
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = SignedRawInvoice_check_signature(&this_arg_conv);
-	return ret_val;
+	jboolean ret_conv = SignedRawInvoice_check_signature(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_RawInvoice_hash"))) TS_RawInvoice_hash(uint32_t this_arg) {
@@ -41161,8 +41222,8 @@ int64_t  __attribute__((export_name("TS_PositiveTimestamp_as_unix_timestamp"))) 
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_unix_timestamp(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_unix_timestamp(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_PositiveTimestamp_as_duration_since_epoch"))) TS_PositiveTimestamp_as_duration_since_epoch(uint32_t this_arg) {
@@ -41170,8 +41231,8 @@ int64_t  __attribute__((export_name("TS_PositiveTimestamp_as_duration_since_epoc
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = PositiveTimestamp_as_duration_since_epoch(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = PositiveTimestamp_as_duration_since_epoch(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_Invoice_into_signed_raw"))) TS_Invoice_into_signed_raw(uint32_t this_arg) {
@@ -41218,8 +41279,8 @@ int64_t  __attribute__((export_name("TS_Invoice_duration_since_epoch"))) TS_Invo
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_duration_since_epoch(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_duration_since_epoch(&this_arg_conv);
+	return ret_conv;
 }
 
 int8_tArray  __attribute__((export_name("TS_Invoice_payment_hash"))) TS_Invoice_payment_hash(uint32_t this_arg) {
@@ -41286,8 +41347,8 @@ int64_t  __attribute__((export_name("TS_Invoice_expiry_time"))) TS_Invoice_expir
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_expiry_time(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_expiry_time(&this_arg_conv);
+	return ret_conv;
 }
 
 jboolean  __attribute__((export_name("TS_Invoice_would_expire"))) TS_Invoice_would_expire(uint32_t this_arg, int64_t at_time) {
@@ -41295,8 +41356,8 @@ jboolean  __attribute__((export_name("TS_Invoice_would_expire"))) TS_Invoice_wou
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	jboolean ret_val = Invoice_would_expire(&this_arg_conv, at_time);
-	return ret_val;
+	jboolean ret_conv = Invoice_would_expire(&this_arg_conv, at_time);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_Invoice_min_final_cltv_expiry"))) TS_Invoice_min_final_cltv_expiry(uint32_t this_arg) {
@@ -41304,8 +41365,8 @@ int64_t  __attribute__((export_name("TS_Invoice_min_final_cltv_expiry"))) TS_Inv
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = Invoice_min_final_cltv_expiry(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = Invoice_min_final_cltv_expiry(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_tArray  __attribute__((export_name("TS_Invoice_private_routes"))) TS_Invoice_private_routes(uint32_t this_arg) {
@@ -41430,8 +41491,8 @@ int64_t  __attribute__((export_name("TS_ExpiryTime_as_seconds"))) TS_ExpiryTime_
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ExpiryTime_as_seconds(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_as_seconds(&this_arg_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_ExpiryTime_as_duration"))) TS_ExpiryTime_as_duration(uint32_t this_arg) {
@@ -41439,8 +41500,8 @@ int64_t  __attribute__((export_name("TS_ExpiryTime_as_duration"))) TS_ExpiryTime
 	this_arg_conv.inner = (void*)(this_arg & (~1));
 	this_arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_arg_conv);
-	int64_t ret_val = ExpiryTime_as_duration(&this_arg_conv);
-	return ret_val;
+	int64_t ret_conv = ExpiryTime_as_duration(&this_arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PrivateRoute_new"))) TS_PrivateRoute_new(uint32_t hops) {
@@ -41506,8 +41567,8 @@ uint32_t  __attribute__((export_name("TS_CreationError_missing_route_hints"))) T
 jboolean  __attribute__((export_name("TS_CreationError_eq"))) TS_CreationError_eq(uint32_t a, uint32_t b) {
 	LDKCreationError* a_conv = (LDKCreationError*)(a & ~1);
 	LDKCreationError* b_conv = (LDKCreationError*)(b & ~1);
-	jboolean ret_val = CreationError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = CreationError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 jstring  __attribute__((export_name("TS_CreationError_to_str"))) TS_CreationError_to_str(uint32_t o) {
@@ -41577,8 +41638,8 @@ uint32_t  __attribute__((export_name("TS_SemanticError_imprecise_amount"))) TS_S
 jboolean  __attribute__((export_name("TS_SemanticError_eq"))) TS_SemanticError_eq(uint32_t a, uint32_t b) {
 	LDKSemanticError* a_conv = (LDKSemanticError*)(a & ~1);
 	LDKSemanticError* b_conv = (LDKSemanticError*)(b & ~1);
-	jboolean ret_val = SemanticError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SemanticError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 jstring  __attribute__((export_name("TS_SemanticError_to_str"))) TS_SemanticError_to_str(uint32_t o) {
@@ -41606,8 +41667,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_SignOrCreationError_clone_ptr"))) TS_SignOrCreationError_clone_ptr(uint32_t arg) {
 	LDKSignOrCreationError* arg_conv = (LDKSignOrCreationError*)arg;
-	uint32_t ret_val = SignOrCreationError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = SignOrCreationError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_SignOrCreationError_clone"))) TS_SignOrCreationError_clone(uint32_t orig) {
@@ -41636,8 +41697,8 @@ uint32_t  __attribute__((export_name("TS_SignOrCreationError_creation_error"))) 
 jboolean  __attribute__((export_name("TS_SignOrCreationError_eq"))) TS_SignOrCreationError_eq(uint32_t a, uint32_t b) {
 	LDKSignOrCreationError* a_conv = (LDKSignOrCreationError*)a;
 	LDKSignOrCreationError* b_conv = (LDKSignOrCreationError*)b;
-	jboolean ret_val = SignOrCreationError_eq(a_conv, b_conv);
-	return ret_val;
+	jboolean ret_conv = SignOrCreationError_eq(a_conv, b_conv);
+	return ret_conv;
 }
 
 jstring  __attribute__((export_name("TS_SignOrCreationError_to_str"))) TS_SignOrCreationError_to_str(uint32_t o) {
@@ -41687,8 +41748,8 @@ uint32_t  __attribute__((export_name("TS_RetryAttempts_get_a"))) TS_RetryAttempt
 	this_ptr_conv.inner = (void*)(this_ptr & (~1));
 	this_ptr_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(this_ptr_conv);
-	uint32_t ret_val = RetryAttempts_get_a(&this_ptr_conv);
-	return ret_val;
+	uint32_t ret_conv = RetryAttempts_get_a(&this_ptr_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_RetryAttempts_set_a"))) TS_RetryAttempts_set_a(uint32_t this_ptr, uint32_t val) {
@@ -41729,8 +41790,8 @@ uint32_t  __attribute__((export_name("TS_RetryAttempts_clone_ptr"))) TS_RetryAtt
 	arg_conv.inner = (void*)(arg & (~1));
 	arg_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(arg_conv);
-	uint32_t ret_val = RetryAttempts_clone_ptr(&arg_conv);
-	return ret_val;
+	uint32_t ret_conv = RetryAttempts_clone_ptr(&arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_RetryAttempts_clone"))) TS_RetryAttempts_clone(uint32_t orig) {
@@ -41759,8 +41820,8 @@ jboolean  __attribute__((export_name("TS_RetryAttempts_eq"))) TS_RetryAttempts_e
 	b_conv.inner = (void*)(b & (~1));
 	b_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(b_conv);
-	jboolean ret_val = RetryAttempts_eq(&a_conv, &b_conv);
-	return ret_val;
+	jboolean ret_conv = RetryAttempts_eq(&a_conv, &b_conv);
+	return ret_conv;
 }
 
 int64_t  __attribute__((export_name("TS_RetryAttempts_hash"))) TS_RetryAttempts_hash(uint32_t o) {
@@ -41768,8 +41829,8 @@ int64_t  __attribute__((export_name("TS_RetryAttempts_hash"))) TS_RetryAttempts_
 	o_conv.inner = (void*)(o & (~1));
 	o_conv.is_owned = false;
 	CHECK_INNER_FIELD_ACCESS_OR_NULL(o_conv);
-	int64_t ret_val = RetryAttempts_hash(&o_conv);
-	return ret_val;
+	int64_t ret_conv = RetryAttempts_hash(&o_conv);
+	return ret_conv;
 }
 
 void  __attribute__((export_name("TS_PaymentError_free"))) TS_PaymentError_free(uint32_t this_ptr) {
@@ -41789,8 +41850,8 @@ uint32_t ret_ref = (uintptr_t)ret_copy;
 }
 uint32_t  __attribute__((export_name("TS_PaymentError_clone_ptr"))) TS_PaymentError_clone_ptr(uint32_t arg) {
 	LDKPaymentError* arg_conv = (LDKPaymentError*)arg;
-	uint32_t ret_val = PaymentError_clone_ptr(arg_conv);
-	return ret_val;
+	uint32_t ret_conv = PaymentError_clone_ptr(arg_conv);
+	return ret_conv;
 }
 
 uint32_t  __attribute__((export_name("TS_PaymentError_clone"))) TS_PaymentError_clone(uint32_t orig) {


### PR DESCRIPTION
This resolves an issue where we map unsigned primitives to their
signed variants, and occasionally pass the unsigned variant (which
is outside the bounds of the signed variant) to the host language.

In Java this can cause a panic as the VM sees an int outside the
range of a short (for example with network ports).