### PR TITLE
Handle socket errors (the same as socket closure)

### DIFF
--- a/node-net/net.mts
+++ b/node-net/net.mts
@@ -82,6 +82,9 @@ export class NodeLDKNet {
 		socket.on("close", function() {
 			this_pm.socket_disconnected(descriptor);
 		});
+		socket.on("error", function() {
+			this_pm.socket_disconnected(descriptor);
+		});
 
 		return descriptor;
 	}


### PR DESCRIPTION
`gr0kchain` on Discord reported that not handling "error" causes
us to get unhandled exceptions, so we have to handle it.