### PR TITLE
Specify Node version for Wasm BigInt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Some functions may error spuriously due to oversights or missing implementations
 
 The TypeScript bindings require modern web standards, including support for `FinalizationRegistry`
 and `WeakRef` (Chrome 84, Firefox 79, Safari 14.1/iOS 14.5 and Node 14.6) and WASM BigInt support
-(Chrome 85, Firefox 78, Safari 14.1/iOS 14.5, and Node ??).
+(Chrome 85, Firefox 78, Safari 14.1/iOS 14.5, and Node 15.0).
 
 ## General
 


### PR DESCRIPTION
From Node v15.0, Wasm BigInt support is no longer experimental

See: https://github.com/nodejs/node/commit/ca8f3ef2e5