### PR TITLE
[Java] Correct trivial race condition in HumanObjectPeerTest

### DIFF
--- a/src/test/java/org/ldk/HumanObjectPeerTest.java
+++ b/src/test/java/org/ldk/HumanObjectPeerTest.java
@@ -678,9 +678,6 @@ class HumanObjectPeerTestInstance {
 
     void maybe_exchange_peer_messages(Peer peer1, Peer peer2) {
         if (!use_nio_peer_handler) {
-            synchronized (runqueue) {
-                ran = false;
-            }
             while (true) {
                 peer1.peer_manager.process_events();
                 peer2.peer_manager.process_events();

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightningdevkit",
-  "version": "0.0.104.1alpha4",
+  "version": "0.0.106.0beta1",
   "description": "Lightning Development Kit",
   "main": "index.mjs",
   "types": "index.d.mts",


### PR DESCRIPTION
On my (very slow) old armv7 device, HumanObjectPeerTest can fail as
`maybe_exchange_peer_messages` will set `ran = false` *after* a
message is added to the runqueue, but before it runs, then when we
call `process_events` there will be no events to process, then
before we get into the `runqueue` `synchronized` block the message
will be delivered, causing us to think we're done, even though
there are now events pending. Because going around the loop twice
is free, we should just not set `ran` to false at the top of
`maybe_exchange_peer_messages`.