### PR TITLE
[TS+Java] Ensure we don't try to add a reference from null.

### DIFF
--- a/java_strings.py
+++ b/java_strings.py
@@ -704,7 +704,7 @@ import javax.annotation.Nullable;
         return var + ".ptr" + " = 0;"
 
     def add_ref(self, holder, referent):
-        return holder + ".ptrs_to.add(" + referent + ")"
+        return "if (" + holder + " != null) { " + holder + ".ptrs_to.add(" + referent + "); }"
 
     def fully_qualified_hu_ty_path(self, ty):
         if ty.java_fn_ty_arg.startswith("L") and ty.java_fn_ty_arg.endswith(";"):

--- a/src/main/java/org/ldk/structs/APIError.java
+++ b/src/main/java/org/ldk/structs/APIError.java
@@ -134,7 +134,7 @@ public class APIError extends CommonBase {
 			super(null, ptr);
 			long script = obj.script;
 			org.ldk.structs.ShutdownScript script_hu_conv = null; if (script < 0 || script > 4096) { script_hu_conv = new org.ldk.structs.ShutdownScript(null, script); }
-			script_hu_conv.ptrs_to.add(this);
+			if (script_hu_conv != null) { script_hu_conv.ptrs_to.add(this); };
 			this.script = script_hu_conv;
 		}
 	}
@@ -152,7 +152,7 @@ public class APIError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.APIError ret_hu_conv = org.ldk.structs.APIError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -164,7 +164,7 @@ public class APIError extends CommonBase {
 		Reference.reachabilityFence(err);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.APIError ret_hu_conv = org.ldk.structs.APIError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -177,7 +177,7 @@ public class APIError extends CommonBase {
 		Reference.reachabilityFence(feerate);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.APIError ret_hu_conv = org.ldk.structs.APIError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -189,7 +189,7 @@ public class APIError extends CommonBase {
 		Reference.reachabilityFence(err);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.APIError ret_hu_conv = org.ldk.structs.APIError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -201,7 +201,7 @@ public class APIError extends CommonBase {
 		Reference.reachabilityFence(err);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.APIError ret_hu_conv = org.ldk.structs.APIError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -212,7 +212,7 @@ public class APIError extends CommonBase {
 		long ret = bindings.APIError_monitor_update_failed();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.APIError ret_hu_conv = org.ldk.structs.APIError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -224,8 +224,8 @@ public class APIError extends CommonBase {
 		Reference.reachabilityFence(script);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.APIError ret_hu_conv = org.ldk.structs.APIError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(script);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(script); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/AcceptChannel.java
+++ b/src/main/java/org/ldk/structs/AcceptChannel.java
@@ -287,7 +287,7 @@ public class AcceptChannel extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTypeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTypeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -304,7 +304,7 @@ public class AcceptChannel extends CommonBase {
 		bindings.AcceptChannel_set_channel_type(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	long clone_ptr() {
@@ -321,7 +321,7 @@ public class AcceptChannel extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.AcceptChannel ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.AcceptChannel(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/AnnouncementSignatures.java
+++ b/src/main/java/org/ldk/structs/AnnouncementSignatures.java
@@ -103,7 +103,7 @@ public class AnnouncementSignatures extends CommonBase {
 		Reference.reachabilityFence(bitcoin_signature_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.AnnouncementSignatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.AnnouncementSignatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -121,7 +121,7 @@ public class AnnouncementSignatures extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.AnnouncementSignatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.AnnouncementSignatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/BackgroundProcessor.java
+++ b/src/main/java/org/ldk/structs/BackgroundProcessor.java
@@ -104,14 +104,14 @@ public class BackgroundProcessor extends CommonBase {
 		Reference.reachabilityFence(scorer);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BackgroundProcessor ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BackgroundProcessor(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(persister);
-		ret_hu_conv.ptrs_to.add(event_handler);
-		ret_hu_conv.ptrs_to.add(chain_monitor);
-		ret_hu_conv.ptrs_to.add(channel_manager);
-		ret_hu_conv.ptrs_to.add(peer_manager);
-		ret_hu_conv.ptrs_to.add(logger);
-		ret_hu_conv.ptrs_to.add(scorer);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(persister); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(event_handler); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(chain_monitor); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channel_manager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(peer_manager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(scorer); };
 		return ret_hu_conv;
 	}
 
@@ -131,7 +131,7 @@ public class BackgroundProcessor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneErrorZ ret_hu_conv = Result_NoneErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(this);
+		if (this != null) { this.ptrs_to.add(this); };
 		// Due to rust's strict-ownership memory model, in some cases we need to "move"
 		// an object to pass exclusive ownership to the function being called.
 		// In most cases, we avoid this being visible in GC'd languages by cloning the object
@@ -159,7 +159,7 @@ public class BackgroundProcessor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneErrorZ ret_hu_conv = Result_NoneErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(this);
+		if (this != null) { this.ptrs_to.add(this); };
 		// Due to rust's strict-ownership memory model, in some cases we need to "move"
 		// an object to pass exclusive ownership to the function being called.
 		// In most cases, we avoid this being visible in GC'd languages by cloning the object

--- a/src/main/java/org/ldk/structs/Balance.java
+++ b/src/main/java/org/ldk/structs/Balance.java
@@ -138,7 +138,7 @@ public class Balance extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Balance ret_hu_conv = org.ldk.structs.Balance.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -150,7 +150,7 @@ public class Balance extends CommonBase {
 		Reference.reachabilityFence(claimable_amount_satoshis);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Balance ret_hu_conv = org.ldk.structs.Balance.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -163,7 +163,7 @@ public class Balance extends CommonBase {
 		Reference.reachabilityFence(confirmation_height);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Balance ret_hu_conv = org.ldk.structs.Balance.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -176,7 +176,7 @@ public class Balance extends CommonBase {
 		Reference.reachabilityFence(timeout_height);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Balance ret_hu_conv = org.ldk.structs.Balance.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -189,7 +189,7 @@ public class Balance extends CommonBase {
 		Reference.reachabilityFence(claimable_height);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Balance ret_hu_conv = org.ldk.structs.Balance.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/BaseSign.java
+++ b/src/main/java/org/ldk/structs/BaseSign.java
@@ -349,7 +349,7 @@ public class BaseSign extends CommonBase {
 		Reference.reachabilityFence(preimages);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneNoneZ ret_hu_conv = Result_NoneNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(holder_tx);
+		if (this != null) { this.ptrs_to.add(holder_tx); };
 		return ret_hu_conv;
 	}
 
@@ -386,7 +386,7 @@ public class BaseSign extends CommonBase {
 		Reference.reachabilityFence(preimages);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_SignatureCVec_SignatureZZNoneZ ret_hu_conv = Result_C2Tuple_SignatureCVec_SignatureZZNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(commitment_tx);
+		if (this != null) { this.ptrs_to.add(commitment_tx); };
 		return ret_hu_conv;
 	}
 
@@ -425,7 +425,7 @@ public class BaseSign extends CommonBase {
 		Reference.reachabilityFence(commitment_tx);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_SignatureCVec_SignatureZZNoneZ ret_hu_conv = Result_C2Tuple_SignatureCVec_SignatureZZNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(commitment_tx);
+		if (this != null) { this.ptrs_to.add(commitment_tx); };
 		return ret_hu_conv;
 	}
 
@@ -486,7 +486,7 @@ public class BaseSign extends CommonBase {
 		Reference.reachabilityFence(htlc);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_SignatureNoneZ ret_hu_conv = Result_SignatureNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(htlc);
+		if (this != null) { this.ptrs_to.add(htlc); };
 		return ret_hu_conv;
 	}
 
@@ -519,7 +519,7 @@ public class BaseSign extends CommonBase {
 		Reference.reachabilityFence(htlc);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_SignatureNoneZ ret_hu_conv = Result_SignatureNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(htlc);
+		if (this != null) { this.ptrs_to.add(htlc); };
 		return ret_hu_conv;
 	}
 
@@ -535,7 +535,7 @@ public class BaseSign extends CommonBase {
 		Reference.reachabilityFence(closing_tx);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_SignatureNoneZ ret_hu_conv = Result_SignatureNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(closing_tx);
+		if (this != null) { this.ptrs_to.add(closing_tx); };
 		return ret_hu_conv;
 	}
 
@@ -556,7 +556,7 @@ public class BaseSign extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_SignatureSignatureZNoneZ ret_hu_conv = Result_C2Tuple_SignatureSignatureZNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -576,7 +576,7 @@ public class BaseSign extends CommonBase {
 		bindings.BaseSign_ready_channel(this.ptr, channel_parameters == null ? 0 : channel_parameters.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(channel_parameters);
-		this.ptrs_to.add(channel_parameters);
+		if (this != null) { this.ptrs_to.add(channel_parameters); };
 	}
 
 	/**
@@ -588,7 +588,7 @@ public class BaseSign extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelPublicKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Bech32Error.java
+++ b/src/main/java/org/ldk/structs/Bech32Error.java
@@ -119,7 +119,7 @@ public class Bech32Error extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Bech32Error ret_hu_conv = org.ldk.structs.Bech32Error.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/BestBlock.java
+++ b/src/main/java/org/ldk/structs/BestBlock.java
@@ -34,7 +34,7 @@ public class BestBlock extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BestBlock ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BestBlock(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -47,7 +47,7 @@ public class BestBlock extends CommonBase {
 		Reference.reachabilityFence(network);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BestBlock ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BestBlock(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -60,7 +60,7 @@ public class BestBlock extends CommonBase {
 		Reference.reachabilityFence(height);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BestBlock ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BestBlock(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/BigSize.java
+++ b/src/main/java/org/ldk/structs/BigSize.java
@@ -46,7 +46,7 @@ public class BigSize extends CommonBase {
 		Reference.reachabilityFence(a_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BigSize ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BigSize(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/BuiltCommitmentTransaction.java
+++ b/src/main/java/org/ldk/structs/BuiltCommitmentTransaction.java
@@ -71,7 +71,7 @@ public class BuiltCommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(txid_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BuiltCommitmentTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BuiltCommitmentTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class BuiltCommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BuiltCommitmentTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BuiltCommitmentTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChainMonitor.java
+++ b/src/main/java/org/ldk/structs/ChainMonitor.java
@@ -46,12 +46,12 @@ public class ChainMonitor extends CommonBase {
 		Reference.reachabilityFence(persister);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChainMonitor ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChainMonitor(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(chain_source);
-		ret_hu_conv.ptrs_to.add(broadcaster);
-		ret_hu_conv.ptrs_to.add(logger);
-		ret_hu_conv.ptrs_to.add(feeest);
-		ret_hu_conv.ptrs_to.add(persister);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(chain_source); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(broadcaster); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(feeest); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(persister); };
 		return ret_hu_conv;
 	}
 
@@ -75,10 +75,10 @@ public class ChainMonitor extends CommonBase {
 		for (int j = 0; j < ret_conv_9_len; j++) {
 			long ret_conv_9 = ret[j];
 			org.ldk.structs.Balance ret_conv_9_hu_conv = org.ldk.structs.Balance.constr_from_ptr(ret_conv_9);
-			ret_conv_9_hu_conv.ptrs_to.add(this);
+			if (ret_conv_9_hu_conv != null) { ret_conv_9_hu_conv.ptrs_to.add(this); };
 			ret_conv_9_arr[j] = ret_conv_9_hu_conv;
 		}
-		for (ChannelDetails ignored_channels_conv_16: ignored_channels) { this.ptrs_to.add(ignored_channels_conv_16); };
+		for (ChannelDetails ignored_channels_conv_16: ignored_channels) { if (this != null) { this.ptrs_to.add(ignored_channels_conv_16); }; };
 		return ret_conv_9_arr;
 	}
 
@@ -95,7 +95,7 @@ public class ChainMonitor extends CommonBase {
 		Reference.reachabilityFence(funding_txo);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_LockedChannelMonitorNoneZ ret_hu_conv = Result_LockedChannelMonitorNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(funding_txo);
+		if (this != null) { this.ptrs_to.add(funding_txo); };
 		return ret_hu_conv;
 	}
 
@@ -113,7 +113,7 @@ public class ChainMonitor extends CommonBase {
 		for (int k = 0; k < ret_conv_10_len; k++) {
 			long ret_conv_10 = ret[k];
 			org.ldk.structs.OutPoint ret_conv_10_hu_conv = null; if (ret_conv_10 < 0 || ret_conv_10 > 4096) { ret_conv_10_hu_conv = new org.ldk.structs.OutPoint(null, ret_conv_10); }
-			ret_conv_10_hu_conv.ptrs_to.add(this);
+			if (ret_conv_10_hu_conv != null) { ret_conv_10_hu_conv.ptrs_to.add(this); };
 			ret_conv_10_arr[k] = ret_conv_10_hu_conv;
 		}
 		return ret_conv_10_arr;
@@ -141,8 +141,8 @@ public class ChainMonitor extends CommonBase {
 		Reference.reachabilityFence(completed_update_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneAPIErrorZ ret_hu_conv = Result_NoneAPIErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(funding_txo);
-		this.ptrs_to.add(completed_update_id);
+		if (this != null) { this.ptrs_to.add(funding_txo); };
+		if (this != null) { this.ptrs_to.add(completed_update_id); };
 		return ret_hu_conv;
 	}
 
@@ -155,7 +155,7 @@ public class ChainMonitor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Listen ret_hu_conv = new Listen(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -168,7 +168,7 @@ public class ChainMonitor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Confirm ret_hu_conv = new Confirm(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -181,7 +181,7 @@ public class ChainMonitor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Watch ret_hu_conv = new Watch(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -194,7 +194,7 @@ public class ChainMonitor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		EventsProvider ret_hu_conv = new EventsProvider(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChainParameters.java
+++ b/src/main/java/org/ldk/structs/ChainParameters.java
@@ -52,7 +52,7 @@ public class ChainParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BestBlock ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BestBlock(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -65,7 +65,7 @@ public class ChainParameters extends CommonBase {
 		bindings.ChainParameters_set_best_block(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -77,8 +77,8 @@ public class ChainParameters extends CommonBase {
 		Reference.reachabilityFence(best_block_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChainParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChainParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(best_block_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(best_block_arg); };
 		return ret_hu_conv;
 	}
 
@@ -96,7 +96,7 @@ public class ChainParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChainParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChainParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelAnnouncement.java
+++ b/src/main/java/org/ldk/structs/ChannelAnnouncement.java
@@ -100,7 +100,7 @@ public class ChannelAnnouncement extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UnsignedChannelAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UnsignedChannelAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -111,7 +111,7 @@ public class ChannelAnnouncement extends CommonBase {
 		bindings.ChannelAnnouncement_set_contents(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -126,8 +126,8 @@ public class ChannelAnnouncement extends CommonBase {
 		Reference.reachabilityFence(contents_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(contents_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(contents_arg); };
 		return ret_hu_conv;
 	}
 
@@ -145,7 +145,7 @@ public class ChannelAnnouncement extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelConfig.java
+++ b/src/main/java/org/ldk/structs/ChannelConfig.java
@@ -261,7 +261,7 @@ public class ChannelConfig extends CommonBase {
 		Reference.reachabilityFence(force_close_avoidance_max_fee_satoshis_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -279,7 +279,7 @@ public class ChannelConfig extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -290,7 +290,7 @@ public class ChannelConfig extends CommonBase {
 		long ret = bindings.ChannelConfig_default();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelCounterparty.java
+++ b/src/main/java/org/ldk/structs/ChannelCounterparty.java
@@ -49,7 +49,7 @@ public class ChannelCounterparty extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InitFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InitFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class ChannelCounterparty extends CommonBase {
 		bindings.ChannelCounterparty_set_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -107,7 +107,7 @@ public class ChannelCounterparty extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CounterpartyForwardingInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CounterpartyForwardingInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -121,7 +121,7 @@ public class ChannelCounterparty extends CommonBase {
 		bindings.ChannelCounterparty_set_forwarding_info(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -134,7 +134,7 @@ public class ChannelCounterparty extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -157,7 +157,7 @@ public class ChannelCounterparty extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -183,9 +183,9 @@ public class ChannelCounterparty extends CommonBase {
 		Reference.reachabilityFence(outbound_htlc_maximum_msat_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelCounterparty ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelCounterparty(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(features_arg);
-		ret_hu_conv.ptrs_to.add(forwarding_info_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(features_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(forwarding_info_arg); };
 		return ret_hu_conv;
 	}
 
@@ -203,7 +203,7 @@ public class ChannelCounterparty extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelCounterparty ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelCounterparty(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelDetails.java
+++ b/src/main/java/org/ldk/structs/ChannelDetails.java
@@ -52,7 +52,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelCounterparty ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelCounterparty(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -63,7 +63,7 @@ public class ChannelDetails extends CommonBase {
 		bindings.ChannelDetails_set_counterparty(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -81,7 +81,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -98,7 +98,7 @@ public class ChannelDetails extends CommonBase {
 		bindings.ChannelDetails_set_funding_txo(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -114,7 +114,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTypeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTypeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -129,7 +129,7 @@ public class ChannelDetails extends CommonBase {
 		bindings.ChannelDetails_set_channel_type(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -153,7 +153,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -195,7 +195,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -232,7 +232,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -287,7 +287,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -478,7 +478,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u32Z ret_hu_conv = org.ldk.structs.Option_u32Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -515,7 +515,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u16Z ret_hu_conv = org.ldk.structs.Option_u16Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -633,7 +633,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -655,7 +655,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -681,7 +681,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -696,7 +696,7 @@ public class ChannelDetails extends CommonBase {
 		bindings.ChannelDetails_set_config(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -729,11 +729,11 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(config_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelDetails ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelDetails(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(counterparty_arg);
-		ret_hu_conv.ptrs_to.add(funding_txo_arg);
-		ret_hu_conv.ptrs_to.add(channel_type_arg);
-		ret_hu_conv.ptrs_to.add(config_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(counterparty_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(funding_txo_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channel_type_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(config_arg); };
 		return ret_hu_conv;
 	}
 
@@ -751,7 +751,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelDetails ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelDetails(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -768,7 +768,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -785,7 +785,7 @@ public class ChannelDetails extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelFeatures.java
+++ b/src/main/java/org/ldk/structs/ChannelFeatures.java
@@ -29,7 +29,7 @@ public class ChannelFeatures extends CommonBase {
 		boolean ret = bindings.ChannelFeatures_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -51,7 +51,7 @@ public class ChannelFeatures extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class ChannelFeatures extends CommonBase {
 		long ret = bindings.ChannelFeatures_empty();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -73,7 +73,7 @@ public class ChannelFeatures extends CommonBase {
 		long ret = bindings.ChannelFeatures_known();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelHandshakeConfig.java
+++ b/src/main/java/org/ldk/structs/ChannelHandshakeConfig.java
@@ -350,7 +350,7 @@ public class ChannelHandshakeConfig extends CommonBase {
 		Reference.reachabilityFence(commit_upfront_shutdown_pubkey_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelHandshakeConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelHandshakeConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -368,7 +368,7 @@ public class ChannelHandshakeConfig extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelHandshakeConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelHandshakeConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -379,7 +379,7 @@ public class ChannelHandshakeConfig extends CommonBase {
 		long ret = bindings.ChannelHandshakeConfig_default();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelHandshakeConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelHandshakeConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelHandshakeLimits.java
+++ b/src/main/java/org/ldk/structs/ChannelHandshakeLimits.java
@@ -333,7 +333,7 @@ public class ChannelHandshakeLimits extends CommonBase {
 		Reference.reachabilityFence(their_to_self_delay_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelHandshakeLimits ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelHandshakeLimits(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -351,7 +351,7 @@ public class ChannelHandshakeLimits extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelHandshakeLimits ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelHandshakeLimits(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -362,7 +362,7 @@ public class ChannelHandshakeLimits extends CommonBase {
 		long ret = bindings.ChannelHandshakeLimits_default();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelHandshakeLimits ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelHandshakeLimits(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelInfo.java
+++ b/src/main/java/org/ldk/structs/ChannelInfo.java
@@ -29,7 +29,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -40,7 +40,7 @@ public class ChannelInfo extends CommonBase {
 		bindings.ChannelInfo_set_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -51,7 +51,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeId ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeId(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class ChannelInfo extends CommonBase {
 		bindings.ChannelInfo_set_node_one(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -76,7 +76,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdateInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdateInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class ChannelInfo extends CommonBase {
 		bindings.ChannelInfo_set_one_to_two(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -100,7 +100,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeId ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeId(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -111,7 +111,7 @@ public class ChannelInfo extends CommonBase {
 		bindings.ChannelInfo_set_node_two(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -125,7 +125,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdateInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdateInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -138,7 +138,7 @@ public class ChannelInfo extends CommonBase {
 		bindings.ChannelInfo_set_two_to_one(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -149,7 +149,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -176,7 +176,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -192,7 +192,7 @@ public class ChannelInfo extends CommonBase {
 		bindings.ChannelInfo_set_announcement_message(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	long clone_ptr() {
@@ -209,7 +209,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -225,7 +225,7 @@ public class ChannelInfo extends CommonBase {
 		Reference.reachabilityFence(channel_flags);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdateInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdateInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelManager.java
+++ b/src/main/java/org/ldk/structs/ChannelManager.java
@@ -78,14 +78,14 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(params);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelManager ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelManager(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(fee_est);
-		ret_hu_conv.ptrs_to.add(chain_monitor);
-		ret_hu_conv.ptrs_to.add(tx_broadcaster);
-		ret_hu_conv.ptrs_to.add(logger);
-		ret_hu_conv.ptrs_to.add(keys_manager);
-		ret_hu_conv.ptrs_to.add(config);
-		ret_hu_conv.ptrs_to.add(params);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(fee_est); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(chain_monitor); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(tx_broadcaster); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(config); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(params); };
 		return ret_hu_conv;
 	}
 
@@ -97,7 +97,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UserConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UserConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -141,7 +141,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(override_config);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result__u832APIErrorZ ret_hu_conv = Result__u832APIErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(override_config);
+		if (this != null) { this.ptrs_to.add(override_config); };
 		return ret_hu_conv;
 	}
 
@@ -157,7 +157,7 @@ public class ChannelManager extends CommonBase {
 		for (int q = 0; q < ret_conv_16_len; q++) {
 			long ret_conv_16 = ret[q];
 			org.ldk.structs.ChannelDetails ret_conv_16_hu_conv = null; if (ret_conv_16 < 0 || ret_conv_16 > 4096) { ret_conv_16_hu_conv = new org.ldk.structs.ChannelDetails(null, ret_conv_16); }
-			ret_conv_16_hu_conv.ptrs_to.add(this);
+			if (ret_conv_16_hu_conv != null) { ret_conv_16_hu_conv.ptrs_to.add(this); };
 			ret_conv_16_arr[q] = ret_conv_16_hu_conv;
 		}
 		return ret_conv_16_arr;
@@ -181,7 +181,7 @@ public class ChannelManager extends CommonBase {
 		for (int q = 0; q < ret_conv_16_len; q++) {
 			long ret_conv_16 = ret[q];
 			org.ldk.structs.ChannelDetails ret_conv_16_hu_conv = null; if (ret_conv_16 < 0 || ret_conv_16 > 4096) { ret_conv_16_hu_conv = new org.ldk.structs.ChannelDetails(null, ret_conv_16); }
-			ret_conv_16_hu_conv.ptrs_to.add(this);
+			if (ret_conv_16_hu_conv != null) { ret_conv_16_hu_conv.ptrs_to.add(this); };
 			ret_conv_16_arr[q] = ret_conv_16_hu_conv;
 		}
 		return ret_conv_16_arr;
@@ -351,7 +351,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(payment_secret);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentIdPaymentSendFailureZ ret_hu_conv = Result_PaymentIdPaymentSendFailureZ.constr_from_ptr(ret);
-		this.ptrs_to.add(route);
+		if (this != null) { this.ptrs_to.add(route); };
 		return ret_hu_conv;
 	}
 
@@ -374,7 +374,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(payment_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NonePaymentSendFailureZ ret_hu_conv = Result_NonePaymentSendFailureZ.constr_from_ptr(ret);
-		this.ptrs_to.add(route);
+		if (this != null) { this.ptrs_to.add(route); };
 		return ret_hu_conv;
 	}
 
@@ -425,7 +425,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(payment_preimage);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ ret_hu_conv = Result_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ.constr_from_ptr(ret);
-		this.ptrs_to.add(route);
+		if (this != null) { this.ptrs_to.add(route); };
 		return ret_hu_conv;
 	}
 
@@ -440,7 +440,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(hops);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ ret_hu_conv = Result_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ.constr_from_ptr(ret);
-		for (RouteHop hops_conv_10: hops) { this.ptrs_to.add(hops_conv_10); };
+		for (RouteHop hops_conv_10: hops) { if (this != null) { this.ptrs_to.add(hops_conv_10); }; };
 		return ret_hu_conv;
 	}
 
@@ -547,7 +547,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(config);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneAPIErrorZ ret_hu_conv = Result_NoneAPIErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(config);
+		if (this != null) { this.ptrs_to.add(config); };
 		return ret_hu_conv;
 	}
 
@@ -872,7 +872,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PhantomRouteHints ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PhantomRouteHints(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -885,7 +885,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		MessageSendEventsProvider ret_hu_conv = new MessageSendEventsProvider(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -898,7 +898,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		EventsProvider ret_hu_conv = new EventsProvider(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -911,7 +911,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Listen ret_hu_conv = new Listen(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -924,7 +924,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Confirm ret_hu_conv = new Confirm(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -962,7 +962,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BestBlock ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BestBlock(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -975,7 +975,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ChannelMessageHandler ret_hu_conv = new ChannelMessageHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -997,7 +997,7 @@ public class ChannelManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Payer ret_hu_conv = new Payer(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelManagerReadArgs.java
+++ b/src/main/java/org/ldk/structs/ChannelManagerReadArgs.java
@@ -61,7 +61,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		KeysInterface ret_hu_conv = new KeysInterface(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -74,7 +74,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		bindings.ChannelManagerReadArgs_set_keys_manager(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -87,7 +87,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		FeeEstimator ret_hu_conv = new FeeEstimator(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -100,7 +100,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		bindings.ChannelManagerReadArgs_set_fee_estimator(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -115,7 +115,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Watch ret_hu_conv = new Watch(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -130,7 +130,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		bindings.ChannelManagerReadArgs_set_chain_monitor(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -143,7 +143,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		BroadcasterInterface ret_hu_conv = new BroadcasterInterface(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -156,7 +156,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		bindings.ChannelManagerReadArgs_set_tx_broadcaster(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -168,7 +168,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Logger ret_hu_conv = new Logger(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -180,7 +180,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		bindings.ChannelManagerReadArgs_set_logger(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -192,7 +192,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UserConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UserConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -204,7 +204,7 @@ public class ChannelManagerReadArgs extends CommonBase {
 		bindings.ChannelManagerReadArgs_set_default_config(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -223,14 +223,14 @@ public class ChannelManagerReadArgs extends CommonBase {
 		Reference.reachabilityFence(channel_monitors);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelManagerReadArgs ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelManagerReadArgs(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(keys_manager);
-		ret_hu_conv.ptrs_to.add(fee_estimator);
-		ret_hu_conv.ptrs_to.add(chain_monitor);
-		ret_hu_conv.ptrs_to.add(tx_broadcaster);
-		ret_hu_conv.ptrs_to.add(logger);
-		ret_hu_conv.ptrs_to.add(default_config);
-		for (ChannelMonitor channel_monitors_conv_16: channel_monitors) { ret_hu_conv.ptrs_to.add(channel_monitors_conv_16); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(fee_estimator); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(chain_monitor); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(tx_broadcaster); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(default_config); };
+		for (ChannelMonitor channel_monitors_conv_16: channel_monitors) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channel_monitors_conv_16); }; };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelMessageHandler.java
+++ b/src/main/java/org/ldk/structs/ChannelMessageHandler.java
@@ -119,14 +119,14 @@ public class ChannelMessageHandler extends CommonBase {
 		impl_holder.held = new ChannelMessageHandler(new bindings.LDKChannelMessageHandler() {
 			@Override public void handle_open_channel(byte[] their_node_id, long their_features, long msg) {
 				org.ldk.structs.InitFeatures their_features_hu_conv = null; if (their_features < 0 || their_features > 4096) { their_features_hu_conv = new org.ldk.structs.InitFeatures(null, their_features); }
-				their_features_hu_conv.ptrs_to.add(this);
+				if (their_features_hu_conv != null) { their_features_hu_conv.ptrs_to.add(this); };
 				org.ldk.structs.OpenChannel msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.OpenChannel(null, msg); }
 				arg.handle_open_channel(their_node_id, their_features_hu_conv, msg_hu_conv);
 				Reference.reachabilityFence(arg);
 			}
 			@Override public void handle_accept_channel(byte[] their_node_id, long their_features, long msg) {
 				org.ldk.structs.InitFeatures their_features_hu_conv = null; if (their_features < 0 || their_features > 4096) { their_features_hu_conv = new org.ldk.structs.InitFeatures(null, their_features); }
-				their_features_hu_conv.ptrs_to.add(this);
+				if (their_features_hu_conv != null) { their_features_hu_conv.ptrs_to.add(this); };
 				org.ldk.structs.AcceptChannel msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.AcceptChannel(null, msg); }
 				arg.handle_accept_channel(their_node_id, their_features_hu_conv, msg_hu_conv);
 				Reference.reachabilityFence(arg);
@@ -243,8 +243,8 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(their_features);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(their_features);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(their_features); };
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -256,8 +256,8 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(their_features);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(their_features);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(their_features); };
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -268,7 +268,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -279,7 +279,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -290,7 +290,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -302,8 +302,8 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(their_features);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(their_features);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(their_features); };
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -314,7 +314,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -325,7 +325,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -336,7 +336,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -347,7 +347,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -358,7 +358,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -369,7 +369,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -380,7 +380,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -391,7 +391,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -402,7 +402,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -426,7 +426,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -437,7 +437,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -448,7 +448,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 	/**
@@ -459,7 +459,7 @@ public class ChannelMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(msg);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 	}
 
 }

--- a/src/main/java/org/ldk/structs/ChannelMonitor.java
+++ b/src/main/java/org/ldk/structs/ChannelMonitor.java
@@ -49,7 +49,7 @@ public class ChannelMonitor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelMonitor ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelMonitor(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -77,10 +77,10 @@ public class ChannelMonitor extends CommonBase {
 		Reference.reachabilityFence(logger);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneNoneZ ret_hu_conv = Result_NoneNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(updates);
-		this.ptrs_to.add(broadcaster);
-		this.ptrs_to.add(fee_estimator);
-		this.ptrs_to.add(logger);
+		if (this != null) { this.ptrs_to.add(updates); };
+		if (this != null) { this.ptrs_to.add(broadcaster); };
+		if (this != null) { this.ptrs_to.add(fee_estimator); };
+		if (this != null) { this.ptrs_to.add(logger); };
 		return ret_hu_conv;
 	}
 
@@ -102,7 +102,7 @@ public class ChannelMonitor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_OutPointScriptZ ret_hu_conv = new TwoTuple_OutPointScriptZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -118,7 +118,7 @@ public class ChannelMonitor extends CommonBase {
 		for (int o = 0; o < ret_conv_40_len; o++) {
 			long ret_conv_40 = ret[o];
 			TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ ret_conv_40_hu_conv = new TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ(null, ret_conv_40);
-			ret_conv_40_hu_conv.ptrs_to.add(this);
+			if (ret_conv_40_hu_conv != null) { ret_conv_40_hu_conv.ptrs_to.add(this); };
 			ret_conv_40_arr[o] = ret_conv_40_hu_conv;
 		}
 		return ret_conv_40_arr;
@@ -133,7 +133,7 @@ public class ChannelMonitor extends CommonBase {
 		bindings.ChannelMonitor_load_outputs_to_watch(this.ptr, filter == null ? 0 : filter.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(filter);
-		this.ptrs_to.add(filter);
+		if (this != null) { this.ptrs_to.add(filter); };
 	}
 
 	/**
@@ -148,7 +148,7 @@ public class ChannelMonitor extends CommonBase {
 		for (int o = 0; o < ret_conv_14_len; o++) {
 			long ret_conv_14 = ret[o];
 			org.ldk.structs.MonitorEvent ret_conv_14_hu_conv = org.ldk.structs.MonitorEvent.constr_from_ptr(ret_conv_14);
-			ret_conv_14_hu_conv.ptrs_to.add(this);
+			if (ret_conv_14_hu_conv != null) { ret_conv_14_hu_conv.ptrs_to.add(this); };
 			ret_conv_14_arr[o] = ret_conv_14_hu_conv;
 		}
 		return ret_conv_14_arr;
@@ -170,7 +170,7 @@ public class ChannelMonitor extends CommonBase {
 		for (int h = 0; h < ret_conv_7_len; h++) {
 			long ret_conv_7 = ret[h];
 			org.ldk.structs.Event ret_conv_7_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret_conv_7);
-			ret_conv_7_hu_conv.ptrs_to.add(this);
+			if (ret_conv_7_hu_conv != null) { ret_conv_7_hu_conv.ptrs_to.add(this); };
 			ret_conv_7_arr[h] = ret_conv_7_hu_conv;
 		}
 		return ret_conv_7_arr;
@@ -206,7 +206,7 @@ public class ChannelMonitor extends CommonBase {
 		byte[][] ret = bindings.ChannelMonitor_get_latest_holder_commitment_txn(this.ptr, logger == null ? 0 : logger.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(logger);
-		this.ptrs_to.add(logger);
+		if (this != null) { this.ptrs_to.add(logger); };
 		return ret;
 	}
 
@@ -237,12 +237,12 @@ public class ChannelMonitor extends CommonBase {
 		for (int n = 0; n < ret_conv_39_len; n++) {
 			long ret_conv_39 = ret[n];
 			TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ ret_conv_39_hu_conv = new TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ(null, ret_conv_39);
-			ret_conv_39_hu_conv.ptrs_to.add(this);
+			if (ret_conv_39_hu_conv != null) { ret_conv_39_hu_conv.ptrs_to.add(this); };
 			ret_conv_39_arr[n] = ret_conv_39_hu_conv;
 		}
-		this.ptrs_to.add(broadcaster);
-		this.ptrs_to.add(fee_estimator);
-		this.ptrs_to.add(logger);
+		if (this != null) { this.ptrs_to.add(broadcaster); };
+		if (this != null) { this.ptrs_to.add(fee_estimator); };
+		if (this != null) { this.ptrs_to.add(logger); };
 		return ret_conv_39_arr;
 	}
 
@@ -258,9 +258,9 @@ public class ChannelMonitor extends CommonBase {
 		Reference.reachabilityFence(broadcaster);
 		Reference.reachabilityFence(fee_estimator);
 		Reference.reachabilityFence(logger);
-		this.ptrs_to.add(broadcaster);
-		this.ptrs_to.add(fee_estimator);
-		this.ptrs_to.add(logger);
+		if (this != null) { this.ptrs_to.add(broadcaster); };
+		if (this != null) { this.ptrs_to.add(fee_estimator); };
+		if (this != null) { this.ptrs_to.add(logger); };
 	}
 
 	/**
@@ -286,12 +286,12 @@ public class ChannelMonitor extends CommonBase {
 		for (int n = 0; n < ret_conv_39_len; n++) {
 			long ret_conv_39 = ret[n];
 			TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ ret_conv_39_hu_conv = new TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ(null, ret_conv_39);
-			ret_conv_39_hu_conv.ptrs_to.add(this);
+			if (ret_conv_39_hu_conv != null) { ret_conv_39_hu_conv.ptrs_to.add(this); };
 			ret_conv_39_arr[n] = ret_conv_39_hu_conv;
 		}
-		this.ptrs_to.add(broadcaster);
-		this.ptrs_to.add(fee_estimator);
-		this.ptrs_to.add(logger);
+		if (this != null) { this.ptrs_to.add(broadcaster); };
+		if (this != null) { this.ptrs_to.add(fee_estimator); };
+		if (this != null) { this.ptrs_to.add(logger); };
 		return ret_conv_39_arr;
 	}
 
@@ -310,9 +310,9 @@ public class ChannelMonitor extends CommonBase {
 		Reference.reachabilityFence(broadcaster);
 		Reference.reachabilityFence(fee_estimator);
 		Reference.reachabilityFence(logger);
-		this.ptrs_to.add(broadcaster);
-		this.ptrs_to.add(fee_estimator);
-		this.ptrs_to.add(logger);
+		if (this != null) { this.ptrs_to.add(broadcaster); };
+		if (this != null) { this.ptrs_to.add(fee_estimator); };
+		if (this != null) { this.ptrs_to.add(logger); };
 	}
 
 	/**
@@ -337,12 +337,12 @@ public class ChannelMonitor extends CommonBase {
 		for (int n = 0; n < ret_conv_39_len; n++) {
 			long ret_conv_39 = ret[n];
 			TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ ret_conv_39_hu_conv = new TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ(null, ret_conv_39);
-			ret_conv_39_hu_conv.ptrs_to.add(this);
+			if (ret_conv_39_hu_conv != null) { ret_conv_39_hu_conv.ptrs_to.add(this); };
 			ret_conv_39_arr[n] = ret_conv_39_hu_conv;
 		}
-		this.ptrs_to.add(broadcaster);
-		this.ptrs_to.add(fee_estimator);
-		this.ptrs_to.add(logger);
+		if (this != null) { this.ptrs_to.add(broadcaster); };
+		if (this != null) { this.ptrs_to.add(fee_estimator); };
+		if (this != null) { this.ptrs_to.add(logger); };
 		return ret_conv_39_arr;
 	}
 
@@ -364,7 +364,7 @@ public class ChannelMonitor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BestBlock ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BestBlock(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -392,7 +392,7 @@ public class ChannelMonitor extends CommonBase {
 		for (int j = 0; j < ret_conv_9_len; j++) {
 			long ret_conv_9 = ret[j];
 			org.ldk.structs.Balance ret_conv_9_hu_conv = org.ldk.structs.Balance.constr_from_ptr(ret_conv_9);
-			ret_conv_9_hu_conv.ptrs_to.add(this);
+			if (ret_conv_9_hu_conv != null) { ret_conv_9_hu_conv.ptrs_to.add(this); };
 			ret_conv_9_arr[j] = ret_conv_9_hu_conv;
 		}
 		return ret_conv_9_arr;

--- a/src/main/java/org/ldk/structs/ChannelMonitorUpdate.java
+++ b/src/main/java/org/ldk/structs/ChannelMonitorUpdate.java
@@ -73,7 +73,7 @@ public class ChannelMonitorUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelMonitorUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelMonitorUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelPublicKeys.java
+++ b/src/main/java/org/ldk/structs/ChannelPublicKeys.java
@@ -140,7 +140,7 @@ public class ChannelPublicKeys extends CommonBase {
 		Reference.reachabilityFence(htlc_basepoint_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelPublicKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -158,7 +158,7 @@ public class ChannelPublicKeys extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelPublicKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelReady.java
+++ b/src/main/java/org/ldk/structs/ChannelReady.java
@@ -65,7 +65,7 @@ public class ChannelReady extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class ChannelReady extends CommonBase {
 		Reference.reachabilityFence(short_channel_id_alias_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelReady ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelReady(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -107,7 +107,7 @@ public class ChannelReady extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelReady ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelReady(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelReestablish.java
+++ b/src/main/java/org/ldk/structs/ChannelReestablish.java
@@ -88,7 +88,7 @@ public class ChannelReestablish extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelReestablish ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelReestablish(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelTransactionParameters.java
+++ b/src/main/java/org/ldk/structs/ChannelTransactionParameters.java
@@ -32,7 +32,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelPublicKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -43,7 +43,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		bindings.ChannelTransactionParameters_set_holder_pubkeys(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -96,7 +96,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CounterpartyChannelTransactionParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CounterpartyChannelTransactionParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -110,7 +110,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		bindings.ChannelTransactionParameters_set_counterparty_parameters(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -124,7 +124,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -137,7 +137,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		bindings.ChannelTransactionParameters_set_funding_outpoint(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -171,10 +171,10 @@ public class ChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(opt_anchors_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTransactionParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTransactionParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(holder_pubkeys_arg);
-		ret_hu_conv.ptrs_to.add(counterparty_parameters_arg);
-		ret_hu_conv.ptrs_to.add(funding_outpoint_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(holder_pubkeys_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(counterparty_parameters_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(funding_outpoint_arg); };
 		return ret_hu_conv;
 	}
 
@@ -192,7 +192,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTransactionParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTransactionParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -216,7 +216,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DirectedChannelTransactionParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DirectedChannelTransactionParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -231,7 +231,7 @@ public class ChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DirectedChannelTransactionParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DirectedChannelTransactionParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelTypeFeatures.java
+++ b/src/main/java/org/ldk/structs/ChannelTypeFeatures.java
@@ -38,7 +38,7 @@ public class ChannelTypeFeatures extends CommonBase {
 		boolean ret = bindings.ChannelTypeFeatures_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -60,7 +60,7 @@ public class ChannelTypeFeatures extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTypeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTypeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -71,7 +71,7 @@ public class ChannelTypeFeatures extends CommonBase {
 		long ret = bindings.ChannelTypeFeatures_empty();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTypeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTypeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -82,7 +82,7 @@ public class ChannelTypeFeatures extends CommonBase {
 		long ret = bindings.ChannelTypeFeatures_known();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTypeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTypeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelUpdate.java
+++ b/src/main/java/org/ldk/structs/ChannelUpdate.java
@@ -46,7 +46,7 @@ public class ChannelUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UnsignedChannelUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UnsignedChannelUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -57,7 +57,7 @@ public class ChannelUpdate extends CommonBase {
 		bindings.ChannelUpdate_set_contents(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -69,8 +69,8 @@ public class ChannelUpdate extends CommonBase {
 		Reference.reachabilityFence(contents_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(contents_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(contents_arg); };
 		return ret_hu_conv;
 	}
 
@@ -88,7 +88,7 @@ public class ChannelUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelUpdateInfo.java
+++ b/src/main/java/org/ldk/structs/ChannelUpdateInfo.java
@@ -120,7 +120,7 @@ public class ChannelUpdateInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RoutingFees ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RoutingFees(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -131,7 +131,7 @@ public class ChannelUpdateInfo extends CommonBase {
 		bindings.ChannelUpdateInfo_set_fees(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -148,7 +148,7 @@ public class ChannelUpdateInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -164,7 +164,7 @@ public class ChannelUpdateInfo extends CommonBase {
 		bindings.ChannelUpdateInfo_set_last_update_message(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -181,9 +181,9 @@ public class ChannelUpdateInfo extends CommonBase {
 		Reference.reachabilityFence(last_update_message_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdateInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdateInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(fees_arg);
-		ret_hu_conv.ptrs_to.add(last_update_message_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(fees_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(last_update_message_arg); };
 		return ret_hu_conv;
 	}
 
@@ -201,7 +201,7 @@ public class ChannelUpdateInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdateInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdateInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ChannelUsage.java
+++ b/src/main/java/org/ldk/structs/ChannelUsage.java
@@ -66,7 +66,7 @@ public class ChannelUsage extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.EffectiveCapacity ret_hu_conv = org.ldk.structs.EffectiveCapacity.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class ChannelUsage extends CommonBase {
 		Reference.reachabilityFence(effective_capacity_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUsage ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUsage(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -107,7 +107,7 @@ public class ChannelUsage extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUsage ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUsage(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ClosingSigned.java
+++ b/src/main/java/org/ldk/structs/ClosingSigned.java
@@ -86,7 +86,7 @@ public class ClosingSigned extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosingSignedFeeRange ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ClosingSignedFeeRange(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -100,7 +100,7 @@ public class ClosingSigned extends CommonBase {
 		bindings.ClosingSigned_set_fee_range(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -114,8 +114,8 @@ public class ClosingSigned extends CommonBase {
 		Reference.reachabilityFence(fee_range_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosingSigned ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ClosingSigned(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(fee_range_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(fee_range_arg); };
 		return ret_hu_conv;
 	}
 
@@ -133,7 +133,7 @@ public class ClosingSigned extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosingSigned ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ClosingSigned(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ClosingSignedFeeRange.java
+++ b/src/main/java/org/ldk/structs/ClosingSignedFeeRange.java
@@ -71,7 +71,7 @@ public class ClosingSignedFeeRange extends CommonBase {
 		Reference.reachabilityFence(max_fee_satoshis_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosingSignedFeeRange ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ClosingSignedFeeRange(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class ClosingSignedFeeRange extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosingSignedFeeRange ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ClosingSignedFeeRange(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ClosingTransaction.java
+++ b/src/main/java/org/ldk/structs/ClosingTransaction.java
@@ -38,7 +38,7 @@ public class ClosingTransaction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosingTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ClosingTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -66,8 +66,8 @@ public class ClosingTransaction extends CommonBase {
 		Reference.reachabilityFence(funding_outpoint);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosingTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ClosingTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(funding_outpoint);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(funding_outpoint); };
 		return ret_hu_conv;
 	}
 
@@ -84,7 +84,7 @@ public class ClosingTransaction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.TrustedClosingTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.TrustedClosingTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -102,7 +102,7 @@ public class ClosingTransaction extends CommonBase {
 		Reference.reachabilityFence(funding_outpoint);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_TrustedClosingTransactionNoneZ ret_hu_conv = Result_TrustedClosingTransactionNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(funding_outpoint);
+		if (this != null) { this.ptrs_to.add(funding_outpoint); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ClosureReason.java
+++ b/src/main/java/org/ldk/structs/ClosureReason.java
@@ -153,7 +153,7 @@ public class ClosureReason extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -165,7 +165,7 @@ public class ClosureReason extends CommonBase {
 		Reference.reachabilityFence(peer_msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -176,7 +176,7 @@ public class ClosureReason extends CommonBase {
 		long ret = bindings.ClosureReason_holder_force_closed();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -187,7 +187,7 @@ public class ClosureReason extends CommonBase {
 		long ret = bindings.ClosureReason_cooperative_closure();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -198,7 +198,7 @@ public class ClosureReason extends CommonBase {
 		long ret = bindings.ClosureReason_commitment_tx_confirmed();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -209,7 +209,7 @@ public class ClosureReason extends CommonBase {
 		long ret = bindings.ClosureReason_funding_timed_out();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -221,7 +221,7 @@ public class ClosureReason extends CommonBase {
 		Reference.reachabilityFence(err);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -232,7 +232,7 @@ public class ClosureReason extends CommonBase {
 		long ret = bindings.ClosureReason_disconnected_peer();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -243,7 +243,7 @@ public class ClosureReason extends CommonBase {
 		long ret = bindings.ClosureReason_outdated_channel_manager();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ClosureReason ret_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/CommitmentSigned.java
+++ b/src/main/java/org/ldk/structs/CommitmentSigned.java
@@ -86,7 +86,7 @@ public class CommitmentSigned extends CommonBase {
 		Reference.reachabilityFence(htlc_signatures_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CommitmentSigned ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CommitmentSigned(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -104,7 +104,7 @@ public class CommitmentSigned extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CommitmentSigned ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CommitmentSigned(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/CommitmentTransaction.java
+++ b/src/main/java/org/ldk/structs/CommitmentTransaction.java
@@ -39,7 +39,7 @@ public class CommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CommitmentTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CommitmentTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -112,7 +112,7 @@ public class CommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.TrustedCommitmentTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.TrustedCommitmentTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -132,9 +132,9 @@ public class CommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(countersignatory_keys);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_TrustedCommitmentTransactionNoneZ ret_hu_conv = Result_TrustedCommitmentTransactionNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(channel_parameters);
-		this.ptrs_to.add(broadcaster_keys);
-		this.ptrs_to.add(countersignatory_keys);
+		if (this != null) { this.ptrs_to.add(channel_parameters); };
+		if (this != null) { this.ptrs_to.add(broadcaster_keys); };
+		if (this != null) { this.ptrs_to.add(countersignatory_keys); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/CommitmentUpdate.java
+++ b/src/main/java/org/ldk/structs/CommitmentUpdate.java
@@ -32,7 +32,7 @@ public class CommitmentUpdate extends CommonBase {
 		for (int p = 0; p < ret_conv_15_len; p++) {
 			long ret_conv_15 = ret[p];
 			org.ldk.structs.UpdateAddHTLC ret_conv_15_hu_conv = null; if (ret_conv_15 < 0 || ret_conv_15 > 4096) { ret_conv_15_hu_conv = new org.ldk.structs.UpdateAddHTLC(null, ret_conv_15); }
-			ret_conv_15_hu_conv.ptrs_to.add(this);
+			if (ret_conv_15_hu_conv != null) { ret_conv_15_hu_conv.ptrs_to.add(this); };
 			ret_conv_15_arr[p] = ret_conv_15_hu_conv;
 		}
 		return ret_conv_15_arr;
@@ -45,7 +45,7 @@ public class CommitmentUpdate extends CommonBase {
 		bindings.CommitmentUpdate_set_update_add_htlcs(this.ptr, val != null ? Arrays.stream(val).mapToLong(val_conv_15 -> val_conv_15 == null ? 0 : val_conv_15.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		for (UpdateAddHTLC val_conv_15: val) { this.ptrs_to.add(val_conv_15); };
+		for (UpdateAddHTLC val_conv_15: val) { if (this != null) { this.ptrs_to.add(val_conv_15); }; };
 	}
 
 	/**
@@ -59,7 +59,7 @@ public class CommitmentUpdate extends CommonBase {
 		for (int t = 0; t < ret_conv_19_len; t++) {
 			long ret_conv_19 = ret[t];
 			org.ldk.structs.UpdateFulfillHTLC ret_conv_19_hu_conv = null; if (ret_conv_19 < 0 || ret_conv_19 > 4096) { ret_conv_19_hu_conv = new org.ldk.structs.UpdateFulfillHTLC(null, ret_conv_19); }
-			ret_conv_19_hu_conv.ptrs_to.add(this);
+			if (ret_conv_19_hu_conv != null) { ret_conv_19_hu_conv.ptrs_to.add(this); };
 			ret_conv_19_arr[t] = ret_conv_19_hu_conv;
 		}
 		return ret_conv_19_arr;
@@ -72,7 +72,7 @@ public class CommitmentUpdate extends CommonBase {
 		bindings.CommitmentUpdate_set_update_fulfill_htlcs(this.ptr, val != null ? Arrays.stream(val).mapToLong(val_conv_19 -> val_conv_19 == null ? 0 : val_conv_19.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		for (UpdateFulfillHTLC val_conv_19: val) { this.ptrs_to.add(val_conv_19); };
+		for (UpdateFulfillHTLC val_conv_19: val) { if (this != null) { this.ptrs_to.add(val_conv_19); }; };
 	}
 
 	/**
@@ -86,7 +86,7 @@ public class CommitmentUpdate extends CommonBase {
 		for (int q = 0; q < ret_conv_16_len; q++) {
 			long ret_conv_16 = ret[q];
 			org.ldk.structs.UpdateFailHTLC ret_conv_16_hu_conv = null; if (ret_conv_16 < 0 || ret_conv_16 > 4096) { ret_conv_16_hu_conv = new org.ldk.structs.UpdateFailHTLC(null, ret_conv_16); }
-			ret_conv_16_hu_conv.ptrs_to.add(this);
+			if (ret_conv_16_hu_conv != null) { ret_conv_16_hu_conv.ptrs_to.add(this); };
 			ret_conv_16_arr[q] = ret_conv_16_hu_conv;
 		}
 		return ret_conv_16_arr;
@@ -99,7 +99,7 @@ public class CommitmentUpdate extends CommonBase {
 		bindings.CommitmentUpdate_set_update_fail_htlcs(this.ptr, val != null ? Arrays.stream(val).mapToLong(val_conv_16 -> val_conv_16 == null ? 0 : val_conv_16.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		for (UpdateFailHTLC val_conv_16: val) { this.ptrs_to.add(val_conv_16); };
+		for (UpdateFailHTLC val_conv_16: val) { if (this != null) { this.ptrs_to.add(val_conv_16); }; };
 	}
 
 	/**
@@ -113,7 +113,7 @@ public class CommitmentUpdate extends CommonBase {
 		for (int z = 0; z < ret_conv_25_len; z++) {
 			long ret_conv_25 = ret[z];
 			org.ldk.structs.UpdateFailMalformedHTLC ret_conv_25_hu_conv = null; if (ret_conv_25 < 0 || ret_conv_25 > 4096) { ret_conv_25_hu_conv = new org.ldk.structs.UpdateFailMalformedHTLC(null, ret_conv_25); }
-			ret_conv_25_hu_conv.ptrs_to.add(this);
+			if (ret_conv_25_hu_conv != null) { ret_conv_25_hu_conv.ptrs_to.add(this); };
 			ret_conv_25_arr[z] = ret_conv_25_hu_conv;
 		}
 		return ret_conv_25_arr;
@@ -126,7 +126,7 @@ public class CommitmentUpdate extends CommonBase {
 		bindings.CommitmentUpdate_set_update_fail_malformed_htlcs(this.ptr, val != null ? Arrays.stream(val).mapToLong(val_conv_25 -> val_conv_25 == null ? 0 : val_conv_25.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		for (UpdateFailMalformedHTLC val_conv_25: val) { this.ptrs_to.add(val_conv_25); };
+		for (UpdateFailMalformedHTLC val_conv_25: val) { if (this != null) { this.ptrs_to.add(val_conv_25); }; };
 	}
 
 	/**
@@ -140,7 +140,7 @@ public class CommitmentUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UpdateFee ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UpdateFee(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -153,7 +153,7 @@ public class CommitmentUpdate extends CommonBase {
 		bindings.CommitmentUpdate_set_update_fee(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -164,7 +164,7 @@ public class CommitmentUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CommitmentSigned ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CommitmentSigned(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -175,7 +175,7 @@ public class CommitmentUpdate extends CommonBase {
 		bindings.CommitmentUpdate_set_commitment_signed(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -191,13 +191,13 @@ public class CommitmentUpdate extends CommonBase {
 		Reference.reachabilityFence(commitment_signed_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CommitmentUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CommitmentUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		for (UpdateAddHTLC update_add_htlcs_arg_conv_15: update_add_htlcs_arg) { ret_hu_conv.ptrs_to.add(update_add_htlcs_arg_conv_15); };
-		for (UpdateFulfillHTLC update_fulfill_htlcs_arg_conv_19: update_fulfill_htlcs_arg) { ret_hu_conv.ptrs_to.add(update_fulfill_htlcs_arg_conv_19); };
-		for (UpdateFailHTLC update_fail_htlcs_arg_conv_16: update_fail_htlcs_arg) { ret_hu_conv.ptrs_to.add(update_fail_htlcs_arg_conv_16); };
-		for (UpdateFailMalformedHTLC update_fail_malformed_htlcs_arg_conv_25: update_fail_malformed_htlcs_arg) { ret_hu_conv.ptrs_to.add(update_fail_malformed_htlcs_arg_conv_25); };
-		ret_hu_conv.ptrs_to.add(update_fee_arg);
-		ret_hu_conv.ptrs_to.add(commitment_signed_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		for (UpdateAddHTLC update_add_htlcs_arg_conv_15: update_add_htlcs_arg) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(update_add_htlcs_arg_conv_15); }; };
+		for (UpdateFulfillHTLC update_fulfill_htlcs_arg_conv_19: update_fulfill_htlcs_arg) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(update_fulfill_htlcs_arg_conv_19); }; };
+		for (UpdateFailHTLC update_fail_htlcs_arg_conv_16: update_fail_htlcs_arg) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(update_fail_htlcs_arg_conv_16); }; };
+		for (UpdateFailMalformedHTLC update_fail_malformed_htlcs_arg_conv_25: update_fail_malformed_htlcs_arg) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(update_fail_malformed_htlcs_arg_conv_25); }; };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(update_fee_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(commitment_signed_arg); };
 		return ret_hu_conv;
 	}
 
@@ -215,7 +215,7 @@ public class CommitmentUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CommitmentUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CommitmentUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Confirm.java
+++ b/src/main/java/org/ldk/structs/Confirm.java
@@ -117,7 +117,7 @@ public class Confirm extends CommonBase {
 				for (int c = 0; c < txdata_conv_28_len; c++) {
 					long txdata_conv_28 = txdata[c];
 					TwoTuple_usizeTransactionZ txdata_conv_28_hu_conv = new TwoTuple_usizeTransactionZ(null, txdata_conv_28);
-					txdata_conv_28_hu_conv.ptrs_to.add(this);
+					if (txdata_conv_28_hu_conv != null) { txdata_conv_28_hu_conv.ptrs_to.add(this); };
 					txdata_conv_28_arr[c] = txdata_conv_28_hu_conv;
 				}
 				arg.transactions_confirmed(header, txdata_conv_28_arr, height);

--- a/src/main/java/org/ldk/structs/CounterpartyChannelTransactionParameters.java
+++ b/src/main/java/org/ldk/structs/CounterpartyChannelTransactionParameters.java
@@ -28,7 +28,7 @@ public class CounterpartyChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelPublicKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -39,7 +39,7 @@ public class CounterpartyChannelTransactionParameters extends CommonBase {
 		bindings.CounterpartyChannelTransactionParameters_set_pubkeys(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -69,8 +69,8 @@ public class CounterpartyChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(selected_contest_delay_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CounterpartyChannelTransactionParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CounterpartyChannelTransactionParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(pubkeys_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(pubkeys_arg); };
 		return ret_hu_conv;
 	}
 
@@ -88,7 +88,7 @@ public class CounterpartyChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CounterpartyChannelTransactionParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CounterpartyChannelTransactionParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/CounterpartyCommitmentSecrets.java
+++ b/src/main/java/org/ldk/structs/CounterpartyCommitmentSecrets.java
@@ -38,7 +38,7 @@ public class CounterpartyCommitmentSecrets extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CounterpartyCommitmentSecrets ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CounterpartyCommitmentSecrets(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -49,7 +49,7 @@ public class CounterpartyCommitmentSecrets extends CommonBase {
 		long ret = bindings.CounterpartyCommitmentSecrets_new();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CounterpartyCommitmentSecrets ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CounterpartyCommitmentSecrets(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/CounterpartyForwardingInfo.java
+++ b/src/main/java/org/ldk/structs/CounterpartyForwardingInfo.java
@@ -88,7 +88,7 @@ public class CounterpartyForwardingInfo extends CommonBase {
 		Reference.reachabilityFence(cltv_expiry_delta_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CounterpartyForwardingInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CounterpartyForwardingInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -106,7 +106,7 @@ public class CounterpartyForwardingInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.CounterpartyForwardingInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.CounterpartyForwardingInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/CustomMessageHandler.java
+++ b/src/main/java/org/ldk/structs/CustomMessageHandler.java
@@ -45,7 +45,7 @@ public class CustomMessageHandler extends CommonBase {
 		impl_holder.held = new CustomMessageHandler(new bindings.LDKCustomMessageHandler() {
 			@Override public long handle_custom_message(long msg, byte[] sender_node_id) {
 				Type ret_hu_conv = new Type(null, msg);
-				ret_hu_conv.ptrs_to.add(this);
+				if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 				Result_NoneLightningErrorZ ret = arg.handle_custom_message(ret_hu_conv, sender_node_id);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -81,7 +81,7 @@ public class CustomMessageHandler extends CommonBase {
 		Reference.reachabilityFence(sender_node_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -99,7 +99,7 @@ public class CustomMessageHandler extends CommonBase {
 		for (int z = 0; z < ret_conv_25_len; z++) {
 			long ret_conv_25 = ret[z];
 			TwoTuple_PublicKeyTypeZ ret_conv_25_hu_conv = new TwoTuple_PublicKeyTypeZ(null, ret_conv_25);
-			ret_conv_25_hu_conv.ptrs_to.add(this);
+			if (ret_conv_25_hu_conv != null) { ret_conv_25_hu_conv.ptrs_to.add(this); };
 			ret_conv_25_arr[z] = ret_conv_25_hu_conv;
 		}
 		return ret_conv_25_arr;

--- a/src/main/java/org/ldk/structs/DataLossProtect.java
+++ b/src/main/java/org/ldk/structs/DataLossProtect.java
@@ -70,7 +70,7 @@ public class DataLossProtect extends CommonBase {
 		Reference.reachabilityFence(my_current_per_commitment_point_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DataLossProtect ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DataLossProtect(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -88,7 +88,7 @@ public class DataLossProtect extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DataLossProtect ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DataLossProtect(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/DecodeError.java
+++ b/src/main/java/org/ldk/structs/DecodeError.java
@@ -34,7 +34,7 @@ public class DecodeError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DecodeError ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DecodeError(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/DefaultRouter.java
+++ b/src/main/java/org/ldk/structs/DefaultRouter.java
@@ -31,9 +31,9 @@ public class DefaultRouter extends CommonBase {
 		Reference.reachabilityFence(random_seed_bytes);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DefaultRouter ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DefaultRouter(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(network_graph);
-		ret_hu_conv.ptrs_to.add(logger);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(network_graph); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
 		return ret_hu_conv;
 	}
 
@@ -46,7 +46,7 @@ public class DefaultRouter extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Router ret_hu_conv = new Router(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/DelayedPaymentOutputDescriptor.java
+++ b/src/main/java/org/ldk/structs/DelayedPaymentOutputDescriptor.java
@@ -29,7 +29,7 @@ public class DelayedPaymentOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -40,7 +40,7 @@ public class DelayedPaymentOutputDescriptor extends CommonBase {
 		bindings.DelayedPaymentOutputDescriptor_set_outpoint(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -177,8 +177,8 @@ public class DelayedPaymentOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(channel_value_satoshis_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DelayedPaymentOutputDescriptor ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DelayedPaymentOutputDescriptor(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(outpoint_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(outpoint_arg); };
 		return ret_hu_conv;
 	}
 
@@ -196,7 +196,7 @@ public class DelayedPaymentOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DelayedPaymentOutputDescriptor ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DelayedPaymentOutputDescriptor(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Description.java
+++ b/src/main/java/org/ldk/structs/Description.java
@@ -37,7 +37,7 @@ public class Description extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Description ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Description(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Description extends CommonBase {
 		boolean ret = bindings.Description_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -90,7 +90,7 @@ public class Description extends CommonBase {
 	public String into_inner() {
 		String ret = bindings.Description_into_inner(this.ptr);
 		Reference.reachabilityFence(this);
-		this.ptrs_to.add(this);
+		if (this != null) { this.ptrs_to.add(this); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/DirectedChannelInfo.java
+++ b/src/main/java/org/ldk/structs/DirectedChannelInfo.java
@@ -35,7 +35,7 @@ public class DirectedChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.DirectedChannelInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.DirectedChannelInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -47,7 +47,7 @@ public class DirectedChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class DirectedChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdateInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdateInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -87,7 +87,7 @@ public class DirectedChannelInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.EffectiveCapacity ret_hu_conv = org.ldk.structs.EffectiveCapacity.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/DirectedChannelTransactionParameters.java
+++ b/src/main/java/org/ldk/structs/DirectedChannelTransactionParameters.java
@@ -32,7 +32,7 @@ public class DirectedChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelPublicKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -44,7 +44,7 @@ public class DirectedChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelPublicKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -78,7 +78,7 @@ public class DirectedChannelTransactionParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/EffectiveCapacity.java
+++ b/src/main/java/org/ldk/structs/EffectiveCapacity.java
@@ -87,7 +87,7 @@ public class EffectiveCapacity extends CommonBase {
 			this.capacity_msat = obj.capacity_msat;
 			long htlc_maximum_msat = obj.htlc_maximum_msat;
 			org.ldk.structs.Option_u64Z htlc_maximum_msat_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(htlc_maximum_msat);
-			htlc_maximum_msat_hu_conv.ptrs_to.add(this);
+			if (htlc_maximum_msat_hu_conv != null) { htlc_maximum_msat_hu_conv.ptrs_to.add(this); };
 			this.htlc_maximum_msat = htlc_maximum_msat_hu_conv;
 		}
 	}
@@ -123,7 +123,7 @@ public class EffectiveCapacity extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.EffectiveCapacity ret_hu_conv = org.ldk.structs.EffectiveCapacity.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -135,7 +135,7 @@ public class EffectiveCapacity extends CommonBase {
 		Reference.reachabilityFence(liquidity_msat);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.EffectiveCapacity ret_hu_conv = org.ldk.structs.EffectiveCapacity.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -147,7 +147,7 @@ public class EffectiveCapacity extends CommonBase {
 		Reference.reachabilityFence(amount_msat);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.EffectiveCapacity ret_hu_conv = org.ldk.structs.EffectiveCapacity.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -160,7 +160,7 @@ public class EffectiveCapacity extends CommonBase {
 		Reference.reachabilityFence(htlc_maximum_msat);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.EffectiveCapacity ret_hu_conv = org.ldk.structs.EffectiveCapacity.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -171,7 +171,7 @@ public class EffectiveCapacity extends CommonBase {
 		long ret = bindings.EffectiveCapacity_infinite();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.EffectiveCapacity ret_hu_conv = org.ldk.structs.EffectiveCapacity.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -182,7 +182,7 @@ public class EffectiveCapacity extends CommonBase {
 		long ret = bindings.EffectiveCapacity_unknown();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.EffectiveCapacity ret_hu_conv = org.ldk.structs.EffectiveCapacity.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ErrorAction.java
+++ b/src/main/java/org/ldk/structs/ErrorAction.java
@@ -56,7 +56,7 @@ public class ErrorAction extends CommonBase {
 			super(null, ptr);
 			long msg = obj.msg;
 			org.ldk.structs.ErrorMessage msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ErrorMessage(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -101,7 +101,7 @@ public class ErrorAction extends CommonBase {
 			super(null, ptr);
 			long msg = obj.msg;
 			org.ldk.structs.ErrorMessage msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ErrorMessage(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -123,7 +123,7 @@ public class ErrorAction extends CommonBase {
 			super(null, ptr);
 			long msg = obj.msg;
 			org.ldk.structs.WarningMessage msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.WarningMessage(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 			this.log_level = obj.log_level;
 		}
@@ -142,7 +142,7 @@ public class ErrorAction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorAction ret_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -154,8 +154,8 @@ public class ErrorAction extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorAction ret_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -166,7 +166,7 @@ public class ErrorAction extends CommonBase {
 		long ret = bindings.ErrorAction_ignore_error();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorAction ret_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -178,7 +178,7 @@ public class ErrorAction extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorAction ret_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -189,7 +189,7 @@ public class ErrorAction extends CommonBase {
 		long ret = bindings.ErrorAction_ignore_duplicate_gossip();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorAction ret_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -201,8 +201,8 @@ public class ErrorAction extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorAction ret_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -215,8 +215,8 @@ public class ErrorAction extends CommonBase {
 		Reference.reachabilityFence(log_level);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorAction ret_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ErrorMessage.java
+++ b/src/main/java/org/ldk/structs/ErrorMessage.java
@@ -77,7 +77,7 @@ public class ErrorMessage extends CommonBase {
 		Reference.reachabilityFence(data_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorMessage ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ErrorMessage(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -95,7 +95,7 @@ public class ErrorMessage extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorMessage ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ErrorMessage(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ErroringMessageHandler.java
+++ b/src/main/java/org/ldk/structs/ErroringMessageHandler.java
@@ -28,7 +28,7 @@ public class ErroringMessageHandler extends CommonBase {
 		long ret = bindings.ErroringMessageHandler_new();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErroringMessageHandler ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ErroringMessageHandler(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -41,7 +41,7 @@ public class ErroringMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		MessageSendEventsProvider ret_hu_conv = new MessageSendEventsProvider(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -54,7 +54,7 @@ public class ErroringMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ChannelMessageHandler ret_hu_conv = new ChannelMessageHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Event.java
+++ b/src/main/java/org/ldk/structs/Event.java
@@ -164,7 +164,7 @@ public class Event extends CommonBase {
 			this.amount_msat = obj.amount_msat;
 			long purpose = obj.purpose;
 			org.ldk.structs.PaymentPurpose purpose_hu_conv = org.ldk.structs.PaymentPurpose.constr_from_ptr(purpose);
-			purpose_hu_conv.ptrs_to.add(this);
+			if (purpose_hu_conv != null) { purpose_hu_conv.ptrs_to.add(this); };
 			this.purpose = purpose_hu_conv;
 		}
 	}
@@ -205,7 +205,7 @@ public class Event extends CommonBase {
 			this.amount_msat = obj.amount_msat;
 			long purpose = obj.purpose;
 			org.ldk.structs.PaymentPurpose purpose_hu_conv = org.ldk.structs.PaymentPurpose.constr_from_ptr(purpose);
-			purpose_hu_conv.ptrs_to.add(this);
+			if (purpose_hu_conv != null) { purpose_hu_conv.ptrs_to.add(this); };
 			this.purpose = purpose_hu_conv;
 		}
 	}
@@ -258,7 +258,7 @@ public class Event extends CommonBase {
 			this.payment_hash = obj.payment_hash;
 			long fee_paid_msat = obj.fee_paid_msat;
 			org.ldk.structs.Option_u64Z fee_paid_msat_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(fee_paid_msat);
-			fee_paid_msat_hu_conv.ptrs_to.add(this);
+			if (fee_paid_msat_hu_conv != null) { fee_paid_msat_hu_conv.ptrs_to.add(this); };
 			this.fee_paid_msat = fee_paid_msat_hu_conv;
 		}
 	}
@@ -333,7 +333,7 @@ public class Event extends CommonBase {
 			for (int k = 0; k < path_conv_10_len; k++) {
 				long path_conv_10 = path[k];
 				org.ldk.structs.RouteHop path_conv_10_hu_conv = null; if (path_conv_10 < 0 || path_conv_10 > 4096) { path_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, path_conv_10); }
-				path_conv_10_hu_conv.ptrs_to.add(this);
+				if (path_conv_10_hu_conv != null) { path_conv_10_hu_conv.ptrs_to.add(this); };
 				path_conv_10_arr[k] = path_conv_10_hu_conv;
 			}
 			this.path = path_conv_10_arr;
@@ -435,7 +435,7 @@ public class Event extends CommonBase {
 			this.rejected_by_dest = obj.rejected_by_dest;
 			long network_update = obj.network_update;
 			org.ldk.structs.Option_NetworkUpdateZ network_update_hu_conv = org.ldk.structs.Option_NetworkUpdateZ.constr_from_ptr(network_update);
-			network_update_hu_conv.ptrs_to.add(this);
+			if (network_update_hu_conv != null) { network_update_hu_conv.ptrs_to.add(this); };
 			this.network_update = network_update_hu_conv;
 			this.all_paths_failed = obj.all_paths_failed;
 			long[] path = obj.path;
@@ -444,17 +444,17 @@ public class Event extends CommonBase {
 			for (int k = 0; k < path_conv_10_len; k++) {
 				long path_conv_10 = path[k];
 				org.ldk.structs.RouteHop path_conv_10_hu_conv = null; if (path_conv_10 < 0 || path_conv_10 > 4096) { path_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, path_conv_10); }
-				path_conv_10_hu_conv.ptrs_to.add(this);
+				if (path_conv_10_hu_conv != null) { path_conv_10_hu_conv.ptrs_to.add(this); };
 				path_conv_10_arr[k] = path_conv_10_hu_conv;
 			}
 			this.path = path_conv_10_arr;
 			long short_channel_id = obj.short_channel_id;
 			org.ldk.structs.Option_u64Z short_channel_id_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(short_channel_id);
-			short_channel_id_hu_conv.ptrs_to.add(this);
+			if (short_channel_id_hu_conv != null) { short_channel_id_hu_conv.ptrs_to.add(this); };
 			this.short_channel_id = short_channel_id_hu_conv;
 			long retry = obj.retry;
 			org.ldk.structs.RouteParameters retry_hu_conv = null; if (retry < 0 || retry > 4096) { retry_hu_conv = new org.ldk.structs.RouteParameters(null, retry); }
-			retry_hu_conv.ptrs_to.add(this);
+			if (retry_hu_conv != null) { retry_hu_conv.ptrs_to.add(this); };
 			this.retry = retry_hu_conv;
 		}
 	}
@@ -488,7 +488,7 @@ public class Event extends CommonBase {
 			for (int k = 0; k < path_conv_10_len; k++) {
 				long path_conv_10 = path[k];
 				org.ldk.structs.RouteHop path_conv_10_hu_conv = null; if (path_conv_10 < 0 || path_conv_10 > 4096) { path_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, path_conv_10); }
-				path_conv_10_hu_conv.ptrs_to.add(this);
+				if (path_conv_10_hu_conv != null) { path_conv_10_hu_conv.ptrs_to.add(this); };
 				path_conv_10_arr[k] = path_conv_10_hu_conv;
 			}
 			this.path = path_conv_10_arr;
@@ -532,13 +532,13 @@ public class Event extends CommonBase {
 			for (int k = 0; k < path_conv_10_len; k++) {
 				long path_conv_10 = path[k];
 				org.ldk.structs.RouteHop path_conv_10_hu_conv = null; if (path_conv_10 < 0 || path_conv_10 > 4096) { path_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, path_conv_10); }
-				path_conv_10_hu_conv.ptrs_to.add(this);
+				if (path_conv_10_hu_conv != null) { path_conv_10_hu_conv.ptrs_to.add(this); };
 				path_conv_10_arr[k] = path_conv_10_hu_conv;
 			}
 			this.path = path_conv_10_arr;
 			long short_channel_id = obj.short_channel_id;
 			org.ldk.structs.Option_u64Z short_channel_id_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(short_channel_id);
-			short_channel_id_hu_conv.ptrs_to.add(this);
+			if (short_channel_id_hu_conv != null) { short_channel_id_hu_conv.ptrs_to.add(this); };
 			this.short_channel_id = short_channel_id_hu_conv;
 		}
 	}
@@ -581,7 +581,7 @@ public class Event extends CommonBase {
 			for (int b = 0; b < outputs_conv_27_len; b++) {
 				long outputs_conv_27 = outputs[b];
 				org.ldk.structs.SpendableOutputDescriptor outputs_conv_27_hu_conv = org.ldk.structs.SpendableOutputDescriptor.constr_from_ptr(outputs_conv_27);
-				outputs_conv_27_hu_conv.ptrs_to.add(this);
+				if (outputs_conv_27_hu_conv != null) { outputs_conv_27_hu_conv.ptrs_to.add(this); };
 				outputs_conv_27_arr[b] = outputs_conv_27_hu_conv;
 			}
 			this.outputs = outputs_conv_27_arr;
@@ -633,7 +633,7 @@ public class Event extends CommonBase {
 			this.next_channel_id = obj.next_channel_id;
 			long fee_earned_msat = obj.fee_earned_msat;
 			org.ldk.structs.Option_u64Z fee_earned_msat_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(fee_earned_msat);
-			fee_earned_msat_hu_conv.ptrs_to.add(this);
+			if (fee_earned_msat_hu_conv != null) { fee_earned_msat_hu_conv.ptrs_to.add(this); };
 			this.fee_earned_msat = fee_earned_msat_hu_conv;
 			this.claim_from_onchain_tx = obj.claim_from_onchain_tx;
 		}
@@ -670,7 +670,7 @@ public class Event extends CommonBase {
 			this.user_channel_id = obj.user_channel_id;
 			long reason = obj.reason;
 			org.ldk.structs.ClosureReason reason_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(reason);
-			reason_hu_conv.ptrs_to.add(this);
+			if (reason_hu_conv != null) { reason_hu_conv.ptrs_to.add(this); };
 			this.reason = reason_hu_conv;
 		}
 	}
@@ -764,7 +764,7 @@ public class Event extends CommonBase {
 			this.push_msat = obj.push_msat;
 			long channel_type = obj.channel_type;
 			org.ldk.structs.ChannelTypeFeatures channel_type_hu_conv = null; if (channel_type < 0 || channel_type > 4096) { channel_type_hu_conv = new org.ldk.structs.ChannelTypeFeatures(null, channel_type); }
-			channel_type_hu_conv.ptrs_to.add(this);
+			if (channel_type_hu_conv != null) { channel_type_hu_conv.ptrs_to.add(this); };
 			this.channel_type = channel_type_hu_conv;
 		}
 	}
@@ -796,7 +796,7 @@ public class Event extends CommonBase {
 			this.prev_channel_id = obj.prev_channel_id;
 			long failed_next_destination = obj.failed_next_destination;
 			org.ldk.structs.HTLCDestination failed_next_destination_hu_conv = org.ldk.structs.HTLCDestination.constr_from_ptr(failed_next_destination);
-			failed_next_destination_hu_conv.ptrs_to.add(this);
+			if (failed_next_destination_hu_conv != null) { failed_next_destination_hu_conv.ptrs_to.add(this); };
 			this.failed_next_destination = failed_next_destination_hu_conv;
 		}
 	}
@@ -814,7 +814,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -830,7 +830,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(user_channel_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -844,7 +844,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(purpose);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -858,7 +858,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(purpose);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -873,7 +873,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(fee_paid_msat);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -886,7 +886,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(payment_hash);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -900,8 +900,8 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(path);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		for (RouteHop path_conv_10: path) { ret_hu_conv.ptrs_to.add(path_conv_10); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		for (RouteHop path_conv_10: path) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(path_conv_10); }; };
 		return ret_hu_conv;
 	}
 
@@ -920,9 +920,9 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(retry);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		for (RouteHop path_conv_10: path) { ret_hu_conv.ptrs_to.add(path_conv_10); };
-		ret_hu_conv.ptrs_to.add(retry);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		for (RouteHop path_conv_10: path) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(path_conv_10); }; };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(retry); };
 		return ret_hu_conv;
 	}
 
@@ -936,8 +936,8 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(path);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		for (RouteHop path_conv_10: path) { ret_hu_conv.ptrs_to.add(path_conv_10); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		for (RouteHop path_conv_10: path) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(path_conv_10); }; };
 		return ret_hu_conv;
 	}
 
@@ -952,8 +952,8 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(short_channel_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		for (RouteHop path_conv_10: path) { ret_hu_conv.ptrs_to.add(path_conv_10); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		for (RouteHop path_conv_10: path) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(path_conv_10); }; };
 		return ret_hu_conv;
 	}
 
@@ -965,7 +965,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(time_forwardable);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -977,7 +977,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(outputs);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -992,7 +992,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(claim_from_onchain_tx);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -1006,7 +1006,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(reason);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -1019,7 +1019,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(transaction);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -1035,8 +1035,8 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(channel_type);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(channel_type);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channel_type); };
 		return ret_hu_conv;
 	}
 
@@ -1049,7 +1049,7 @@ public class Event extends CommonBase {
 		Reference.reachabilityFence(failed_next_destination);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Event ret_hu_conv = org.ldk.structs.Event.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/EventsProvider.java
+++ b/src/main/java/org/ldk/structs/EventsProvider.java
@@ -63,7 +63,7 @@ public class EventsProvider extends CommonBase {
 		impl_holder.held = new EventsProvider(new bindings.LDKEventsProvider() {
 			@Override public void process_pending_events(long handler) {
 				EventHandler ret_hu_conv = new EventHandler(null, handler);
-				ret_hu_conv.ptrs_to.add(this);
+				if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 				arg.process_pending_events(ret_hu_conv);
 				Reference.reachabilityFence(arg);
 			}
@@ -81,7 +81,7 @@ public class EventsProvider extends CommonBase {
 		bindings.EventsProvider_process_pending_events(this.ptr, handler == null ? 0 : handler.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(handler);
-		this.ptrs_to.add(handler);
+		if (this != null) { this.ptrs_to.add(handler); };
 	}
 
 }

--- a/src/main/java/org/ldk/structs/ExpandedKey.java
+++ b/src/main/java/org/ldk/structs/ExpandedKey.java
@@ -33,7 +33,7 @@ public class ExpandedKey extends CommonBase {
 		Reference.reachabilityFence(key_material);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ExpandedKey ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ExpandedKey(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ExpiryTime.java
+++ b/src/main/java/org/ldk/structs/ExpiryTime.java
@@ -35,7 +35,7 @@ public class ExpiryTime extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ExpiryTime ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ExpiryTime(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -60,7 +60,7 @@ public class ExpiryTime extends CommonBase {
 		boolean ret = bindings.ExpiryTime_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -76,7 +76,7 @@ public class ExpiryTime extends CommonBase {
 		Reference.reachabilityFence(seconds);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ExpiryTime ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ExpiryTime(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -88,7 +88,7 @@ public class ExpiryTime extends CommonBase {
 		Reference.reachabilityFence(duration);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ExpiryTime ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ExpiryTime(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Fallback.java
+++ b/src/main/java/org/ldk/structs/Fallback.java
@@ -72,7 +72,7 @@ public class Fallback extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Fallback ret_hu_conv = org.ldk.structs.Fallback.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -85,7 +85,7 @@ public class Fallback extends CommonBase {
 		Reference.reachabilityFence(program);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Fallback ret_hu_conv = org.ldk.structs.Fallback.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -97,7 +97,7 @@ public class Fallback extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Fallback ret_hu_conv = org.ldk.structs.Fallback.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -109,7 +109,7 @@ public class Fallback extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Fallback ret_hu_conv = org.ldk.structs.Fallback.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/FilesystemPersister.java
+++ b/src/main/java/org/ldk/structs/FilesystemPersister.java
@@ -40,7 +40,7 @@ public class FilesystemPersister extends CommonBase {
 		Reference.reachabilityFence(path_to_channel_data);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.FilesystemPersister ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.FilesystemPersister(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class FilesystemPersister extends CommonBase {
 		Reference.reachabilityFence(keys_manager);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ ret_hu_conv = Result_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(keys_manager);
+		if (this != null) { this.ptrs_to.add(keys_manager); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Filter.java
+++ b/src/main/java/org/ldk/structs/Filter.java
@@ -72,7 +72,7 @@ public class Filter extends CommonBase {
 			}
 			@Override public long register_output(long output) {
 				org.ldk.structs.WatchedOutput output_hu_conv = null; if (output < 0 || output > 4096) { output_hu_conv = new org.ldk.structs.WatchedOutput(null, output); }
-				output_hu_conv.ptrs_to.add(this);
+				if (output_hu_conv != null) { output_hu_conv.ptrs_to.add(this); };
 				Option_C2Tuple_usizeTransactionZZ ret = arg.register_output(output_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -109,8 +109,8 @@ public class Filter extends CommonBase {
 		Reference.reachabilityFence(output);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_C2Tuple_usizeTransactionZZ ret_hu_conv = org.ldk.structs.Option_C2Tuple_usizeTransactionZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
-		this.ptrs_to.add(output);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
+		if (this != null) { this.ptrs_to.add(output); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/FixedPenaltyScorer.java
+++ b/src/main/java/org/ldk/structs/FixedPenaltyScorer.java
@@ -34,7 +34,7 @@ public class FixedPenaltyScorer extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.FixedPenaltyScorer ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.FixedPenaltyScorer(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -46,7 +46,7 @@ public class FixedPenaltyScorer extends CommonBase {
 		Reference.reachabilityFence(penalty_msat);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.FixedPenaltyScorer ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.FixedPenaltyScorer(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -59,7 +59,7 @@ public class FixedPenaltyScorer extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Score ret_hu_conv = new Score(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/FundingCreated.java
+++ b/src/main/java/org/ldk/structs/FundingCreated.java
@@ -103,7 +103,7 @@ public class FundingCreated extends CommonBase {
 		Reference.reachabilityFence(signature_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.FundingCreated ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.FundingCreated(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -121,7 +121,7 @@ public class FundingCreated extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.FundingCreated ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.FundingCreated(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/FundingSigned.java
+++ b/src/main/java/org/ldk/structs/FundingSigned.java
@@ -65,7 +65,7 @@ public class FundingSigned extends CommonBase {
 		Reference.reachabilityFence(signature_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.FundingSigned ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.FundingSigned(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -83,7 +83,7 @@ public class FundingSigned extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.FundingSigned ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.FundingSigned(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/GossipSync.java
+++ b/src/main/java/org/ldk/structs/GossipSync.java
@@ -42,7 +42,7 @@ public class GossipSync extends CommonBase {
 			super(null, ptr);
 			long p2p = obj.p2p;
 			org.ldk.structs.P2PGossipSync p2p_hu_conv = null; if (p2p < 0 || p2p > 4096) { p2p_hu_conv = new org.ldk.structs.P2PGossipSync(null, p2p); }
-			p2p_hu_conv.ptrs_to.add(this);
+			if (p2p_hu_conv != null) { p2p_hu_conv.ptrs_to.add(this); };
 			this.p2p = p2p_hu_conv;
 		}
 	}
@@ -55,7 +55,7 @@ public class GossipSync extends CommonBase {
 			super(null, ptr);
 			long rapid = obj.rapid;
 			org.ldk.structs.RapidGossipSync rapid_hu_conv = null; if (rapid < 0 || rapid > 4096) { rapid_hu_conv = new org.ldk.structs.RapidGossipSync(null, rapid); }
-			rapid_hu_conv.ptrs_to.add(this);
+			if (rapid_hu_conv != null) { rapid_hu_conv.ptrs_to.add(this); };
 			this.rapid = rapid_hu_conv;
 		}
 	}
@@ -75,8 +75,8 @@ public class GossipSync extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.GossipSync ret_hu_conv = org.ldk.structs.GossipSync.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 
@@ -88,8 +88,8 @@ public class GossipSync extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.GossipSync ret_hu_conv = org.ldk.structs.GossipSync.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 
@@ -100,7 +100,7 @@ public class GossipSync extends CommonBase {
 		long ret = bindings.GossipSync_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.GossipSync ret_hu_conv = org.ldk.structs.GossipSync.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/GossipTimestampFilter.java
+++ b/src/main/java/org/ldk/structs/GossipTimestampFilter.java
@@ -86,7 +86,7 @@ public class GossipTimestampFilter extends CommonBase {
 		Reference.reachabilityFence(timestamp_range_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.GossipTimestampFilter ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.GossipTimestampFilter(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -104,7 +104,7 @@ public class GossipTimestampFilter extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.GossipTimestampFilter ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.GossipTimestampFilter(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/GraphSyncError.java
+++ b/src/main/java/org/ldk/structs/GraphSyncError.java
@@ -40,7 +40,7 @@ public class GraphSyncError extends CommonBase {
 			super(null, ptr);
 			long decode_error = obj.decode_error;
 			org.ldk.structs.DecodeError decode_error_hu_conv = null; if (decode_error < 0 || decode_error > 4096) { decode_error_hu_conv = new org.ldk.structs.DecodeError(null, decode_error); }
-			decode_error_hu_conv.ptrs_to.add(this);
+			if (decode_error_hu_conv != null) { decode_error_hu_conv.ptrs_to.add(this); };
 			this.decode_error = decode_error_hu_conv;
 		}
 	}
@@ -54,7 +54,7 @@ public class GraphSyncError extends CommonBase {
 			super(null, ptr);
 			long lightning_error = obj.lightning_error;
 			org.ldk.structs.LightningError lightning_error_hu_conv = null; if (lightning_error < 0 || lightning_error > 4096) { lightning_error_hu_conv = new org.ldk.structs.LightningError(null, lightning_error); }
-			lightning_error_hu_conv.ptrs_to.add(this);
+			if (lightning_error_hu_conv != null) { lightning_error_hu_conv.ptrs_to.add(this); };
 			this.lightning_error = lightning_error_hu_conv;
 		}
 	}
@@ -72,7 +72,7 @@ public class GraphSyncError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.GraphSyncError ret_hu_conv = org.ldk.structs.GraphSyncError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -84,8 +84,8 @@ public class GraphSyncError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.GraphSyncError ret_hu_conv = org.ldk.structs.GraphSyncError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 
@@ -97,8 +97,8 @@ public class GraphSyncError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.GraphSyncError ret_hu_conv = org.ldk.structs.GraphSyncError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/HTLCDestination.java
+++ b/src/main/java/org/ldk/structs/HTLCDestination.java
@@ -102,7 +102,7 @@ public class HTLCDestination extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HTLCDestination ret_hu_conv = org.ldk.structs.HTLCDestination.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -115,7 +115,7 @@ public class HTLCDestination extends CommonBase {
 		Reference.reachabilityFence(channel_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HTLCDestination ret_hu_conv = org.ldk.structs.HTLCDestination.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -127,7 +127,7 @@ public class HTLCDestination extends CommonBase {
 		Reference.reachabilityFence(requested_forward_scid);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HTLCDestination ret_hu_conv = org.ldk.structs.HTLCDestination.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -139,7 +139,7 @@ public class HTLCDestination extends CommonBase {
 		Reference.reachabilityFence(payment_hash);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HTLCDestination ret_hu_conv = org.ldk.structs.HTLCDestination.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/HTLCOutputInCommitment.java
+++ b/src/main/java/org/ldk/structs/HTLCOutputInCommitment.java
@@ -110,7 +110,7 @@ public class HTLCOutputInCommitment extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u32Z ret_hu_conv = org.ldk.structs.Option_u32Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -137,7 +137,7 @@ public class HTLCOutputInCommitment extends CommonBase {
 		Reference.reachabilityFence(transaction_output_index_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HTLCOutputInCommitment ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.HTLCOutputInCommitment(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -155,7 +155,7 @@ public class HTLCOutputInCommitment extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HTLCOutputInCommitment ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.HTLCOutputInCommitment(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/HTLCUpdate.java
+++ b/src/main/java/org/ldk/structs/HTLCUpdate.java
@@ -36,7 +36,7 @@ public class HTLCUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HTLCUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.HTLCUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/HolderCommitmentTransaction.java
+++ b/src/main/java/org/ldk/structs/HolderCommitmentTransaction.java
@@ -74,7 +74,7 @@ public class HolderCommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HolderCommitmentTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.HolderCommitmentTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -111,8 +111,8 @@ public class HolderCommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(counterparty_funding_key);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.HolderCommitmentTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.HolderCommitmentTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(commitment_tx);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(commitment_tx); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Hostname.java
+++ b/src/main/java/org/ldk/structs/Hostname.java
@@ -38,7 +38,7 @@ public class Hostname extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Hostname ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Hostname(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/IgnoringMessageHandler.java
+++ b/src/main/java/org/ldk/structs/IgnoringMessageHandler.java
@@ -28,7 +28,7 @@ public class IgnoringMessageHandler extends CommonBase {
 		long ret = bindings.IgnoringMessageHandler_new();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.IgnoringMessageHandler ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.IgnoringMessageHandler(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -41,7 +41,7 @@ public class IgnoringMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		MessageSendEventsProvider ret_hu_conv = new MessageSendEventsProvider(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -54,7 +54,7 @@ public class IgnoringMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		RoutingMessageHandler ret_hu_conv = new RoutingMessageHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -67,7 +67,7 @@ public class IgnoringMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		CustomMessageReader ret_hu_conv = new CustomMessageReader(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -80,7 +80,7 @@ public class IgnoringMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		CustomMessageHandler ret_hu_conv = new CustomMessageHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/InMemorySigner.java
+++ b/src/main/java/org/ldk/structs/InMemorySigner.java
@@ -145,7 +145,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InMemorySigner ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InMemorySigner(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -165,7 +165,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(channel_keys_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InMemorySigner ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InMemorySigner(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -178,7 +178,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelPublicKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -225,7 +225,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -240,7 +240,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTransactionParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTransactionParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -270,7 +270,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(descriptor);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CVec_CVec_u8ZZNoneZ ret_hu_conv = Result_CVec_CVec_u8ZZNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(descriptor);
+		if (this != null) { this.ptrs_to.add(descriptor); };
 		return ret_hu_conv;
 	}
 
@@ -291,7 +291,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(descriptor);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CVec_CVec_u8ZZNoneZ ret_hu_conv = Result_CVec_CVec_u8ZZNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(descriptor);
+		if (this != null) { this.ptrs_to.add(descriptor); };
 		return ret_hu_conv;
 	}
 
@@ -304,7 +304,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		BaseSign ret_hu_conv = new BaseSign(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -317,7 +317,7 @@ public class InMemorySigner extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Sign ret_hu_conv = new Sign(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Init.java
+++ b/src/main/java/org/ldk/structs/Init.java
@@ -28,7 +28,7 @@ public class Init extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InitFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InitFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -39,7 +39,7 @@ public class Init extends CommonBase {
 		bindings.Init_set_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -53,7 +53,7 @@ public class Init extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_NetAddressZ ret_hu_conv = org.ldk.structs.Option_NetAddressZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -78,8 +78,8 @@ public class Init extends CommonBase {
 		Reference.reachabilityFence(remote_network_address_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Init ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Init(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(features_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(features_arg); };
 		return ret_hu_conv;
 	}
 
@@ -97,7 +97,7 @@ public class Init extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Init ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Init(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/InitFeatures.java
+++ b/src/main/java/org/ldk/structs/InitFeatures.java
@@ -29,7 +29,7 @@ public class InitFeatures extends CommonBase {
 		boolean ret = bindings.InitFeatures_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -51,7 +51,7 @@ public class InitFeatures extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InitFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InitFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class InitFeatures extends CommonBase {
 		long ret = bindings.InitFeatures_empty();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InitFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InitFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -73,7 +73,7 @@ public class InitFeatures extends CommonBase {
 		long ret = bindings.InitFeatures_known();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InitFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InitFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/InvalidShutdownScript.java
+++ b/src/main/java/org/ldk/structs/InvalidShutdownScript.java
@@ -50,7 +50,7 @@ public class InvalidShutdownScript extends CommonBase {
 		Reference.reachabilityFence(script_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvalidShutdownScript ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvalidShutdownScript(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -68,7 +68,7 @@ public class InvalidShutdownScript extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvalidShutdownScript ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvalidShutdownScript(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Invoice.java
+++ b/src/main/java/org/ldk/structs/Invoice.java
@@ -34,7 +34,7 @@ public class Invoice extends CommonBase {
 		boolean ret = bindings.Invoice_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -56,7 +56,7 @@ public class Invoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Invoice ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Invoice(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -68,8 +68,8 @@ public class Invoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SignedRawInvoice ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.SignedRawInvoice(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
-		this.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
+		if (this != null) { this.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -111,7 +111,7 @@ public class Invoice extends CommonBase {
 		Reference.reachabilityFence(signed_invoice);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSemanticErrorZ ret_hu_conv = Result_InvoiceSemanticErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(signed_invoice);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(signed_invoice); };
 		return ret_hu_conv;
 	}
 
@@ -174,7 +174,7 @@ public class Invoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -237,7 +237,7 @@ public class Invoice extends CommonBase {
 		for (int o = 0; o < ret_conv_14_len; o++) {
 			long ret_conv_14 = ret[o];
 			org.ldk.structs.PrivateRoute ret_conv_14_hu_conv = null; if (ret_conv_14 < 0 || ret_conv_14 > 4096) { ret_conv_14_hu_conv = new org.ldk.structs.PrivateRoute(null, ret_conv_14); }
-			ret_conv_14_hu_conv.ptrs_to.add(this);
+			if (ret_conv_14_hu_conv != null) { ret_conv_14_hu_conv.ptrs_to.add(this); };
 			ret_conv_14_arr[o] = ret_conv_14_hu_conv;
 		}
 		return ret_conv_14_arr;
@@ -254,7 +254,7 @@ public class Invoice extends CommonBase {
 		for (int l = 0; l < ret_conv_11_len; l++) {
 			long ret_conv_11 = ret[l];
 			org.ldk.structs.RouteHint ret_conv_11_hu_conv = null; if (ret_conv_11 < 0 || ret_conv_11 > 4096) { ret_conv_11_hu_conv = new org.ldk.structs.RouteHint(null, ret_conv_11); }
-			ret_conv_11_hu_conv.ptrs_to.add(this);
+			if (ret_conv_11_hu_conv != null) { ret_conv_11_hu_conv.ptrs_to.add(this); };
 			ret_conv_11_arr[l] = ret_conv_11_hu_conv;
 		}
 		return ret_conv_11_arr;
@@ -277,7 +277,7 @@ public class Invoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/InvoiceFeatures.java
+++ b/src/main/java/org/ldk/structs/InvoiceFeatures.java
@@ -29,7 +29,7 @@ public class InvoiceFeatures extends CommonBase {
 		boolean ret = bindings.InvoiceFeatures_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -51,7 +51,7 @@ public class InvoiceFeatures extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class InvoiceFeatures extends CommonBase {
 		long ret = bindings.InvoiceFeatures_empty();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -73,7 +73,7 @@ public class InvoiceFeatures extends CommonBase {
 		long ret = bindings.InvoiceFeatures_known();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/InvoicePayer.java
+++ b/src/main/java/org/ldk/structs/InvoicePayer.java
@@ -40,12 +40,12 @@ public class InvoicePayer extends CommonBase {
 		Reference.reachabilityFence(retry);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoicePayer ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoicePayer(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(payer);
-		ret_hu_conv.ptrs_to.add(router);
-		ret_hu_conv.ptrs_to.add(scorer);
-		ret_hu_conv.ptrs_to.add(logger);
-		ret_hu_conv.ptrs_to.add(event_handler);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(payer); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(router); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(scorer); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(event_handler); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class InvoicePayer extends CommonBase {
 		Reference.reachabilityFence(invoice);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentIdPaymentErrorZ ret_hu_conv = Result_PaymentIdPaymentErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(invoice);
+		if (this != null) { this.ptrs_to.add(invoice); };
 		return ret_hu_conv;
 	}
 
@@ -81,7 +81,7 @@ public class InvoicePayer extends CommonBase {
 		Reference.reachabilityFence(amount_msats);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentIdPaymentErrorZ ret_hu_conv = Result_PaymentIdPaymentErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(invoice);
+		if (this != null) { this.ptrs_to.add(invoice); };
 		return ret_hu_conv;
 	}
 
@@ -125,7 +125,7 @@ public class InvoicePayer extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		EventHandler ret_hu_conv = new EventHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/InvoiceSignature.java
+++ b/src/main/java/org/ldk/structs/InvoiceSignature.java
@@ -34,7 +34,7 @@ public class InvoiceSignature extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceSignature ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceSignature(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -47,7 +47,7 @@ public class InvoiceSignature extends CommonBase {
 		boolean ret = bindings.InvoiceSignature_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/KeysInterface.java
+++ b/src/main/java/org/ldk/structs/KeysInterface.java
@@ -120,7 +120,7 @@ public class KeysInterface extends CommonBase {
 				Sign ret = arg.get_channel_signer(inbound, channel_value_satoshis);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
-				impl_holder.held.ptrs_to.add(ret);
+				if (impl_holder.held != null) { impl_holder.held.ptrs_to.add(ret); };
 				return result;
 			}
 			@Override public byte[] get_secure_random_bytes() {
@@ -197,7 +197,7 @@ public class KeysInterface extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ShutdownScript ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ShutdownScript(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -214,7 +214,7 @@ public class KeysInterface extends CommonBase {
 		Reference.reachabilityFence(channel_value_satoshis);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Sign ret_hu_conv = new Sign(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/KeysManager.java
+++ b/src/main/java/org/ldk/structs/KeysManager.java
@@ -60,7 +60,7 @@ public class KeysManager extends CommonBase {
 		Reference.reachabilityFence(starting_time_nanos);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.KeysManager ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.KeysManager(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -78,7 +78,7 @@ public class KeysManager extends CommonBase {
 		Reference.reachabilityFence(params);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InMemorySigner ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InMemorySigner(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -117,7 +117,7 @@ public class KeysManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		KeysInterface ret_hu_conv = new KeysInterface(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/LightningError.java
+++ b/src/main/java/org/ldk/structs/LightningError.java
@@ -46,7 +46,7 @@ public class LightningError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ErrorAction ret_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -68,7 +68,7 @@ public class LightningError extends CommonBase {
 		Reference.reachabilityFence(action_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.LightningError ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.LightningError(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -86,7 +86,7 @@ public class LightningError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.LightningError ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.LightningError(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Listen.java
+++ b/src/main/java/org/ldk/structs/Listen.java
@@ -59,7 +59,7 @@ public class Listen extends CommonBase {
 				for (int c = 0; c < txdata_conv_28_len; c++) {
 					long txdata_conv_28 = txdata[c];
 					TwoTuple_usizeTransactionZ txdata_conv_28_hu_conv = new TwoTuple_usizeTransactionZ(null, txdata_conv_28);
-					txdata_conv_28_hu_conv.ptrs_to.add(this);
+					if (txdata_conv_28_hu_conv != null) { txdata_conv_28_hu_conv.ptrs_to.add(this); };
 					txdata_conv_28_arr[c] = txdata_conv_28_hu_conv;
 				}
 				arg.filtered_block_connected(header, txdata_conv_28_arr, height);

--- a/src/main/java/org/ldk/structs/LockableScore.java
+++ b/src/main/java/org/ldk/structs/LockableScore.java
@@ -45,7 +45,7 @@ public class LockableScore extends CommonBase {
 				Score ret = arg.lock();
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.ptr;
-				impl_holder.held.ptrs_to.add(ret);
+				if (impl_holder.held != null) { impl_holder.held.ptrs_to.add(ret); };
 				return result;
 			}
 		});
@@ -59,7 +59,7 @@ public class LockableScore extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Score ret_hu_conv = new Score(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/MessageHandler.java
+++ b/src/main/java/org/ldk/structs/MessageHandler.java
@@ -31,7 +31,7 @@ public class MessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ChannelMessageHandler ret_hu_conv = new ChannelMessageHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -45,7 +45,7 @@ public class MessageHandler extends CommonBase {
 		bindings.MessageHandler_set_chan_handler(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -59,7 +59,7 @@ public class MessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		RoutingMessageHandler ret_hu_conv = new RoutingMessageHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -73,7 +73,7 @@ public class MessageHandler extends CommonBase {
 		bindings.MessageHandler_set_route_handler(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -85,9 +85,9 @@ public class MessageHandler extends CommonBase {
 		Reference.reachabilityFence(route_handler_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageHandler ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.MessageHandler(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(chan_handler_arg);
-		ret_hu_conv.ptrs_to.add(route_handler_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(chan_handler_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(route_handler_arg); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/MessageSendEvent.java
+++ b/src/main/java/org/ldk/structs/MessageSendEvent.java
@@ -104,7 +104,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.AcceptChannel msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.AcceptChannel(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -126,7 +126,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.OpenChannel msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.OpenChannel(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -147,7 +147,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.FundingCreated msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.FundingCreated(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -168,7 +168,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.FundingSigned msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.FundingSigned(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -189,7 +189,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.ChannelReady msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ChannelReady(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -210,7 +210,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.AnnouncementSignatures msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.AnnouncementSignatures(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -232,7 +232,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long updates = obj.updates;
 			org.ldk.structs.CommitmentUpdate updates_hu_conv = null; if (updates < 0 || updates > 4096) { updates_hu_conv = new org.ldk.structs.CommitmentUpdate(null, updates); }
-			updates_hu_conv.ptrs_to.add(this);
+			if (updates_hu_conv != null) { updates_hu_conv.ptrs_to.add(this); };
 			this.updates = updates_hu_conv;
 		}
 	}
@@ -253,7 +253,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.RevokeAndACK msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.RevokeAndACK(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -274,7 +274,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.ClosingSigned msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ClosingSigned(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -295,7 +295,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.Shutdown msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.Shutdown(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -316,7 +316,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.ChannelReestablish msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ChannelReestablish(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -343,11 +343,11 @@ public class MessageSendEvent extends CommonBase {
 			super(null, ptr);
 			long msg = obj.msg;
 			org.ldk.structs.ChannelAnnouncement msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ChannelAnnouncement(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 			long update_msg = obj.update_msg;
 			org.ldk.structs.ChannelUpdate update_msg_hu_conv = null; if (update_msg < 0 || update_msg > 4096) { update_msg_hu_conv = new org.ldk.structs.ChannelUpdate(null, update_msg); }
-			update_msg_hu_conv.ptrs_to.add(this);
+			if (update_msg_hu_conv != null) { update_msg_hu_conv.ptrs_to.add(this); };
 			this.update_msg = update_msg_hu_conv;
 		}
 	}
@@ -363,7 +363,7 @@ public class MessageSendEvent extends CommonBase {
 			super(null, ptr);
 			long msg = obj.msg;
 			org.ldk.structs.NodeAnnouncement msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.NodeAnnouncement(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -379,7 +379,7 @@ public class MessageSendEvent extends CommonBase {
 			super(null, ptr);
 			long msg = obj.msg;
 			org.ldk.structs.ChannelUpdate msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ChannelUpdate(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -402,7 +402,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.ChannelUpdate msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ChannelUpdate(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -423,7 +423,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long action = obj.action;
 			org.ldk.structs.ErrorAction action_hu_conv = org.ldk.structs.ErrorAction.constr_from_ptr(action);
-			action_hu_conv.ptrs_to.add(this);
+			if (action_hu_conv != null) { action_hu_conv.ptrs_to.add(this); };
 			this.action = action_hu_conv;
 		}
 	}
@@ -444,7 +444,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.QueryChannelRange msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.QueryChannelRange(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -466,7 +466,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.QueryShortChannelIds msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.QueryShortChannelIds(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -488,7 +488,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.ReplyChannelRange msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ReplyChannelRange(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -510,7 +510,7 @@ public class MessageSendEvent extends CommonBase {
 			this.node_id = obj.node_id;
 			long msg = obj.msg;
 			org.ldk.structs.GossipTimestampFilter msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.GossipTimestampFilter(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -528,7 +528,7 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -541,8 +541,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -555,8 +555,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -569,8 +569,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -583,8 +583,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -597,8 +597,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -611,8 +611,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -625,8 +625,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(updates);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(updates);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(updates); };
 		return ret_hu_conv;
 	}
 
@@ -639,8 +639,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -653,8 +653,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -667,8 +667,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -681,8 +681,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -695,9 +695,9 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(update_msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
-		ret_hu_conv.ptrs_to.add(update_msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(update_msg); };
 		return ret_hu_conv;
 	}
 
@@ -709,8 +709,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -722,8 +722,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -736,8 +736,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -750,7 +750,7 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(action);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -763,8 +763,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -777,8 +777,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -791,8 +791,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -805,8 +805,8 @@ public class MessageSendEvent extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MessageSendEvent ret_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/MessageSendEventsProvider.java
+++ b/src/main/java/org/ldk/structs/MessageSendEventsProvider.java
@@ -56,7 +56,7 @@ public class MessageSendEventsProvider extends CommonBase {
 		for (int s = 0; s < ret_conv_18_len; s++) {
 			long ret_conv_18 = ret[s];
 			org.ldk.structs.MessageSendEvent ret_conv_18_hu_conv = org.ldk.structs.MessageSendEvent.constr_from_ptr(ret_conv_18);
-			ret_conv_18_hu_conv.ptrs_to.add(this);
+			if (ret_conv_18_hu_conv != null) { ret_conv_18_hu_conv.ptrs_to.add(this); };
 			ret_conv_18_arr[s] = ret_conv_18_hu_conv;
 		}
 		return ret_conv_18_arr;

--- a/src/main/java/org/ldk/structs/MinFinalCltvExpiry.java
+++ b/src/main/java/org/ldk/structs/MinFinalCltvExpiry.java
@@ -40,7 +40,7 @@ public class MinFinalCltvExpiry extends CommonBase {
 		Reference.reachabilityFence(a_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MinFinalCltvExpiry ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.MinFinalCltvExpiry(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -58,7 +58,7 @@ public class MinFinalCltvExpiry extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MinFinalCltvExpiry ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.MinFinalCltvExpiry(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -83,7 +83,7 @@ public class MinFinalCltvExpiry extends CommonBase {
 		boolean ret = bindings.MinFinalCltvExpiry_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/MonitorEvent.java
+++ b/src/main/java/org/ldk/structs/MonitorEvent.java
@@ -45,7 +45,7 @@ public class MonitorEvent extends CommonBase {
 			super(null, ptr);
 			long htlc_event = obj.htlc_event;
 			org.ldk.structs.HTLCUpdate htlc_event_hu_conv = null; if (htlc_event < 0 || htlc_event > 4096) { htlc_event_hu_conv = new org.ldk.structs.HTLCUpdate(null, htlc_event); }
-			htlc_event_hu_conv.ptrs_to.add(this);
+			if (htlc_event_hu_conv != null) { htlc_event_hu_conv.ptrs_to.add(this); };
 			this.htlc_event = htlc_event_hu_conv;
 		}
 	}
@@ -58,7 +58,7 @@ public class MonitorEvent extends CommonBase {
 			super(null, ptr);
 			long commitment_tx_confirmed = obj.commitment_tx_confirmed;
 			org.ldk.structs.OutPoint commitment_tx_confirmed_hu_conv = null; if (commitment_tx_confirmed < 0 || commitment_tx_confirmed > 4096) { commitment_tx_confirmed_hu_conv = new org.ldk.structs.OutPoint(null, commitment_tx_confirmed); }
-			commitment_tx_confirmed_hu_conv.ptrs_to.add(this);
+			if (commitment_tx_confirmed_hu_conv != null) { commitment_tx_confirmed_hu_conv.ptrs_to.add(this); };
 			this.commitment_tx_confirmed = commitment_tx_confirmed_hu_conv;
 		}
 	}
@@ -85,7 +85,7 @@ public class MonitorEvent extends CommonBase {
 			super(null, ptr);
 			long funding_txo = obj.funding_txo;
 			org.ldk.structs.OutPoint funding_txo_hu_conv = null; if (funding_txo < 0 || funding_txo > 4096) { funding_txo_hu_conv = new org.ldk.structs.OutPoint(null, funding_txo); }
-			funding_txo_hu_conv.ptrs_to.add(this);
+			if (funding_txo_hu_conv != null) { funding_txo_hu_conv.ptrs_to.add(this); };
 			this.funding_txo = funding_txo_hu_conv;
 			this.monitor_update_id = obj.monitor_update_id;
 		}
@@ -102,7 +102,7 @@ public class MonitorEvent extends CommonBase {
 			super(null, ptr);
 			long update_failed = obj.update_failed;
 			org.ldk.structs.OutPoint update_failed_hu_conv = null; if (update_failed < 0 || update_failed > 4096) { update_failed_hu_conv = new org.ldk.structs.OutPoint(null, update_failed); }
-			update_failed_hu_conv.ptrs_to.add(this);
+			if (update_failed_hu_conv != null) { update_failed_hu_conv.ptrs_to.add(this); };
 			this.update_failed = update_failed_hu_conv;
 		}
 	}
@@ -120,7 +120,7 @@ public class MonitorEvent extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MonitorEvent ret_hu_conv = org.ldk.structs.MonitorEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -132,8 +132,8 @@ public class MonitorEvent extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MonitorEvent ret_hu_conv = org.ldk.structs.MonitorEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 
@@ -145,8 +145,8 @@ public class MonitorEvent extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MonitorEvent ret_hu_conv = org.ldk.structs.MonitorEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 
@@ -159,8 +159,8 @@ public class MonitorEvent extends CommonBase {
 		Reference.reachabilityFence(monitor_update_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MonitorEvent ret_hu_conv = org.ldk.structs.MonitorEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(funding_txo);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(funding_txo); };
 		return ret_hu_conv;
 	}
 
@@ -172,8 +172,8 @@ public class MonitorEvent extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MonitorEvent ret_hu_conv = org.ldk.structs.MonitorEvent.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/MonitorUpdateId.java
+++ b/src/main/java/org/ldk/structs/MonitorUpdateId.java
@@ -34,7 +34,7 @@ public class MonitorUpdateId extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MonitorUpdateId ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.MonitorUpdateId(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -59,7 +59,7 @@ public class MonitorUpdateId extends CommonBase {
 		boolean ret = bindings.MonitorUpdateId_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/MultiThreadedLockableScore.java
+++ b/src/main/java/org/ldk/structs/MultiThreadedLockableScore.java
@@ -37,8 +37,8 @@ public class MultiThreadedLockableScore extends CommonBase {
 		Reference.reachabilityFence(score);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MultiThreadedLockableScore ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.MultiThreadedLockableScore(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(score);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(score); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NetAddress.java
+++ b/src/main/java/org/ldk/structs/NetAddress.java
@@ -134,7 +134,7 @@ public class NetAddress extends CommonBase {
 			super(null, ptr);
 			long hostname = obj.hostname;
 			org.ldk.structs.Hostname hostname_hu_conv = null; if (hostname < 0 || hostname > 4096) { hostname_hu_conv = new org.ldk.structs.Hostname(null, hostname); }
-			hostname_hu_conv.ptrs_to.add(this);
+			if (hostname_hu_conv != null) { hostname_hu_conv.ptrs_to.add(this); };
 			this.hostname = hostname_hu_conv;
 			this.port = obj.port;
 		}
@@ -153,7 +153,7 @@ public class NetAddress extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetAddress ret_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -166,7 +166,7 @@ public class NetAddress extends CommonBase {
 		Reference.reachabilityFence(port);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetAddress ret_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -179,7 +179,7 @@ public class NetAddress extends CommonBase {
 		Reference.reachabilityFence(port);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetAddress ret_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -191,7 +191,7 @@ public class NetAddress extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetAddress ret_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -206,7 +206,7 @@ public class NetAddress extends CommonBase {
 		Reference.reachabilityFence(port);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetAddress ret_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -219,8 +219,8 @@ public class NetAddress extends CommonBase {
 		Reference.reachabilityFence(port);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetAddress ret_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(hostname);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(hostname); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NetworkGraph.java
+++ b/src/main/java/org/ldk/structs/NetworkGraph.java
@@ -29,7 +29,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		EventHandler ret_hu_conv = new EventHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -51,7 +51,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NetworkGraphDecodeErrorZ ret_hu_conv = Result_NetworkGraphDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg); };
 		return ret_hu_conv;
 	}
 
@@ -64,8 +64,8 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(logger);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetworkGraph ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NetworkGraph(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(logger);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
 		return ret_hu_conv;
 	}
 
@@ -77,7 +77,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ReadOnlyNetworkGraph ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ReadOnlyNetworkGraph(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -90,7 +90,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u32Z ret_hu_conv = org.ldk.structs.Option_u32Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -118,7 +118,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -134,7 +134,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -155,8 +155,8 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(chain_access);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
-		this.ptrs_to.add(chain_access);
+		if (this != null) { this.ptrs_to.add(msg); };
+		if (this != null) { this.ptrs_to.add(chain_access); };
 		return ret_hu_conv;
 	}
 
@@ -175,8 +175,8 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(chain_access);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
-		this.ptrs_to.add(chain_access);
+		if (this != null) { this.ptrs_to.add(msg); };
+		if (this != null) { this.ptrs_to.add(chain_access); };
 		return ret_hu_conv;
 	}
 
@@ -198,7 +198,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(node_id_2);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(features);
+		if (this != null) { this.ptrs_to.add(features); };
 		return ret_hu_conv;
 	}
 
@@ -280,7 +280,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -298,7 +298,7 @@ public class NetworkGraph extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NetworkUpdate.java
+++ b/src/main/java/org/ldk/structs/NetworkUpdate.java
@@ -49,7 +49,7 @@ public class NetworkUpdate extends CommonBase {
 			super(null, ptr);
 			long msg = obj.msg;
 			org.ldk.structs.ChannelUpdate msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ChannelUpdate(null, msg); }
-			msg_hu_conv.ptrs_to.add(this);
+			if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 			this.msg = msg_hu_conv;
 		}
 	}
@@ -107,7 +107,7 @@ public class NetworkUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetworkUpdate ret_hu_conv = org.ldk.structs.NetworkUpdate.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -119,8 +119,8 @@ public class NetworkUpdate extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetworkUpdate ret_hu_conv = org.ldk.structs.NetworkUpdate.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(msg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -133,7 +133,7 @@ public class NetworkUpdate extends CommonBase {
 		Reference.reachabilityFence(is_permanent);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetworkUpdate ret_hu_conv = org.ldk.structs.NetworkUpdate.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -146,7 +146,7 @@ public class NetworkUpdate extends CommonBase {
 		Reference.reachabilityFence(is_permanent);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NetworkUpdate ret_hu_conv = org.ldk.structs.NetworkUpdate.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NodeAlias.java
+++ b/src/main/java/org/ldk/structs/NodeAlias.java
@@ -43,7 +43,7 @@ public class NodeAlias extends CommonBase {
 		Reference.reachabilityFence(a_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAlias ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAlias(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -61,7 +61,7 @@ public class NodeAlias extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAlias ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAlias(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NodeAnnouncement.java
+++ b/src/main/java/org/ldk/structs/NodeAnnouncement.java
@@ -46,7 +46,7 @@ public class NodeAnnouncement extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UnsignedNodeAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UnsignedNodeAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -57,7 +57,7 @@ public class NodeAnnouncement extends CommonBase {
 		bindings.NodeAnnouncement_set_contents(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -69,8 +69,8 @@ public class NodeAnnouncement extends CommonBase {
 		Reference.reachabilityFence(contents_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(contents_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(contents_arg); };
 		return ret_hu_conv;
 	}
 
@@ -88,7 +88,7 @@ public class NodeAnnouncement extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NodeAnnouncementInfo.java
+++ b/src/main/java/org/ldk/structs/NodeAnnouncementInfo.java
@@ -28,7 +28,7 @@ public class NodeAnnouncementInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -39,7 +39,7 @@ public class NodeAnnouncementInfo extends CommonBase {
 		bindings.NodeAnnouncementInfo_set_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -90,7 +90,7 @@ public class NodeAnnouncementInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAlias ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAlias(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -103,7 +103,7 @@ public class NodeAnnouncementInfo extends CommonBase {
 		bindings.NodeAnnouncementInfo_set_alias(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -119,7 +119,7 @@ public class NodeAnnouncementInfo extends CommonBase {
 		for (int m = 0; m < ret_conv_12_len; m++) {
 			long ret_conv_12 = ret[m];
 			org.ldk.structs.NetAddress ret_conv_12_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(ret_conv_12);
-			ret_conv_12_hu_conv.ptrs_to.add(this);
+			if (ret_conv_12_hu_conv != null) { ret_conv_12_hu_conv.ptrs_to.add(this); };
 			ret_conv_12_arr[m] = ret_conv_12_hu_conv;
 		}
 		return ret_conv_12_arr;
@@ -148,7 +148,7 @@ public class NodeAnnouncementInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -164,7 +164,7 @@ public class NodeAnnouncementInfo extends CommonBase {
 		bindings.NodeAnnouncementInfo_set_announcement_message(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -180,10 +180,10 @@ public class NodeAnnouncementInfo extends CommonBase {
 		Reference.reachabilityFence(announcement_message_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAnnouncementInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAnnouncementInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(features_arg);
-		ret_hu_conv.ptrs_to.add(alias_arg);
-		ret_hu_conv.ptrs_to.add(announcement_message_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(features_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(alias_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(announcement_message_arg); };
 		return ret_hu_conv;
 	}
 
@@ -201,7 +201,7 @@ public class NodeAnnouncementInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAnnouncementInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAnnouncementInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NodeFeatures.java
+++ b/src/main/java/org/ldk/structs/NodeFeatures.java
@@ -29,7 +29,7 @@ public class NodeFeatures extends CommonBase {
 		boolean ret = bindings.NodeFeatures_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -51,7 +51,7 @@ public class NodeFeatures extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class NodeFeatures extends CommonBase {
 		long ret = bindings.NodeFeatures_empty();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -73,7 +73,7 @@ public class NodeFeatures extends CommonBase {
 		long ret = bindings.NodeFeatures_known();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NodeId.java
+++ b/src/main/java/org/ldk/structs/NodeId.java
@@ -34,7 +34,7 @@ public class NodeId extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeId ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeId(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -46,7 +46,7 @@ public class NodeId extends CommonBase {
 		Reference.reachabilityFence(pubkey);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeId ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeId(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/NodeInfo.java
+++ b/src/main/java/org/ldk/structs/NodeInfo.java
@@ -53,7 +53,7 @@ public class NodeInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RoutingFees ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RoutingFees(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -68,7 +68,7 @@ public class NodeInfo extends CommonBase {
 		bindings.NodeInfo_set_lowest_inbound_channel_fees(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -84,7 +84,7 @@ public class NodeInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeAnnouncementInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeAnnouncementInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -99,7 +99,7 @@ public class NodeInfo extends CommonBase {
 		bindings.NodeInfo_set_announcement_info(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -112,9 +112,9 @@ public class NodeInfo extends CommonBase {
 		Reference.reachabilityFence(announcement_info_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(lowest_inbound_channel_fees_arg);
-		ret_hu_conv.ptrs_to.add(announcement_info_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(lowest_inbound_channel_fees_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(announcement_info_arg); };
 		return ret_hu_conv;
 	}
 
@@ -132,7 +132,7 @@ public class NodeInfo extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/OpenChannel.java
+++ b/src/main/java/org/ldk/structs/OpenChannel.java
@@ -357,7 +357,7 @@ public class OpenChannel extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelTypeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelTypeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -372,7 +372,7 @@ public class OpenChannel extends CommonBase {
 		bindings.OpenChannel_set_channel_type(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	long clone_ptr() {
@@ -389,7 +389,7 @@ public class OpenChannel extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OpenChannel ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OpenChannel(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_AccessZ.java
+++ b/src/main/java/org/ldk/structs/Option_AccessZ.java
@@ -39,7 +39,7 @@ public class Option_AccessZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			Access ret_hu_conv = new Access(null, some);
-			ret_hu_conv.ptrs_to.add(this);
+			if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 			this.some = ret_hu_conv;
 		}
 	}
@@ -59,8 +59,8 @@ public class Option_AccessZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_AccessZ ret_hu_conv = org.ldk.structs.Option_AccessZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -71,7 +71,7 @@ public class Option_AccessZ extends CommonBase {
 		long ret = bindings.COption_AccessZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_AccessZ ret_hu_conv = org.ldk.structs.Option_AccessZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_C2Tuple_u64u64ZZ.java
+++ b/src/main/java/org/ldk/structs/Option_C2Tuple_u64u64ZZ.java
@@ -39,7 +39,7 @@ public class Option_C2Tuple_u64u64ZZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			TwoTuple_u64u64Z some_hu_conv = new TwoTuple_u64u64Z(null, some);
-			some_hu_conv.ptrs_to.add(this);
+			if (some_hu_conv != null) { some_hu_conv.ptrs_to.add(this); };
 			this.some = some_hu_conv;
 		}
 	}
@@ -59,7 +59,7 @@ public class Option_C2Tuple_u64u64ZZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_C2Tuple_u64u64ZZ ret_hu_conv = org.ldk.structs.Option_C2Tuple_u64u64ZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -70,7 +70,7 @@ public class Option_C2Tuple_u64u64ZZ extends CommonBase {
 		long ret = bindings.COption_C2Tuple_u64u64ZZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_C2Tuple_u64u64ZZ ret_hu_conv = org.ldk.structs.Option_C2Tuple_u64u64ZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class Option_C2Tuple_u64u64ZZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_C2Tuple_u64u64ZZ ret_hu_conv = org.ldk.structs.Option_C2Tuple_u64u64ZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_C2Tuple_usizeTransactionZZ.java
+++ b/src/main/java/org/ldk/structs/Option_C2Tuple_usizeTransactionZZ.java
@@ -39,7 +39,7 @@ public class Option_C2Tuple_usizeTransactionZZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			TwoTuple_usizeTransactionZ some_hu_conv = new TwoTuple_usizeTransactionZ(null, some);
-			some_hu_conv.ptrs_to.add(this);
+			if (some_hu_conv != null) { some_hu_conv.ptrs_to.add(this); };
 			this.some = some_hu_conv;
 		}
 	}
@@ -59,7 +59,7 @@ public class Option_C2Tuple_usizeTransactionZZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_C2Tuple_usizeTransactionZZ ret_hu_conv = org.ldk.structs.Option_C2Tuple_usizeTransactionZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -70,7 +70,7 @@ public class Option_C2Tuple_usizeTransactionZZ extends CommonBase {
 		long ret = bindings.COption_C2Tuple_usizeTransactionZZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_C2Tuple_usizeTransactionZZ ret_hu_conv = org.ldk.structs.Option_C2Tuple_usizeTransactionZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class Option_C2Tuple_usizeTransactionZZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_C2Tuple_usizeTransactionZZ ret_hu_conv = org.ldk.structs.Option_C2Tuple_usizeTransactionZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_CVec_NetAddressZZ.java
+++ b/src/main/java/org/ldk/structs/Option_CVec_NetAddressZZ.java
@@ -43,7 +43,7 @@ public class Option_CVec_NetAddressZZ extends CommonBase {
 			for (int m = 0; m < some_conv_12_len; m++) {
 				long some_conv_12 = some[m];
 				org.ldk.structs.NetAddress some_conv_12_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(some_conv_12);
-				some_conv_12_hu_conv.ptrs_to.add(this);
+				if (some_conv_12_hu_conv != null) { some_conv_12_hu_conv.ptrs_to.add(this); };
 				some_conv_12_arr[m] = some_conv_12_hu_conv;
 			}
 			this.some = some_conv_12_arr;
@@ -65,7 +65,7 @@ public class Option_CVec_NetAddressZZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_CVec_NetAddressZZ ret_hu_conv = org.ldk.structs.Option_CVec_NetAddressZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -76,7 +76,7 @@ public class Option_CVec_NetAddressZZ extends CommonBase {
 		long ret = bindings.COption_CVec_NetAddressZZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_CVec_NetAddressZZ ret_hu_conv = org.ldk.structs.Option_CVec_NetAddressZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -95,7 +95,7 @@ public class Option_CVec_NetAddressZZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_CVec_NetAddressZZ ret_hu_conv = org.ldk.structs.Option_CVec_NetAddressZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_ClosureReasonZ.java
+++ b/src/main/java/org/ldk/structs/Option_ClosureReasonZ.java
@@ -39,7 +39,7 @@ public class Option_ClosureReasonZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			org.ldk.structs.ClosureReason some_hu_conv = org.ldk.structs.ClosureReason.constr_from_ptr(some);
-			some_hu_conv.ptrs_to.add(this);
+			if (some_hu_conv != null) { some_hu_conv.ptrs_to.add(this); };
 			this.some = some_hu_conv;
 		}
 	}
@@ -59,7 +59,7 @@ public class Option_ClosureReasonZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_ClosureReasonZ ret_hu_conv = org.ldk.structs.Option_ClosureReasonZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -70,7 +70,7 @@ public class Option_ClosureReasonZ extends CommonBase {
 		long ret = bindings.COption_ClosureReasonZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_ClosureReasonZ ret_hu_conv = org.ldk.structs.Option_ClosureReasonZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class Option_ClosureReasonZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_ClosureReasonZ ret_hu_conv = org.ldk.structs.Option_ClosureReasonZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_EventZ.java
+++ b/src/main/java/org/ldk/structs/Option_EventZ.java
@@ -39,7 +39,7 @@ public class Option_EventZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			org.ldk.structs.Event some_hu_conv = org.ldk.structs.Event.constr_from_ptr(some);
-			some_hu_conv.ptrs_to.add(this);
+			if (some_hu_conv != null) { some_hu_conv.ptrs_to.add(this); };
 			this.some = some_hu_conv;
 		}
 	}
@@ -59,7 +59,7 @@ public class Option_EventZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_EventZ ret_hu_conv = org.ldk.structs.Option_EventZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -70,7 +70,7 @@ public class Option_EventZ extends CommonBase {
 		long ret = bindings.COption_EventZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_EventZ ret_hu_conv = org.ldk.structs.Option_EventZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class Option_EventZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_EventZ ret_hu_conv = org.ldk.structs.Option_EventZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_FilterZ.java
+++ b/src/main/java/org/ldk/structs/Option_FilterZ.java
@@ -39,7 +39,7 @@ public class Option_FilterZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			Filter ret_hu_conv = new Filter(null, some);
-			ret_hu_conv.ptrs_to.add(this);
+			if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 			this.some = ret_hu_conv;
 		}
 	}
@@ -59,8 +59,8 @@ public class Option_FilterZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_FilterZ ret_hu_conv = org.ldk.structs.Option_FilterZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -71,7 +71,7 @@ public class Option_FilterZ extends CommonBase {
 		long ret = bindings.COption_FilterZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_FilterZ ret_hu_conv = org.ldk.structs.Option_FilterZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_HTLCDestinationZ.java
+++ b/src/main/java/org/ldk/structs/Option_HTLCDestinationZ.java
@@ -39,7 +39,7 @@ public class Option_HTLCDestinationZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			org.ldk.structs.HTLCDestination some_hu_conv = org.ldk.structs.HTLCDestination.constr_from_ptr(some);
-			some_hu_conv.ptrs_to.add(this);
+			if (some_hu_conv != null) { some_hu_conv.ptrs_to.add(this); };
 			this.some = some_hu_conv;
 		}
 	}
@@ -59,7 +59,7 @@ public class Option_HTLCDestinationZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_HTLCDestinationZ ret_hu_conv = org.ldk.structs.Option_HTLCDestinationZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -70,7 +70,7 @@ public class Option_HTLCDestinationZ extends CommonBase {
 		long ret = bindings.COption_HTLCDestinationZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_HTLCDestinationZ ret_hu_conv = org.ldk.structs.Option_HTLCDestinationZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class Option_HTLCDestinationZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_HTLCDestinationZ ret_hu_conv = org.ldk.structs.Option_HTLCDestinationZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_MonitorEventZ.java
+++ b/src/main/java/org/ldk/structs/Option_MonitorEventZ.java
@@ -39,7 +39,7 @@ public class Option_MonitorEventZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			org.ldk.structs.MonitorEvent some_hu_conv = org.ldk.structs.MonitorEvent.constr_from_ptr(some);
-			some_hu_conv.ptrs_to.add(this);
+			if (some_hu_conv != null) { some_hu_conv.ptrs_to.add(this); };
 			this.some = some_hu_conv;
 		}
 	}
@@ -59,7 +59,7 @@ public class Option_MonitorEventZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_MonitorEventZ ret_hu_conv = org.ldk.structs.Option_MonitorEventZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -70,7 +70,7 @@ public class Option_MonitorEventZ extends CommonBase {
 		long ret = bindings.COption_MonitorEventZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_MonitorEventZ ret_hu_conv = org.ldk.structs.Option_MonitorEventZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class Option_MonitorEventZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_MonitorEventZ ret_hu_conv = org.ldk.structs.Option_MonitorEventZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_NetAddressZ.java
+++ b/src/main/java/org/ldk/structs/Option_NetAddressZ.java
@@ -39,7 +39,7 @@ public class Option_NetAddressZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			org.ldk.structs.NetAddress some_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(some);
-			some_hu_conv.ptrs_to.add(this);
+			if (some_hu_conv != null) { some_hu_conv.ptrs_to.add(this); };
 			this.some = some_hu_conv;
 		}
 	}
@@ -59,7 +59,7 @@ public class Option_NetAddressZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_NetAddressZ ret_hu_conv = org.ldk.structs.Option_NetAddressZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -70,7 +70,7 @@ public class Option_NetAddressZ extends CommonBase {
 		long ret = bindings.COption_NetAddressZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_NetAddressZ ret_hu_conv = org.ldk.structs.Option_NetAddressZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class Option_NetAddressZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_NetAddressZ ret_hu_conv = org.ldk.structs.Option_NetAddressZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_NetworkUpdateZ.java
+++ b/src/main/java/org/ldk/structs/Option_NetworkUpdateZ.java
@@ -39,7 +39,7 @@ public class Option_NetworkUpdateZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			org.ldk.structs.NetworkUpdate some_hu_conv = org.ldk.structs.NetworkUpdate.constr_from_ptr(some);
-			some_hu_conv.ptrs_to.add(this);
+			if (some_hu_conv != null) { some_hu_conv.ptrs_to.add(this); };
 			this.some = some_hu_conv;
 		}
 	}
@@ -59,7 +59,7 @@ public class Option_NetworkUpdateZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_NetworkUpdateZ ret_hu_conv = org.ldk.structs.Option_NetworkUpdateZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -70,7 +70,7 @@ public class Option_NetworkUpdateZ extends CommonBase {
 		long ret = bindings.COption_NetworkUpdateZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_NetworkUpdateZ ret_hu_conv = org.ldk.structs.Option_NetworkUpdateZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -89,7 +89,7 @@ public class Option_NetworkUpdateZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_NetworkUpdateZ ret_hu_conv = org.ldk.structs.Option_NetworkUpdateZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_TypeZ.java
+++ b/src/main/java/org/ldk/structs/Option_TypeZ.java
@@ -39,7 +39,7 @@ public class Option_TypeZ extends CommonBase {
 			super(null, ptr);
 			long some = obj.some;
 			Type ret_hu_conv = new Type(null, some);
-			ret_hu_conv.ptrs_to.add(this);
+			if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 			this.some = ret_hu_conv;
 		}
 	}
@@ -59,8 +59,8 @@ public class Option_TypeZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_TypeZ ret_hu_conv = org.ldk.structs.Option_TypeZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -71,7 +71,7 @@ public class Option_TypeZ extends CommonBase {
 		long ret = bindings.COption_TypeZ_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_TypeZ ret_hu_conv = org.ldk.structs.Option_TypeZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -90,7 +90,7 @@ public class Option_TypeZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_TypeZ ret_hu_conv = org.ldk.structs.Option_TypeZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_u16Z.java
+++ b/src/main/java/org/ldk/structs/Option_u16Z.java
@@ -56,7 +56,7 @@ public class Option_u16Z extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u16Z ret_hu_conv = org.ldk.structs.Option_u16Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -67,7 +67,7 @@ public class Option_u16Z extends CommonBase {
 		long ret = bindings.COption_u16Z_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u16Z ret_hu_conv = org.ldk.structs.Option_u16Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -86,7 +86,7 @@ public class Option_u16Z extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u16Z ret_hu_conv = org.ldk.structs.Option_u16Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_u32Z.java
+++ b/src/main/java/org/ldk/structs/Option_u32Z.java
@@ -56,7 +56,7 @@ public class Option_u32Z extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u32Z ret_hu_conv = org.ldk.structs.Option_u32Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -67,7 +67,7 @@ public class Option_u32Z extends CommonBase {
 		long ret = bindings.COption_u32Z_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u32Z ret_hu_conv = org.ldk.structs.Option_u32Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -86,7 +86,7 @@ public class Option_u32Z extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u32Z ret_hu_conv = org.ldk.structs.Option_u32Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Option_u64Z.java
+++ b/src/main/java/org/ldk/structs/Option_u64Z.java
@@ -56,7 +56,7 @@ public class Option_u64Z extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -67,7 +67,7 @@ public class Option_u64Z extends CommonBase {
 		long ret = bindings.COption_u64Z_none();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -86,7 +86,7 @@ public class Option_u64Z extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/OutPoint.java
+++ b/src/main/java/org/ldk/structs/OutPoint.java
@@ -68,7 +68,7 @@ public class OutPoint extends CommonBase {
 		Reference.reachabilityFence(index_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -86,7 +86,7 @@ public class OutPoint extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -99,7 +99,7 @@ public class OutPoint extends CommonBase {
 		boolean ret = bindings.OutPoint_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/P2PGossipSync.java
+++ b/src/main/java/org/ldk/structs/P2PGossipSync.java
@@ -41,10 +41,10 @@ public class P2PGossipSync extends CommonBase {
 		Reference.reachabilityFence(logger);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.P2PGossipSync ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.P2PGossipSync(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(network_graph);
-		ret_hu_conv.ptrs_to.add(chain_access);
-		ret_hu_conv.ptrs_to.add(logger);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(network_graph); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(chain_access); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
 		return ret_hu_conv;
 	}
 
@@ -57,7 +57,7 @@ public class P2PGossipSync extends CommonBase {
 		bindings.P2PGossipSync_add_chain_access(this.ptr, chain_access.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(chain_access);
-		this.ptrs_to.add(chain_access);
+		if (this != null) { this.ptrs_to.add(chain_access); };
 	}
 
 	/**
@@ -69,7 +69,7 @@ public class P2PGossipSync extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		RoutingMessageHandler ret_hu_conv = new RoutingMessageHandler(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -82,7 +82,7 @@ public class P2PGossipSync extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		MessageSendEventsProvider ret_hu_conv = new MessageSendEventsProvider(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ParseError.java
+++ b/src/main/java/org/ldk/structs/ParseError.java
@@ -85,7 +85,7 @@ public class ParseError extends CommonBase {
 			super(null, ptr);
 			long bech32_error = obj.bech32_error;
 			org.ldk.structs.Bech32Error bech32_error_hu_conv = org.ldk.structs.Bech32Error.constr_from_ptr(bech32_error);
-			bech32_error_hu_conv.ptrs_to.add(this);
+			if (bech32_error_hu_conv != null) { bech32_error_hu_conv.ptrs_to.add(this); };
 			this.bech32_error = bech32_error_hu_conv;
 		}
 	}
@@ -204,7 +204,7 @@ public class ParseError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -216,7 +216,7 @@ public class ParseError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -228,7 +228,7 @@ public class ParseError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -240,7 +240,7 @@ public class ParseError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -251,7 +251,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_bad_prefix();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -262,7 +262,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_unknown_currency();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -273,7 +273,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_unknown_si_prefix();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -284,7 +284,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_malformed_hrp();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -295,7 +295,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_too_short_data_part();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -306,7 +306,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_unexpected_end_of_tagged_fields();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -318,7 +318,7 @@ public class ParseError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -329,7 +329,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_padding_error();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -340,7 +340,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_integer_overflow_error();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -351,7 +351,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_invalid_seg_wit_program_length();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -362,7 +362,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_invalid_pub_key_hash_length();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -373,7 +373,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_invalid_script_hash_length();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -384,7 +384,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_invalid_recovery_id();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -396,7 +396,7 @@ public class ParseError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -407,7 +407,7 @@ public class ParseError extends CommonBase {
 		long ret = bindings.ParseError_skip();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseError ret_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ParseOrSemanticError.java
+++ b/src/main/java/org/ldk/structs/ParseOrSemanticError.java
@@ -41,7 +41,7 @@ public class ParseOrSemanticError extends CommonBase {
 			super(null, ptr);
 			long parse_error = obj.parse_error;
 			org.ldk.structs.ParseError parse_error_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(parse_error);
-			parse_error_hu_conv.ptrs_to.add(this);
+			if (parse_error_hu_conv != null) { parse_error_hu_conv.ptrs_to.add(this); };
 			this.parse_error = parse_error_hu_conv;
 		}
 	}
@@ -69,7 +69,7 @@ public class ParseOrSemanticError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseOrSemanticError ret_hu_conv = org.ldk.structs.ParseOrSemanticError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -81,7 +81,7 @@ public class ParseOrSemanticError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseOrSemanticError ret_hu_conv = org.ldk.structs.ParseOrSemanticError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -93,7 +93,7 @@ public class ParseOrSemanticError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ParseOrSemanticError ret_hu_conv = org.ldk.structs.ParseOrSemanticError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PayeePubKey.java
+++ b/src/main/java/org/ldk/structs/PayeePubKey.java
@@ -40,7 +40,7 @@ public class PayeePubKey extends CommonBase {
 		Reference.reachabilityFence(a_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PayeePubKey ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PayeePubKey(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -58,7 +58,7 @@ public class PayeePubKey extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PayeePubKey ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PayeePubKey(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -83,7 +83,7 @@ public class PayeePubKey extends CommonBase {
 		boolean ret = bindings.PayeePubKey_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/Payer.java
+++ b/src/main/java/org/ldk/structs/Payer.java
@@ -116,7 +116,7 @@ public class Payer extends CommonBase {
 		for (int q = 0; q < ret_conv_16_len; q++) {
 			long ret_conv_16 = ret[q];
 			org.ldk.structs.ChannelDetails ret_conv_16_hu_conv = null; if (ret_conv_16 < 0 || ret_conv_16 > 4096) { ret_conv_16_hu_conv = new org.ldk.structs.ChannelDetails(null, ret_conv_16); }
-			ret_conv_16_hu_conv.ptrs_to.add(this);
+			if (ret_conv_16_hu_conv != null) { ret_conv_16_hu_conv.ptrs_to.add(this); };
 			ret_conv_16_arr[q] = ret_conv_16_hu_conv;
 		}
 		return ret_conv_16_arr;
@@ -135,7 +135,7 @@ public class Payer extends CommonBase {
 		Reference.reachabilityFence(payment_secret);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentIdPaymentSendFailureZ ret_hu_conv = Result_PaymentIdPaymentSendFailureZ.constr_from_ptr(ret);
-		this.ptrs_to.add(route);
+		if (this != null) { this.ptrs_to.add(route); };
 		return ret_hu_conv;
 	}
 
@@ -149,7 +149,7 @@ public class Payer extends CommonBase {
 		Reference.reachabilityFence(payment_preimage);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentIdPaymentSendFailureZ ret_hu_conv = Result_PaymentIdPaymentSendFailureZ.constr_from_ptr(ret);
-		this.ptrs_to.add(route);
+		if (this != null) { this.ptrs_to.add(route); };
 		return ret_hu_conv;
 	}
 
@@ -163,7 +163,7 @@ public class Payer extends CommonBase {
 		Reference.reachabilityFence(payment_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NonePaymentSendFailureZ ret_hu_conv = Result_NonePaymentSendFailureZ.constr_from_ptr(ret);
-		this.ptrs_to.add(route);
+		if (this != null) { this.ptrs_to.add(route); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PaymentError.java
+++ b/src/main/java/org/ldk/structs/PaymentError.java
@@ -52,7 +52,7 @@ public class PaymentError extends CommonBase {
 			super(null, ptr);
 			long routing = obj.routing;
 			org.ldk.structs.LightningError routing_hu_conv = null; if (routing < 0 || routing > 4096) { routing_hu_conv = new org.ldk.structs.LightningError(null, routing); }
-			routing_hu_conv.ptrs_to.add(this);
+			if (routing_hu_conv != null) { routing_hu_conv.ptrs_to.add(this); };
 			this.routing = routing_hu_conv;
 		}
 	}
@@ -65,7 +65,7 @@ public class PaymentError extends CommonBase {
 			super(null, ptr);
 			long sending = obj.sending;
 			org.ldk.structs.PaymentSendFailure sending_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(sending);
-			sending_hu_conv.ptrs_to.add(this);
+			if (sending_hu_conv != null) { sending_hu_conv.ptrs_to.add(this); };
 			this.sending = sending_hu_conv;
 		}
 	}
@@ -83,7 +83,7 @@ public class PaymentError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentError ret_hu_conv = org.ldk.structs.PaymentError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -95,7 +95,7 @@ public class PaymentError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentError ret_hu_conv = org.ldk.structs.PaymentError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -107,8 +107,8 @@ public class PaymentError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentError ret_hu_conv = org.ldk.structs.PaymentError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 
@@ -120,7 +120,7 @@ public class PaymentError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentError ret_hu_conv = org.ldk.structs.PaymentError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PaymentParameters.java
+++ b/src/main/java/org/ldk/structs/PaymentParameters.java
@@ -54,7 +54,7 @@ public class PaymentParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -72,7 +72,7 @@ public class PaymentParameters extends CommonBase {
 		bindings.PaymentParameters_set_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -86,7 +86,7 @@ public class PaymentParameters extends CommonBase {
 		for (int l = 0; l < ret_conv_11_len; l++) {
 			long ret_conv_11 = ret[l];
 			org.ldk.structs.RouteHint ret_conv_11_hu_conv = null; if (ret_conv_11 < 0 || ret_conv_11 > 4096) { ret_conv_11_hu_conv = new org.ldk.structs.RouteHint(null, ret_conv_11); }
-			ret_conv_11_hu_conv.ptrs_to.add(this);
+			if (ret_conv_11_hu_conv != null) { ret_conv_11_hu_conv.ptrs_to.add(this); };
 			ret_conv_11_arr[l] = ret_conv_11_hu_conv;
 		}
 		return ret_conv_11_arr;
@@ -99,7 +99,7 @@ public class PaymentParameters extends CommonBase {
 		bindings.PaymentParameters_set_route_hints(this.ptr, val != null ? Arrays.stream(val).mapToLong(val_conv_11 -> val_conv_11 == null ? 0 : val_conv_11.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		for (RouteHint val_conv_11: val) { this.ptrs_to.add(val_conv_11); };
+		for (RouteHint val_conv_11: val) { if (this != null) { this.ptrs_to.add(val_conv_11); }; };
 	}
 
 	/**
@@ -110,7 +110,7 @@ public class PaymentParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -244,9 +244,9 @@ public class PaymentParameters extends CommonBase {
 		Reference.reachabilityFence(previously_failed_channels_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PaymentParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(features_arg);
-		for (RouteHint route_hints_arg_conv_11: route_hints_arg) { ret_hu_conv.ptrs_to.add(route_hints_arg_conv_11); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(features_arg); };
+		for (RouteHint route_hints_arg_conv_11: route_hints_arg) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(route_hints_arg_conv_11); }; };
 		return ret_hu_conv;
 	}
 
@@ -264,7 +264,7 @@ public class PaymentParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PaymentParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -289,7 +289,7 @@ public class PaymentParameters extends CommonBase {
 		boolean ret = bindings.PaymentParameters_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -325,7 +325,7 @@ public class PaymentParameters extends CommonBase {
 		Reference.reachabilityFence(payee_pubkey);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PaymentParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -337,7 +337,7 @@ public class PaymentParameters extends CommonBase {
 		Reference.reachabilityFence(payee_pubkey);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PaymentParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PaymentPurpose.java
+++ b/src/main/java/org/ldk/structs/PaymentPurpose.java
@@ -90,7 +90,7 @@ public class PaymentPurpose extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentPurpose ret_hu_conv = org.ldk.structs.PaymentPurpose.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -103,7 +103,7 @@ public class PaymentPurpose extends CommonBase {
 		Reference.reachabilityFence(payment_secret);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentPurpose ret_hu_conv = org.ldk.structs.PaymentPurpose.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -115,7 +115,7 @@ public class PaymentPurpose extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentPurpose ret_hu_conv = org.ldk.structs.PaymentPurpose.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PaymentSendFailure.java
+++ b/src/main/java/org/ldk/structs/PaymentSendFailure.java
@@ -49,7 +49,7 @@ public class PaymentSendFailure extends CommonBase {
 			super(null, ptr);
 			long parameter_error = obj.parameter_error;
 			org.ldk.structs.APIError parameter_error_hu_conv = org.ldk.structs.APIError.constr_from_ptr(parameter_error);
-			parameter_error_hu_conv.ptrs_to.add(this);
+			if (parameter_error_hu_conv != null) { parameter_error_hu_conv.ptrs_to.add(this); };
 			this.parameter_error = parameter_error_hu_conv;
 		}
 	}
@@ -92,7 +92,7 @@ public class PaymentSendFailure extends CommonBase {
 			for (int k = 0; k < all_failed_retry_safe_conv_10_len; k++) {
 				long all_failed_retry_safe_conv_10 = all_failed_retry_safe[k];
 				org.ldk.structs.APIError all_failed_retry_safe_conv_10_hu_conv = org.ldk.structs.APIError.constr_from_ptr(all_failed_retry_safe_conv_10);
-				all_failed_retry_safe_conv_10_hu_conv.ptrs_to.add(this);
+				if (all_failed_retry_safe_conv_10_hu_conv != null) { all_failed_retry_safe_conv_10_hu_conv.ptrs_to.add(this); };
 				all_failed_retry_safe_conv_10_arr[k] = all_failed_retry_safe_conv_10_hu_conv;
 			}
 			this.all_failed_retry_safe = all_failed_retry_safe_conv_10_arr;
@@ -142,7 +142,7 @@ public class PaymentSendFailure extends CommonBase {
 			this.results = results_conv_22_arr;
 			long failed_paths_retry = obj.failed_paths_retry;
 			org.ldk.structs.RouteParameters failed_paths_retry_hu_conv = null; if (failed_paths_retry < 0 || failed_paths_retry > 4096) { failed_paths_retry_hu_conv = new org.ldk.structs.RouteParameters(null, failed_paths_retry); }
-			failed_paths_retry_hu_conv.ptrs_to.add(this);
+			if (failed_paths_retry_hu_conv != null) { failed_paths_retry_hu_conv.ptrs_to.add(this); };
 			this.failed_paths_retry = failed_paths_retry_hu_conv;
 			this.payment_id = obj.payment_id;
 		}
@@ -161,7 +161,7 @@ public class PaymentSendFailure extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentSendFailure ret_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -173,7 +173,7 @@ public class PaymentSendFailure extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentSendFailure ret_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -185,7 +185,7 @@ public class PaymentSendFailure extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentSendFailure ret_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -197,7 +197,7 @@ public class PaymentSendFailure extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentSendFailure ret_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -211,8 +211,8 @@ public class PaymentSendFailure extends CommonBase {
 		Reference.reachabilityFence(payment_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentSendFailure ret_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(failed_paths_retry);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(failed_paths_retry); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PeerHandleError.java
+++ b/src/main/java/org/ldk/structs/PeerHandleError.java
@@ -60,7 +60,7 @@ public class PeerHandleError extends CommonBase {
 		Reference.reachabilityFence(no_connection_possible_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PeerHandleError ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PeerHandleError(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -78,7 +78,7 @@ public class PeerHandleError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PeerHandleError ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PeerHandleError(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PeerManager.java
+++ b/src/main/java/org/ldk/structs/PeerManager.java
@@ -53,11 +53,11 @@ public class PeerManager extends CommonBase {
 		Reference.reachabilityFence(custom_message_handler);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PeerManager ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PeerManager(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(message_handler_chan_handler_arg);
-		ret_hu_conv.ptrs_to.add(message_handler_route_handler_arg);
-		ret_hu_conv.ptrs_to.add(logger);
-		ret_hu_conv.ptrs_to.add(custom_message_handler);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(message_handler_chan_handler_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(message_handler_route_handler_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(custom_message_handler); };
 		return ret_hu_conv;
 	}
 
@@ -99,7 +99,7 @@ public class PeerManager extends CommonBase {
 		Reference.reachabilityFence(remote_network_address);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CVec_u8ZPeerHandleErrorZ ret_hu_conv = Result_CVec_u8ZPeerHandleErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(descriptor);
+		if (this != null) { this.ptrs_to.add(descriptor); };
 		return ret_hu_conv;
 	}
 
@@ -127,7 +127,7 @@ public class PeerManager extends CommonBase {
 		Reference.reachabilityFence(remote_network_address);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NonePeerHandleErrorZ ret_hu_conv = Result_NonePeerHandleErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(descriptor);
+		if (this != null) { this.ptrs_to.add(descriptor); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Persist.java
+++ b/src/main/java/org/ldk/structs/Persist.java
@@ -106,10 +106,10 @@ public class Persist extends CommonBase {
 		impl_holder.held = new Persist(new bindings.LDKPersist() {
 			@Override public long persist_new_channel(long channel_id, long data, long update_id) {
 				org.ldk.structs.OutPoint channel_id_hu_conv = null; if (channel_id < 0 || channel_id > 4096) { channel_id_hu_conv = new org.ldk.structs.OutPoint(null, channel_id); }
-				channel_id_hu_conv.ptrs_to.add(this);
+				if (channel_id_hu_conv != null) { channel_id_hu_conv.ptrs_to.add(this); };
 				org.ldk.structs.ChannelMonitor data_hu_conv = null; if (data < 0 || data > 4096) { data_hu_conv = new org.ldk.structs.ChannelMonitor(null, data); }
 				org.ldk.structs.MonitorUpdateId update_id_hu_conv = null; if (update_id < 0 || update_id > 4096) { update_id_hu_conv = new org.ldk.structs.MonitorUpdateId(null, update_id); }
-				update_id_hu_conv.ptrs_to.add(this);
+				if (update_id_hu_conv != null) { update_id_hu_conv.ptrs_to.add(this); };
 				Result_NoneChannelMonitorUpdateErrZ ret = arg.persist_new_channel(channel_id_hu_conv, data_hu_conv, update_id_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -117,11 +117,11 @@ public class Persist extends CommonBase {
 			}
 			@Override public long update_persisted_channel(long channel_id, long update, long data, long update_id) {
 				org.ldk.structs.OutPoint channel_id_hu_conv = null; if (channel_id < 0 || channel_id > 4096) { channel_id_hu_conv = new org.ldk.structs.OutPoint(null, channel_id); }
-				channel_id_hu_conv.ptrs_to.add(this);
+				if (channel_id_hu_conv != null) { channel_id_hu_conv.ptrs_to.add(this); };
 				org.ldk.structs.ChannelMonitorUpdate update_hu_conv = null; if (update < 0 || update > 4096) { update_hu_conv = new org.ldk.structs.ChannelMonitorUpdate(null, update); }
 				org.ldk.structs.ChannelMonitor data_hu_conv = null; if (data < 0 || data > 4096) { data_hu_conv = new org.ldk.structs.ChannelMonitor(null, data); }
 				org.ldk.structs.MonitorUpdateId update_id_hu_conv = null; if (update_id < 0 || update_id > 4096) { update_id_hu_conv = new org.ldk.structs.MonitorUpdateId(null, update_id); }
-				update_id_hu_conv.ptrs_to.add(this);
+				if (update_id_hu_conv != null) { update_id_hu_conv.ptrs_to.add(this); };
 				Result_NoneChannelMonitorUpdateErrZ ret = arg.update_persisted_channel(channel_id_hu_conv, update_hu_conv, data_hu_conv, update_id_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -155,9 +155,9 @@ public class Persist extends CommonBase {
 		Reference.reachabilityFence(update_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneChannelMonitorUpdateErrZ ret_hu_conv = Result_NoneChannelMonitorUpdateErrZ.constr_from_ptr(ret);
-		this.ptrs_to.add(channel_id);
-		this.ptrs_to.add(data);
-		this.ptrs_to.add(update_id);
+		if (this != null) { this.ptrs_to.add(channel_id); };
+		if (this != null) { this.ptrs_to.add(data); };
+		if (this != null) { this.ptrs_to.add(update_id); };
 		return ret_hu_conv;
 	}
 
@@ -207,10 +207,10 @@ public class Persist extends CommonBase {
 		Reference.reachabilityFence(update_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneChannelMonitorUpdateErrZ ret_hu_conv = Result_NoneChannelMonitorUpdateErrZ.constr_from_ptr(ret);
-		this.ptrs_to.add(channel_id);
-		this.ptrs_to.add(update);
-		this.ptrs_to.add(data);
-		this.ptrs_to.add(update_id);
+		if (this != null) { this.ptrs_to.add(channel_id); };
+		if (this != null) { this.ptrs_to.add(update); };
+		if (this != null) { this.ptrs_to.add(data); };
+		if (this != null) { this.ptrs_to.add(update_id); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Persister.java
+++ b/src/main/java/org/ldk/structs/Persister.java
@@ -75,7 +75,7 @@ public class Persister extends CommonBase {
 		Reference.reachabilityFence(channel_manager);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneErrorZ ret_hu_conv = Result_NoneErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(channel_manager);
+		if (this != null) { this.ptrs_to.add(channel_manager); };
 		return ret_hu_conv;
 	}
 
@@ -88,7 +88,7 @@ public class Persister extends CommonBase {
 		Reference.reachabilityFence(network_graph);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneErrorZ ret_hu_conv = Result_NoneErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(network_graph);
+		if (this != null) { this.ptrs_to.add(network_graph); };
 		return ret_hu_conv;
 	}
 
@@ -101,7 +101,7 @@ public class Persister extends CommonBase {
 		Reference.reachabilityFence(scorer);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneErrorZ ret_hu_conv = Result_NoneErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(scorer);
+		if (this != null) { this.ptrs_to.add(scorer); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PhantomKeysManager.java
+++ b/src/main/java/org/ldk/structs/PhantomKeysManager.java
@@ -43,7 +43,7 @@ public class PhantomKeysManager extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		KeysInterface ret_hu_conv = new KeysInterface(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -67,7 +67,7 @@ public class PhantomKeysManager extends CommonBase {
 		Reference.reachabilityFence(cross_node_seed);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PhantomKeysManager ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PhantomKeysManager(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -96,7 +96,7 @@ public class PhantomKeysManager extends CommonBase {
 		Reference.reachabilityFence(params);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InMemorySigner ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InMemorySigner(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PhantomRouteHints.java
+++ b/src/main/java/org/ldk/structs/PhantomRouteHints.java
@@ -33,7 +33,7 @@ public class PhantomRouteHints extends CommonBase {
 		for (int q = 0; q < ret_conv_16_len; q++) {
 			long ret_conv_16 = ret[q];
 			org.ldk.structs.ChannelDetails ret_conv_16_hu_conv = null; if (ret_conv_16 < 0 || ret_conv_16 > 4096) { ret_conv_16_hu_conv = new org.ldk.structs.ChannelDetails(null, ret_conv_16); }
-			ret_conv_16_hu_conv.ptrs_to.add(this);
+			if (ret_conv_16_hu_conv != null) { ret_conv_16_hu_conv.ptrs_to.add(this); };
 			ret_conv_16_arr[q] = ret_conv_16_hu_conv;
 		}
 		return ret_conv_16_arr;
@@ -46,7 +46,7 @@ public class PhantomRouteHints extends CommonBase {
 		bindings.PhantomRouteHints_set_channels(this.ptr, val != null ? Arrays.stream(val).mapToLong(val_conv_16 -> val_conv_16 == null ? 0 : val_conv_16.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		for (ChannelDetails val_conv_16: val) { this.ptrs_to.add(val_conv_16); };
+		for (ChannelDetails val_conv_16: val) { if (this != null) { this.ptrs_to.add(val_conv_16); }; };
 	}
 
 	/**
@@ -97,8 +97,8 @@ public class PhantomRouteHints extends CommonBase {
 		Reference.reachabilityFence(real_node_pubkey_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PhantomRouteHints ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PhantomRouteHints(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		for (ChannelDetails channels_arg_conv_16: channels_arg) { ret_hu_conv.ptrs_to.add(channels_arg_conv_16); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		for (ChannelDetails channels_arg_conv_16: channels_arg) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channels_arg_conv_16); }; };
 		return ret_hu_conv;
 	}
 
@@ -116,7 +116,7 @@ public class PhantomRouteHints extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PhantomRouteHints ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PhantomRouteHints(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Ping.java
+++ b/src/main/java/org/ldk/structs/Ping.java
@@ -67,7 +67,7 @@ public class Ping extends CommonBase {
 		Reference.reachabilityFence(byteslen_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Ping ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Ping(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -85,7 +85,7 @@ public class Ping extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Ping ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Ping(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Pong.java
+++ b/src/main/java/org/ldk/structs/Pong.java
@@ -48,7 +48,7 @@ public class Pong extends CommonBase {
 		Reference.reachabilityFence(byteslen_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Pong ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Pong(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class Pong extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Pong ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Pong(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PositiveTimestamp.java
+++ b/src/main/java/org/ldk/structs/PositiveTimestamp.java
@@ -34,7 +34,7 @@ public class PositiveTimestamp extends CommonBase {
 		boolean ret = bindings.PositiveTimestamp_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -56,7 +56,7 @@ public class PositiveTimestamp extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PositiveTimestamp ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PositiveTimestamp(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/PrivateRoute.java
+++ b/src/main/java/org/ldk/structs/PrivateRoute.java
@@ -37,7 +37,7 @@ public class PrivateRoute extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PrivateRoute ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PrivateRoute(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class PrivateRoute extends CommonBase {
 		boolean ret = bindings.PrivateRoute_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -78,7 +78,7 @@ public class PrivateRoute extends CommonBase {
 		Reference.reachabilityFence(hops);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PrivateRouteCreationErrorZ ret_hu_conv = Result_PrivateRouteCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(hops);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(hops); };
 		return ret_hu_conv;
 	}
 
@@ -90,8 +90,8 @@ public class PrivateRoute extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteHint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteHint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
-		this.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
+		if (this != null) { this.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ProbabilisticScorer.java
+++ b/src/main/java/org/ldk/structs/ProbabilisticScorer.java
@@ -52,10 +52,10 @@ public class ProbabilisticScorer extends CommonBase {
 		Reference.reachabilityFence(logger);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ProbabilisticScorer ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ProbabilisticScorer(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(params);
-		ret_hu_conv.ptrs_to.add(network_graph);
-		ret_hu_conv.ptrs_to.add(logger);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(params); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(network_graph); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
 		return ret_hu_conv;
 	}
 
@@ -81,8 +81,8 @@ public class ProbabilisticScorer extends CommonBase {
 		Reference.reachabilityFence(target);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_C2Tuple_u64u64ZZ ret_hu_conv = org.ldk.structs.Option_C2Tuple_u64u64ZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
-		this.ptrs_to.add(target);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
+		if (this != null) { this.ptrs_to.add(target); };
 		return ret_hu_conv;
 	}
 
@@ -94,7 +94,7 @@ public class ProbabilisticScorer extends CommonBase {
 		bindings.ProbabilisticScorer_add_banned(this.ptr, node_id == null ? 0 : node_id.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(node_id);
-		this.ptrs_to.add(node_id);
+		if (this != null) { this.ptrs_to.add(node_id); };
 	}
 
 	/**
@@ -104,7 +104,7 @@ public class ProbabilisticScorer extends CommonBase {
 		bindings.ProbabilisticScorer_remove_banned(this.ptr, node_id == null ? 0 : node_id.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(node_id);
-		this.ptrs_to.add(node_id);
+		if (this != null) { this.ptrs_to.add(node_id); };
 	}
 
 	/**
@@ -115,7 +115,7 @@ public class ProbabilisticScorer extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(node_id);
 		Reference.reachabilityFence(penalty);
-		this.ptrs_to.add(node_id);
+		if (this != null) { this.ptrs_to.add(node_id); };
 	}
 
 	/**
@@ -125,7 +125,7 @@ public class ProbabilisticScorer extends CommonBase {
 		bindings.ProbabilisticScorer_remove_manual_penalty(this.ptr, node_id == null ? 0 : node_id.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(node_id);
-		this.ptrs_to.add(node_id);
+		if (this != null) { this.ptrs_to.add(node_id); };
 	}
 
 	/**
@@ -145,7 +145,7 @@ public class ProbabilisticScorer extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Score ret_hu_conv = new Score(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -169,9 +169,9 @@ public class ProbabilisticScorer extends CommonBase {
 		Reference.reachabilityFence(arg_c);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ProbabilisticScorerDecodeErrorZ ret_hu_conv = Result_ProbabilisticScorerDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(arg_a);
-		ret_hu_conv.ptrs_to.add(arg_b);
-		ret_hu_conv.ptrs_to.add(arg_c);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_a); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_b); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_c); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ProbabilisticScoringParameters.java
+++ b/src/main/java/org/ldk/structs/ProbabilisticScoringParameters.java
@@ -314,7 +314,7 @@ public class ProbabilisticScoringParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ProbabilisticScoringParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ProbabilisticScoringParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -326,7 +326,7 @@ public class ProbabilisticScoringParameters extends CommonBase {
 		bindings.ProbabilisticScoringParameters_add_banned_from_list(this.ptr, node_ids != null ? Arrays.stream(node_ids).mapToLong(node_ids_conv_8 -> node_ids_conv_8 == null ? 0 : node_ids_conv_8.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(node_ids);
-		for (NodeId node_ids_conv_8: node_ids) { this.ptrs_to.add(node_ids_conv_8); };
+		for (NodeId node_ids_conv_8: node_ids) { if (this != null) { this.ptrs_to.add(node_ids_conv_8); }; };
 	}
 
 	/**
@@ -336,7 +336,7 @@ public class ProbabilisticScoringParameters extends CommonBase {
 		long ret = bindings.ProbabilisticScoringParameters_default();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ProbabilisticScoringParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ProbabilisticScoringParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/QueryChannelRange.java
+++ b/src/main/java/org/ldk/structs/QueryChannelRange.java
@@ -87,7 +87,7 @@ public class QueryChannelRange extends CommonBase {
 		Reference.reachabilityFence(number_of_blocks_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.QueryChannelRange ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.QueryChannelRange(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -105,7 +105,7 @@ public class QueryChannelRange extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.QueryChannelRange ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.QueryChannelRange(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/QueryShortChannelIds.java
+++ b/src/main/java/org/ldk/structs/QueryShortChannelIds.java
@@ -74,7 +74,7 @@ public class QueryShortChannelIds extends CommonBase {
 		Reference.reachabilityFence(short_channel_ids_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.QueryShortChannelIds ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.QueryShortChannelIds(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -92,7 +92,7 @@ public class QueryShortChannelIds extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.QueryShortChannelIds ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.QueryShortChannelIds(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/RapidGossipSync.java
+++ b/src/main/java/org/ldk/structs/RapidGossipSync.java
@@ -31,8 +31,8 @@ public class RapidGossipSync extends CommonBase {
 		Reference.reachabilityFence(network_graph);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RapidGossipSync ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RapidGossipSync(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(network_graph);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(network_graph); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/RawDataPart.java
+++ b/src/main/java/org/ldk/structs/RawDataPart.java
@@ -28,7 +28,7 @@ public class RawDataPart extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PositiveTimestamp ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PositiveTimestamp(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -39,7 +39,7 @@ public class RawDataPart extends CommonBase {
 		bindings.RawDataPart_set_timestamp(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -51,7 +51,7 @@ public class RawDataPart extends CommonBase {
 		boolean ret = bindings.RawDataPart_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -73,7 +73,7 @@ public class RawDataPart extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RawDataPart ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RawDataPart(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/RawInvoice.java
+++ b/src/main/java/org/ldk/structs/RawInvoice.java
@@ -32,7 +32,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RawDataPart ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RawDataPart(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -43,7 +43,7 @@ public class RawInvoice extends CommonBase {
 		bindings.RawInvoice_set_data(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -55,7 +55,7 @@ public class RawInvoice extends CommonBase {
 		boolean ret = bindings.RawInvoice_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -77,7 +77,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RawInvoice ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RawInvoice(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -99,7 +99,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Sha256 ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Sha256(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -112,7 +112,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Description ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Description(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -125,7 +125,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PayeePubKey ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PayeePubKey(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -138,7 +138,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Sha256 ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Sha256(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -151,7 +151,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ExpiryTime ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ExpiryTime(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -164,7 +164,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.MinFinalCltvExpiry ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.MinFinalCltvExpiry(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -187,7 +187,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -199,7 +199,7 @@ public class RawInvoice extends CommonBase {
 		for (int o = 0; o < ret_conv_14_len; o++) {
 			long ret_conv_14 = ret[o];
 			org.ldk.structs.PrivateRoute ret_conv_14_hu_conv = null; if (ret_conv_14 < 0 || ret_conv_14 > 4096) { ret_conv_14_hu_conv = new org.ldk.structs.PrivateRoute(null, ret_conv_14); }
-			ret_conv_14_hu_conv.ptrs_to.add(this);
+			if (ret_conv_14_hu_conv != null) { ret_conv_14_hu_conv.ptrs_to.add(this); };
 			ret_conv_14_arr[o] = ret_conv_14_hu_conv;
 		}
 		return ret_conv_14_arr;
@@ -210,7 +210,7 @@ public class RawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ReadOnlyNetworkGraph.java
+++ b/src/main/java/org/ldk/structs/ReadOnlyNetworkGraph.java
@@ -30,7 +30,7 @@ public class ReadOnlyNetworkGraph extends CommonBase implements AutoCloseable {
 		Reference.reachabilityFence(short_channel_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -55,8 +55,8 @@ public class ReadOnlyNetworkGraph extends CommonBase implements AutoCloseable {
 		Reference.reachabilityFence(node_id);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeInfo ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeInfo(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
-		this.ptrs_to.add(node_id);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
+		if (this != null) { this.ptrs_to.add(node_id); };
 		return ret_hu_conv;
 	}
 
@@ -71,7 +71,7 @@ public class ReadOnlyNetworkGraph extends CommonBase implements AutoCloseable {
 		for (int i = 0; i < ret_conv_8_len; i++) {
 			long ret_conv_8 = ret[i];
 			org.ldk.structs.NodeId ret_conv_8_hu_conv = null; if (ret_conv_8 < 0 || ret_conv_8 > 4096) { ret_conv_8_hu_conv = new org.ldk.structs.NodeId(null, ret_conv_8); }
-			ret_conv_8_hu_conv.ptrs_to.add(this);
+			if (ret_conv_8_hu_conv != null) { ret_conv_8_hu_conv.ptrs_to.add(this); };
 			ret_conv_8_arr[i] = ret_conv_8_hu_conv;
 		}
 		return ret_conv_8_arr;
@@ -88,7 +88,7 @@ public class ReadOnlyNetworkGraph extends CommonBase implements AutoCloseable {
 		Reference.reachabilityFence(pubkey);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_CVec_NetAddressZZ ret_hu_conv = org.ldk.structs.Option_CVec_NetAddressZZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Record.java
+++ b/src/main/java/org/ldk/structs/Record.java
@@ -125,7 +125,7 @@ public class Record extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Record ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Record(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ReplyChannelRange.java
+++ b/src/main/java/org/ldk/structs/ReplyChannelRange.java
@@ -130,7 +130,7 @@ public class ReplyChannelRange extends CommonBase {
 		Reference.reachabilityFence(short_channel_ids_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ReplyChannelRange ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ReplyChannelRange(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -148,7 +148,7 @@ public class ReplyChannelRange extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ReplyChannelRange ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ReplyChannelRange(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ReplyShortChannelIdsEnd.java
+++ b/src/main/java/org/ldk/structs/ReplyShortChannelIdsEnd.java
@@ -70,7 +70,7 @@ public class ReplyShortChannelIdsEnd extends CommonBase {
 		Reference.reachabilityFence(full_information_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ReplyShortChannelIdsEnd ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ReplyShortChannelIdsEnd(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -88,7 +88,7 @@ public class ReplyShortChannelIdsEnd extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ReplyShortChannelIdsEnd ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ReplyShortChannelIdsEnd(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_AcceptChannelDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_AcceptChannelDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_AcceptChannelDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_AcceptChannelDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.AcceptChannel res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.AcceptChannel(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_AcceptChannelDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_AcceptChannelDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_AcceptChannelDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_AcceptChannelDecodeErrorZ ret_hu_conv = Result_AcceptChannelDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_AcceptChannelDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_AcceptChannelDecodeErrorZ ret_hu_conv = Result_AcceptChannelDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_AnnouncementSignaturesDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_AnnouncementSignaturesDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_AnnouncementSignaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_AnnouncementSignaturesDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.AnnouncementSignatures res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.AnnouncementSignatures(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_AnnouncementSignaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_AnnouncementSignaturesDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_AnnouncementSignaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_AnnouncementSignaturesDecodeErrorZ ret_hu_conv = Result_AnnouncementSignaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_AnnouncementSignaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_AnnouncementSignaturesDecodeErrorZ ret_hu_conv = Result_AnnouncementSignaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_BuiltCommitmentTransactionDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_BuiltCommitmentTransactionDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_BuiltCommitmentTransactionDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_BuiltCommitmentTransactionDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.BuiltCommitmentTransaction res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.BuiltCommitmentTransaction(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_BuiltCommitmentTransactionDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_BuiltCommitmentTransactionDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_BuiltCommitmentTransactionDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_BuiltCommitmentTransactionDecodeErrorZ ret_hu_conv = Result_BuiltCommitmentTransactionDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_BuiltCommitmentTransactionDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_BuiltCommitmentTransactionDecodeErrorZ ret_hu_conv = Result_BuiltCommitmentTransactionDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ extends CommonB
 			super(_dummy, ptr);
 			long res = bindings.CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_get_ok(ptr);
 			TwoTuple_BlockHashChannelManagerZ res_hu_conv = new TwoTuple_BlockHashChannelManagerZ(null, res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ extends CommonB
 			super(_dummy, ptr);
 			long err = bindings.CResult_C2Tuple_BlockHashChannelManagerZDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ extends CommonB
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ ret_hu_conv = Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ extends CommonB
 			super(_dummy, ptr);
 			long res = bindings.CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_get_ok(ptr);
 			TwoTuple_BlockHashChannelMonitorZ res_hu_conv = new TwoTuple_BlockHashChannelMonitorZ(null, res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ extends CommonB
 			super(_dummy, ptr);
 			long err = bindings.CResult_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ extends CommonB
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ ret_hu_conv = Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ.java
+++ b/src/main/java/org/ldk/structs/Result_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ.java
@@ -26,7 +26,7 @@ public class Result_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ extends Com
 			super(_dummy, ptr);
 			long res = bindings.CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_get_ok(ptr);
 			TwoTuple_PaymentHashPaymentIdZ res_hu_conv = new TwoTuple_PaymentHashPaymentIdZ(null, res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ extends Com
 			super(_dummy, ptr);
 			long err = bindings.CResult_C2Tuple_PaymentHashPaymentIdZPaymentSendFailureZ_get_err(ptr);
 			org.ldk.structs.PaymentSendFailure err_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ.java
@@ -26,7 +26,7 @@ public class Result_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ extends CommonBas
 			super(_dummy, ptr);
 			long res = bindings.CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_get_ok(ptr);
 			TwoTuple_PaymentHashPaymentSecretZ res_hu_conv = new TwoTuple_PaymentHashPaymentSecretZ(null, res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ extends CommonBas
 			super(_dummy, ptr);
 			long err = bindings.CResult_C2Tuple_PaymentHashPaymentSecretZAPIErrorZ_get_err(ptr);
 			org.ldk.structs.APIError err_hu_conv = org.ldk.structs.APIError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_C2Tuple_PaymentHashPaymentSecretZNoneZ.java
+++ b/src/main/java/org/ldk/structs/Result_C2Tuple_PaymentHashPaymentSecretZNoneZ.java
@@ -26,7 +26,7 @@ public class Result_C2Tuple_PaymentHashPaymentSecretZNoneZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_C2Tuple_PaymentHashPaymentSecretZNoneZ_get_ok(ptr);
 			TwoTuple_PaymentHashPaymentSecretZ res_hu_conv = new TwoTuple_PaymentHashPaymentSecretZ(null, res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_C2Tuple_SignatureCVec_SignatureZZNoneZ.java
+++ b/src/main/java/org/ldk/structs/Result_C2Tuple_SignatureCVec_SignatureZZNoneZ.java
@@ -26,7 +26,7 @@ public class Result_C2Tuple_SignatureCVec_SignatureZZNoneZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_C2Tuple_SignatureCVec_SignatureZZNoneZ_get_ok(ptr);
 			TwoTuple_SignatureCVec_SignatureZZ res_hu_conv = new TwoTuple_SignatureCVec_SignatureZZ(null, res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_C2Tuple_SignatureSignatureZNoneZ.java
+++ b/src/main/java/org/ldk/structs/Result_C2Tuple_SignatureSignatureZNoneZ.java
@@ -26,7 +26,7 @@ public class Result_C2Tuple_SignatureSignatureZNoneZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_C2Tuple_SignatureSignatureZNoneZ_get_ok(ptr);
 			TwoTuple_SignatureSignatureZ res_hu_conv = new TwoTuple_SignatureSignatureZ(null, res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_COption_ClosureReasonZDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_COption_ClosureReasonZDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_COption_ClosureReasonZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_COption_ClosureReasonZDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Option_ClosureReasonZ res_hu_conv = org.ldk.structs.Option_ClosureReasonZ.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_COption_ClosureReasonZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_COption_ClosureReasonZDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_COption_ClosureReasonZDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_COption_ClosureReasonZDecodeErrorZ ret_hu_conv = Result_COption_ClosureReasonZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_COption_EventZDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_COption_EventZDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_COption_EventZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_COption_EventZDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Option_EventZ res_hu_conv = org.ldk.structs.Option_EventZ.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_COption_EventZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_COption_EventZDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_COption_EventZDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_COption_EventZDecodeErrorZ ret_hu_conv = Result_COption_EventZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_COption_HTLCDestinationZDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_COption_HTLCDestinationZDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_COption_HTLCDestinationZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_COption_HTLCDestinationZDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Option_HTLCDestinationZ res_hu_conv = org.ldk.structs.Option_HTLCDestinationZ.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_COption_HTLCDestinationZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_COption_HTLCDestinationZDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_COption_HTLCDestinationZDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_COption_HTLCDestinationZDecodeErrorZ ret_hu_conv = Result_COption_HTLCDestinationZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_COption_MonitorEventZDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_COption_MonitorEventZDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_COption_MonitorEventZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_COption_MonitorEventZDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Option_MonitorEventZ res_hu_conv = org.ldk.structs.Option_MonitorEventZ.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_COption_MonitorEventZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_COption_MonitorEventZDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_COption_MonitorEventZDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_COption_MonitorEventZDecodeErrorZ ret_hu_conv = Result_COption_MonitorEventZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_COption_NetworkUpdateZDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_COption_NetworkUpdateZDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_COption_NetworkUpdateZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_COption_NetworkUpdateZDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Option_NetworkUpdateZ res_hu_conv = org.ldk.structs.Option_NetworkUpdateZ.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_COption_NetworkUpdateZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_COption_NetworkUpdateZDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_COption_NetworkUpdateZDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_COption_NetworkUpdateZDecodeErrorZ ret_hu_conv = Result_COption_NetworkUpdateZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_COption_TypeZDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_COption_TypeZDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_COption_TypeZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_COption_TypeZDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Option_TypeZ res_hu_conv = org.ldk.structs.Option_TypeZ.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_COption_TypeZDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_COption_TypeZDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_COption_TypeZDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_COption_TypeZDecodeErrorZ ret_hu_conv = Result_COption_TypeZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ.java
@@ -30,7 +30,7 @@ public class Result_CVec_C2Tuple_BlockHashChannelMonitorZZErrorZ extends CommonB
 			for (int j = 0; j < res_conv_35_len; j++) {
 				long res_conv_35 = res[j];
 				TwoTuple_BlockHashChannelMonitorZ res_conv_35_hu_conv = new TwoTuple_BlockHashChannelMonitorZ(null, res_conv_35);
-				res_conv_35_hu_conv.ptrs_to.add(this);
+				if (res_conv_35_hu_conv != null) { res_conv_35_hu_conv.ptrs_to.add(this); };
 				res_conv_35_arr[j] = res_conv_35_hu_conv;
 			}
 			this.res = res_conv_35_arr;

--- a/src/main/java/org/ldk/structs/Result_CVec_u8ZPeerHandleErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_CVec_u8ZPeerHandleErrorZ.java
@@ -34,7 +34,7 @@ public class Result_CVec_u8ZPeerHandleErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_CVec_u8ZPeerHandleErrorZ_get_err(ptr);
 			org.ldk.structs.PeerHandleError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.PeerHandleError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -58,7 +58,7 @@ public class Result_CVec_u8ZPeerHandleErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CVec_u8ZPeerHandleErrorZ ret_hu_conv = Result_CVec_u8ZPeerHandleErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelAnnouncementDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelAnnouncementDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelAnnouncementDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelAnnouncementDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelAnnouncement res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelAnnouncement(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelAnnouncementDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelAnnouncementDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelAnnouncementDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelAnnouncementDecodeErrorZ ret_hu_conv = Result_ChannelAnnouncementDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelAnnouncementDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelAnnouncementDecodeErrorZ ret_hu_conv = Result_ChannelAnnouncementDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelConfigDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelConfigDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelConfigDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelConfigDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelConfig res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelConfig(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelConfigDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelConfigDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelConfigDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelConfigDecodeErrorZ ret_hu_conv = Result_ChannelConfigDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelConfigDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelConfigDecodeErrorZ ret_hu_conv = Result_ChannelConfigDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelCounterpartyDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelCounterpartyDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelCounterpartyDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelCounterpartyDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelCounterparty res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelCounterparty(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelCounterpartyDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelCounterpartyDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelCounterpartyDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelCounterpartyDecodeErrorZ ret_hu_conv = Result_ChannelCounterpartyDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelCounterpartyDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelCounterpartyDecodeErrorZ ret_hu_conv = Result_ChannelCounterpartyDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelDetailsDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelDetailsDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelDetailsDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelDetailsDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelDetails res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelDetails(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelDetailsDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelDetailsDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelDetailsDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelDetailsDecodeErrorZ ret_hu_conv = Result_ChannelDetailsDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelDetailsDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelDetailsDecodeErrorZ ret_hu_conv = Result_ChannelDetailsDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelFeaturesDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelFeaturesDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelFeaturesDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelFeatures res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelFeatures(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelFeaturesDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelFeaturesDecodeErrorZ ret_hu_conv = Result_ChannelFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelFeaturesDecodeErrorZ ret_hu_conv = Result_ChannelFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelInfoDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelInfoDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelInfoDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelInfo res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelInfo(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelInfoDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelInfoDecodeErrorZ ret_hu_conv = Result_ChannelInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelInfoDecodeErrorZ ret_hu_conv = Result_ChannelInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelMonitorUpdateDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelMonitorUpdateDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelMonitorUpdateDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelMonitorUpdateDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelMonitorUpdate res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelMonitorUpdate(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelMonitorUpdateDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelMonitorUpdateDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelMonitorUpdateDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelMonitorUpdateDecodeErrorZ ret_hu_conv = Result_ChannelMonitorUpdateDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelMonitorUpdateDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelMonitorUpdateDecodeErrorZ ret_hu_conv = Result_ChannelMonitorUpdateDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelPublicKeysDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelPublicKeysDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelPublicKeysDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelPublicKeysDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelPublicKeys res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelPublicKeys(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelPublicKeysDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelPublicKeysDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelPublicKeysDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelPublicKeysDecodeErrorZ ret_hu_conv = Result_ChannelPublicKeysDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelPublicKeysDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelPublicKeysDecodeErrorZ ret_hu_conv = Result_ChannelPublicKeysDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelReadyDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelReadyDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelReadyDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelReadyDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelReady res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelReady(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelReadyDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelReadyDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelReadyDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelReadyDecodeErrorZ ret_hu_conv = Result_ChannelReadyDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelReadyDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelReadyDecodeErrorZ ret_hu_conv = Result_ChannelReadyDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelReestablishDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelReestablishDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelReestablishDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelReestablishDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelReestablish res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelReestablish(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelReestablishDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelReestablishDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelReestablishDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelReestablishDecodeErrorZ ret_hu_conv = Result_ChannelReestablishDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelReestablishDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelReestablishDecodeErrorZ ret_hu_conv = Result_ChannelReestablishDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelTransactionParametersDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelTransactionParametersDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelTransactionParametersDecodeErrorZ extends CommonBase 
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelTransactionParametersDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelTransactionParameters res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelTransactionParameters(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelTransactionParametersDecodeErrorZ extends CommonBase 
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelTransactionParametersDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelTransactionParametersDecodeErrorZ extends CommonBase 
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelTransactionParametersDecodeErrorZ ret_hu_conv = Result_ChannelTransactionParametersDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelTransactionParametersDecodeErrorZ extends CommonBase 
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelTransactionParametersDecodeErrorZ ret_hu_conv = Result_ChannelTransactionParametersDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelTypeFeaturesDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelTypeFeaturesDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelTypeFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelTypeFeaturesDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelTypeFeatures res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelTypeFeatures(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelTypeFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelTypeFeaturesDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelTypeFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelTypeFeaturesDecodeErrorZ ret_hu_conv = Result_ChannelTypeFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelTypeFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelTypeFeaturesDecodeErrorZ ret_hu_conv = Result_ChannelTypeFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelUpdateDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelUpdateDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelUpdateDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelUpdateDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelUpdate res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelUpdate(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelUpdateDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelUpdateDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelUpdateDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelUpdateDecodeErrorZ ret_hu_conv = Result_ChannelUpdateDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelUpdateDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelUpdateDecodeErrorZ ret_hu_conv = Result_ChannelUpdateDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ChannelUpdateInfoDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ChannelUpdateInfoDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ChannelUpdateInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ChannelUpdateInfoDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ChannelUpdateInfo res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ChannelUpdateInfo(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ChannelUpdateInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ChannelUpdateInfoDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ChannelUpdateInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelUpdateInfoDecodeErrorZ ret_hu_conv = Result_ChannelUpdateInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ChannelUpdateInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ChannelUpdateInfoDecodeErrorZ ret_hu_conv = Result_ChannelUpdateInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ClosingSignedDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ClosingSignedDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ClosingSignedDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ClosingSignedDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ClosingSigned res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ClosingSigned(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ClosingSignedDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ClosingSignedDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ClosingSignedDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ClosingSignedDecodeErrorZ ret_hu_conv = Result_ClosingSignedDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ClosingSignedDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ClosingSignedDecodeErrorZ ret_hu_conv = Result_ClosingSignedDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ClosingSignedFeeRangeDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ClosingSignedFeeRangeDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ClosingSignedFeeRangeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ClosingSignedFeeRangeDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ClosingSignedFeeRange res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ClosingSignedFeeRange(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ClosingSignedFeeRangeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ClosingSignedFeeRangeDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ClosingSignedFeeRangeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ClosingSignedFeeRangeDecodeErrorZ ret_hu_conv = Result_ClosingSignedFeeRangeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ClosingSignedFeeRangeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ClosingSignedFeeRangeDecodeErrorZ ret_hu_conv = Result_ClosingSignedFeeRangeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_CommitmentSignedDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_CommitmentSignedDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_CommitmentSignedDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_CommitmentSignedDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.CommitmentSigned res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.CommitmentSigned(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_CommitmentSignedDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_CommitmentSignedDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_CommitmentSignedDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CommitmentSignedDecodeErrorZ ret_hu_conv = Result_CommitmentSignedDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_CommitmentSignedDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CommitmentSignedDecodeErrorZ ret_hu_conv = Result_CommitmentSignedDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_CommitmentTransactionDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_CommitmentTransactionDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_CommitmentTransactionDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_CommitmentTransactionDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.CommitmentTransaction res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.CommitmentTransaction(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_CommitmentTransactionDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_CommitmentTransactionDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_CommitmentTransactionDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CommitmentTransactionDecodeErrorZ ret_hu_conv = Result_CommitmentTransactionDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_CommitmentTransactionDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CommitmentTransactionDecodeErrorZ ret_hu_conv = Result_CommitmentTransactionDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_CounterpartyChannelTransactionParametersDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_CounterpartyChannelTransactionParametersDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_CounterpartyChannelTransactionParametersDecodeErrorZ extends
 			super(_dummy, ptr);
 			long res = bindings.CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.CounterpartyChannelTransactionParameters res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.CounterpartyChannelTransactionParameters(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_CounterpartyChannelTransactionParametersDecodeErrorZ extends
 			super(_dummy, ptr);
 			long err = bindings.CResult_CounterpartyChannelTransactionParametersDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_CounterpartyChannelTransactionParametersDecodeErrorZ extends
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CounterpartyChannelTransactionParametersDecodeErrorZ ret_hu_conv = Result_CounterpartyChannelTransactionParametersDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_CounterpartyChannelTransactionParametersDecodeErrorZ extends
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CounterpartyChannelTransactionParametersDecodeErrorZ ret_hu_conv = Result_CounterpartyChannelTransactionParametersDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_CounterpartyCommitmentSecretsDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_CounterpartyCommitmentSecretsDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_CounterpartyCommitmentSecretsDecodeErrorZ extends CommonBase
 			super(_dummy, ptr);
 			long res = bindings.CResult_CounterpartyCommitmentSecretsDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.CounterpartyCommitmentSecrets res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.CounterpartyCommitmentSecrets(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_CounterpartyCommitmentSecretsDecodeErrorZ extends CommonBase
 			super(_dummy, ptr);
 			long err = bindings.CResult_CounterpartyCommitmentSecretsDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_CounterpartyCommitmentSecretsDecodeErrorZ extends CommonBase
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CounterpartyCommitmentSecretsDecodeErrorZ ret_hu_conv = Result_CounterpartyCommitmentSecretsDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_CounterpartyCommitmentSecretsDecodeErrorZ extends CommonBase
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CounterpartyCommitmentSecretsDecodeErrorZ ret_hu_conv = Result_CounterpartyCommitmentSecretsDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_CounterpartyForwardingInfoDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_CounterpartyForwardingInfoDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_CounterpartyForwardingInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_CounterpartyForwardingInfoDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.CounterpartyForwardingInfo res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.CounterpartyForwardingInfo(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_CounterpartyForwardingInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_CounterpartyForwardingInfoDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_CounterpartyForwardingInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CounterpartyForwardingInfoDecodeErrorZ ret_hu_conv = Result_CounterpartyForwardingInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_CounterpartyForwardingInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CounterpartyForwardingInfoDecodeErrorZ ret_hu_conv = Result_CounterpartyForwardingInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_DelayedPaymentOutputDescriptorDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_DelayedPaymentOutputDescriptorDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_DelayedPaymentOutputDescriptorDecodeErrorZ extends CommonBas
 			super(_dummy, ptr);
 			long res = bindings.CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.DelayedPaymentOutputDescriptor res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.DelayedPaymentOutputDescriptor(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_DelayedPaymentOutputDescriptorDecodeErrorZ extends CommonBas
 			super(_dummy, ptr);
 			long err = bindings.CResult_DelayedPaymentOutputDescriptorDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_DelayedPaymentOutputDescriptorDecodeErrorZ extends CommonBas
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_DelayedPaymentOutputDescriptorDecodeErrorZ ret_hu_conv = Result_DelayedPaymentOutputDescriptorDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_DelayedPaymentOutputDescriptorDecodeErrorZ extends CommonBas
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_DelayedPaymentOutputDescriptorDecodeErrorZ ret_hu_conv = Result_DelayedPaymentOutputDescriptorDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_DescriptionCreationErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_DescriptionCreationErrorZ.java
@@ -26,7 +26,7 @@ public class Result_DescriptionCreationErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_DescriptionCreationErrorZ_get_ok(ptr);
 			org.ldk.structs.Description res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Description(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -47,7 +47,7 @@ public class Result_DescriptionCreationErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_DescriptionCreationErrorZ ret_hu_conv = Result_DescriptionCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ErrorMessageDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ErrorMessageDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ErrorMessageDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ErrorMessageDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ErrorMessage res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ErrorMessage(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ErrorMessageDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ErrorMessageDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ErrorMessageDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ErrorMessageDecodeErrorZ ret_hu_conv = Result_ErrorMessageDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ErrorMessageDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ErrorMessageDecodeErrorZ ret_hu_conv = Result_ErrorMessageDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_FixedPenaltyScorerDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_FixedPenaltyScorerDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_FixedPenaltyScorerDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_FixedPenaltyScorerDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.FixedPenaltyScorer res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.FixedPenaltyScorer(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_FixedPenaltyScorerDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_FixedPenaltyScorerDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_FixedPenaltyScorerDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_FixedPenaltyScorerDecodeErrorZ ret_hu_conv = Result_FixedPenaltyScorerDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_FixedPenaltyScorerDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_FixedPenaltyScorerDecodeErrorZ ret_hu_conv = Result_FixedPenaltyScorerDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_FundingCreatedDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_FundingCreatedDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_FundingCreatedDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_FundingCreatedDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.FundingCreated res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.FundingCreated(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_FundingCreatedDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_FundingCreatedDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_FundingCreatedDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_FundingCreatedDecodeErrorZ ret_hu_conv = Result_FundingCreatedDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_FundingCreatedDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_FundingCreatedDecodeErrorZ ret_hu_conv = Result_FundingCreatedDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_FundingSignedDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_FundingSignedDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_FundingSignedDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_FundingSignedDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.FundingSigned res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.FundingSigned(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_FundingSignedDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_FundingSignedDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_FundingSignedDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_FundingSignedDecodeErrorZ ret_hu_conv = Result_FundingSignedDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_FundingSignedDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_FundingSignedDecodeErrorZ ret_hu_conv = Result_FundingSignedDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_GossipTimestampFilterDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_GossipTimestampFilterDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_GossipTimestampFilterDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_GossipTimestampFilterDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.GossipTimestampFilter res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.GossipTimestampFilter(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_GossipTimestampFilterDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_GossipTimestampFilterDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_GossipTimestampFilterDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_GossipTimestampFilterDecodeErrorZ ret_hu_conv = Result_GossipTimestampFilterDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_GossipTimestampFilterDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_GossipTimestampFilterDecodeErrorZ ret_hu_conv = Result_GossipTimestampFilterDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_HTLCOutputInCommitmentDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_HTLCOutputInCommitmentDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_HTLCOutputInCommitmentDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_HTLCOutputInCommitmentDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.HTLCOutputInCommitment res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.HTLCOutputInCommitment(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_HTLCOutputInCommitmentDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_HTLCOutputInCommitmentDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_HTLCOutputInCommitmentDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_HTLCOutputInCommitmentDecodeErrorZ ret_hu_conv = Result_HTLCOutputInCommitmentDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_HTLCOutputInCommitmentDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_HTLCOutputInCommitmentDecodeErrorZ ret_hu_conv = Result_HTLCOutputInCommitmentDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_HTLCUpdateDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_HTLCUpdateDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_HTLCUpdateDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_HTLCUpdateDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.HTLCUpdate res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.HTLCUpdate(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_HTLCUpdateDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_HTLCUpdateDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_HTLCUpdateDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_HTLCUpdateDecodeErrorZ ret_hu_conv = Result_HTLCUpdateDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_HTLCUpdateDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_HTLCUpdateDecodeErrorZ ret_hu_conv = Result_HTLCUpdateDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_HolderCommitmentTransactionDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_HolderCommitmentTransactionDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_HolderCommitmentTransactionDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_HolderCommitmentTransactionDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.HolderCommitmentTransaction res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.HolderCommitmentTransaction(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_HolderCommitmentTransactionDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_HolderCommitmentTransactionDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_HolderCommitmentTransactionDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_HolderCommitmentTransactionDecodeErrorZ ret_hu_conv = Result_HolderCommitmentTransactionDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_HolderCommitmentTransactionDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_HolderCommitmentTransactionDecodeErrorZ ret_hu_conv = Result_HolderCommitmentTransactionDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_InMemorySignerDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_InMemorySignerDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_InMemorySignerDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_InMemorySignerDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.InMemorySigner res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.InMemorySigner(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_InMemorySignerDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_InMemorySignerDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_InMemorySignerDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InMemorySignerDecodeErrorZ ret_hu_conv = Result_InMemorySignerDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_InMemorySignerDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InMemorySignerDecodeErrorZ ret_hu_conv = Result_InMemorySignerDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_InitDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_InitDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_InitDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_InitDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Init res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Init(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_InitDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_InitDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_InitDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InitDecodeErrorZ ret_hu_conv = Result_InitDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_InitDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InitDecodeErrorZ ret_hu_conv = Result_InitDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_InitFeaturesDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_InitFeaturesDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_InitFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_InitFeaturesDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.InitFeatures res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.InitFeatures(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_InitFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_InitFeaturesDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_InitFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InitFeaturesDecodeErrorZ ret_hu_conv = Result_InitFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_InitFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InitFeaturesDecodeErrorZ ret_hu_conv = Result_InitFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_InvoiceFeaturesDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_InvoiceFeaturesDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_InvoiceFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_InvoiceFeaturesDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.InvoiceFeatures res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.InvoiceFeatures(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_InvoiceFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_InvoiceFeaturesDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_InvoiceFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceFeaturesDecodeErrorZ ret_hu_conv = Result_InvoiceFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_InvoiceFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceFeaturesDecodeErrorZ ret_hu_conv = Result_InvoiceFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_InvoiceParseOrSemanticErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_InvoiceParseOrSemanticErrorZ.java
@@ -26,7 +26,7 @@ public class Result_InvoiceParseOrSemanticErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_InvoiceParseOrSemanticErrorZ_get_ok(ptr);
 			org.ldk.structs.Invoice res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Invoice(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_InvoiceParseOrSemanticErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_InvoiceParseOrSemanticErrorZ_get_err(ptr);
 			org.ldk.structs.ParseOrSemanticError err_hu_conv = org.ldk.structs.ParseOrSemanticError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_InvoiceParseOrSemanticErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceParseOrSemanticErrorZ ret_hu_conv = Result_InvoiceParseOrSemanticErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_InvoiceSemanticErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_InvoiceSemanticErrorZ.java
@@ -26,7 +26,7 @@ public class Result_InvoiceSemanticErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_InvoiceSemanticErrorZ_get_ok(ptr);
 			org.ldk.structs.Invoice res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Invoice(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -47,7 +47,7 @@ public class Result_InvoiceSemanticErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSemanticErrorZ ret_hu_conv = Result_InvoiceSemanticErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_InvoiceSignOrCreationErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_InvoiceSignOrCreationErrorZ.java
@@ -26,7 +26,7 @@ public class Result_InvoiceSignOrCreationErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_InvoiceSignOrCreationErrorZ_get_ok(ptr);
 			org.ldk.structs.Invoice res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Invoice(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_InvoiceSignOrCreationErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_InvoiceSignOrCreationErrorZ_get_err(ptr);
 			org.ldk.structs.SignOrCreationError err_hu_conv = org.ldk.structs.SignOrCreationError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_InvoiceSignOrCreationErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSignOrCreationErrorZ ret_hu_conv = Result_InvoiceSignOrCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_LockedChannelMonitorNoneZ.java
+++ b/src/main/java/org/ldk/structs/Result_LockedChannelMonitorNoneZ.java
@@ -26,7 +26,7 @@ public class Result_LockedChannelMonitorNoneZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_LockedChannelMonitorNoneZ_get_ok(ptr);
 			org.ldk.structs.LockedChannelMonitor res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.LockedChannelMonitor(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -45,7 +45,7 @@ public class Result_LockedChannelMonitorNoneZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_LockedChannelMonitorNoneZ ret_hu_conv = Result_LockedChannelMonitorNoneZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		// Due to rust's strict-ownership memory model, in some cases we need to "move"
 		// an object to pass exclusive ownership to the function being called.
 		// In most cases, we avoid ret_hu_conv being visible in GC'd languages by cloning the object

--- a/src/main/java/org/ldk/structs/Result_NetAddressDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NetAddressDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_NetAddressDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_NetAddressDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.NetAddress res_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_NetAddressDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NetAddressDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_NetAddressDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NetAddressDecodeErrorZ ret_hu_conv = Result_NetAddressDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NetworkGraphDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NetworkGraphDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_NetworkGraphDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_NetworkGraphDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.NetworkGraph res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.NetworkGraph(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_NetworkGraphDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NetworkGraphDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -52,7 +52,7 @@ public class Result_NetworkGraphDecodeErrorZ extends CommonBase {
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NetworkGraphDecodeErrorZ ret_hu_conv = Result_NetworkGraphDecodeErrorZ.constr_from_ptr(ret);
 		;
-		ret_hu_conv.ptrs_to.add(o_logger);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o_logger); };
 		return ret_hu_conv;
 	}
 
@@ -64,7 +64,7 @@ public class Result_NetworkGraphDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NetworkGraphDecodeErrorZ ret_hu_conv = Result_NetworkGraphDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NodeAliasDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NodeAliasDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_NodeAliasDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_NodeAliasDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.NodeAlias res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.NodeAlias(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_NodeAliasDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NodeAliasDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_NodeAliasDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeAliasDecodeErrorZ ret_hu_conv = Result_NodeAliasDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_NodeAliasDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeAliasDecodeErrorZ ret_hu_conv = Result_NodeAliasDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NodeAnnouncementDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NodeAnnouncementDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_NodeAnnouncementDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_NodeAnnouncementDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.NodeAnnouncement res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.NodeAnnouncement(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_NodeAnnouncementDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NodeAnnouncementDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_NodeAnnouncementDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeAnnouncementDecodeErrorZ ret_hu_conv = Result_NodeAnnouncementDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_NodeAnnouncementDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeAnnouncementDecodeErrorZ ret_hu_conv = Result_NodeAnnouncementDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NodeAnnouncementInfoDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NodeAnnouncementInfoDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_NodeAnnouncementInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_NodeAnnouncementInfoDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.NodeAnnouncementInfo res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.NodeAnnouncementInfo(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_NodeAnnouncementInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NodeAnnouncementInfoDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_NodeAnnouncementInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeAnnouncementInfoDecodeErrorZ ret_hu_conv = Result_NodeAnnouncementInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_NodeAnnouncementInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeAnnouncementInfoDecodeErrorZ ret_hu_conv = Result_NodeAnnouncementInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NodeFeaturesDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NodeFeaturesDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_NodeFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_NodeFeaturesDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.NodeFeatures res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.NodeFeatures(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_NodeFeaturesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NodeFeaturesDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_NodeFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeFeaturesDecodeErrorZ ret_hu_conv = Result_NodeFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_NodeFeaturesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeFeaturesDecodeErrorZ ret_hu_conv = Result_NodeFeaturesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NodeIdDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NodeIdDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_NodeIdDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_NodeIdDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.NodeId res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.NodeId(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_NodeIdDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NodeIdDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_NodeIdDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeIdDecodeErrorZ ret_hu_conv = Result_NodeIdDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_NodeIdDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeIdDecodeErrorZ ret_hu_conv = Result_NodeIdDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NodeInfoDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NodeInfoDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_NodeInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_NodeInfoDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.NodeInfo res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.NodeInfo(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_NodeInfoDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NodeInfoDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_NodeInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeInfoDecodeErrorZ ret_hu_conv = Result_NodeInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_NodeInfoDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NodeInfoDecodeErrorZ ret_hu_conv = Result_NodeInfoDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NoneAPIErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NoneAPIErrorZ.java
@@ -32,7 +32,7 @@ public class Result_NoneAPIErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NoneAPIErrorZ_get_err(ptr);
 			org.ldk.structs.APIError err_hu_conv = org.ldk.structs.APIError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_NoneLightningErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NoneLightningErrorZ.java
@@ -32,7 +32,7 @@ public class Result_NoneLightningErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NoneLightningErrorZ_get_err(ptr);
 			org.ldk.structs.LightningError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.LightningError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -55,7 +55,7 @@ public class Result_NoneLightningErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_NonePaymentSendFailureZ.java
+++ b/src/main/java/org/ldk/structs/Result_NonePaymentSendFailureZ.java
@@ -32,7 +32,7 @@ public class Result_NonePaymentSendFailureZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NonePaymentSendFailureZ_get_err(ptr);
 			org.ldk.structs.PaymentSendFailure err_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_NonePeerHandleErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_NonePeerHandleErrorZ.java
@@ -32,7 +32,7 @@ public class Result_NonePeerHandleErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_NonePeerHandleErrorZ_get_err(ptr);
 			org.ldk.structs.PeerHandleError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.PeerHandleError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -55,7 +55,7 @@ public class Result_NonePeerHandleErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NonePeerHandleErrorZ ret_hu_conv = Result_NonePeerHandleErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_OpenChannelDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_OpenChannelDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_OpenChannelDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_OpenChannelDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.OpenChannel res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.OpenChannel(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_OpenChannelDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_OpenChannelDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_OpenChannelDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_OpenChannelDecodeErrorZ ret_hu_conv = Result_OpenChannelDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_OpenChannelDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_OpenChannelDecodeErrorZ ret_hu_conv = Result_OpenChannelDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_OutPointDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_OutPointDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_OutPointDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_OutPointDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.OutPoint res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.OutPoint(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_OutPointDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_OutPointDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_OutPointDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_OutPointDecodeErrorZ ret_hu_conv = Result_OutPointDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_OutPointDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_OutPointDecodeErrorZ ret_hu_conv = Result_OutPointDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_PayeePubKeyErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PayeePubKeyErrorZ.java
@@ -26,7 +26,7 @@ public class Result_PayeePubKeyErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_PayeePubKeyErrorZ_get_ok(ptr);
 			org.ldk.structs.PayeePubKey res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.PayeePubKey(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -47,7 +47,7 @@ public class Result_PayeePubKeyErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PayeePubKeyErrorZ ret_hu_conv = Result_PayeePubKeyErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_PaymentIdPaymentErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PaymentIdPaymentErrorZ.java
@@ -34,7 +34,7 @@ public class Result_PaymentIdPaymentErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PaymentIdPaymentErrorZ_get_err(ptr);
 			org.ldk.structs.PaymentError err_hu_conv = org.ldk.structs.PaymentError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_PaymentIdPaymentSendFailureZ.java
+++ b/src/main/java/org/ldk/structs/Result_PaymentIdPaymentSendFailureZ.java
@@ -34,7 +34,7 @@ public class Result_PaymentIdPaymentSendFailureZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PaymentIdPaymentSendFailureZ_get_err(ptr);
 			org.ldk.structs.PaymentSendFailure err_hu_conv = org.ldk.structs.PaymentSendFailure.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_PaymentParametersDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PaymentParametersDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_PaymentParametersDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_PaymentParametersDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.PaymentParameters res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.PaymentParameters(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_PaymentParametersDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PaymentParametersDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_PaymentParametersDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentParametersDecodeErrorZ ret_hu_conv = Result_PaymentParametersDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_PaymentParametersDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentParametersDecodeErrorZ ret_hu_conv = Result_PaymentParametersDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_PaymentPreimageAPIErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PaymentPreimageAPIErrorZ.java
@@ -34,7 +34,7 @@ public class Result_PaymentPreimageAPIErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PaymentPreimageAPIErrorZ_get_err(ptr);
 			org.ldk.structs.APIError err_hu_conv = org.ldk.structs.APIError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_PaymentPurposeDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PaymentPurposeDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_PaymentPurposeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_PaymentPurposeDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.PaymentPurpose res_hu_conv = org.ldk.structs.PaymentPurpose.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_PaymentPurposeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PaymentPurposeDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_PaymentPurposeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentPurposeDecodeErrorZ ret_hu_conv = Result_PaymentPurposeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_PaymentSecretAPIErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PaymentSecretAPIErrorZ.java
@@ -34,7 +34,7 @@ public class Result_PaymentSecretAPIErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PaymentSecretAPIErrorZ_get_err(ptr);
 			org.ldk.structs.APIError err_hu_conv = org.ldk.structs.APIError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_PhantomRouteHintsDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PhantomRouteHintsDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_PhantomRouteHintsDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_PhantomRouteHintsDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.PhantomRouteHints res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.PhantomRouteHints(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_PhantomRouteHintsDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PhantomRouteHintsDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_PhantomRouteHintsDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PhantomRouteHintsDecodeErrorZ ret_hu_conv = Result_PhantomRouteHintsDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_PhantomRouteHintsDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PhantomRouteHintsDecodeErrorZ ret_hu_conv = Result_PhantomRouteHintsDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_PingDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PingDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_PingDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_PingDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Ping res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Ping(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_PingDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PingDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_PingDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PingDecodeErrorZ ret_hu_conv = Result_PingDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_PingDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PingDecodeErrorZ ret_hu_conv = Result_PingDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_PongDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PongDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_PongDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_PongDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Pong res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Pong(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_PongDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_PongDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_PongDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PongDecodeErrorZ ret_hu_conv = Result_PongDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_PongDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PongDecodeErrorZ ret_hu_conv = Result_PongDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_PositiveTimestampCreationErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PositiveTimestampCreationErrorZ.java
@@ -26,7 +26,7 @@ public class Result_PositiveTimestampCreationErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_PositiveTimestampCreationErrorZ_get_ok(ptr);
 			org.ldk.structs.PositiveTimestamp res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.PositiveTimestamp(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -47,7 +47,7 @@ public class Result_PositiveTimestampCreationErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PositiveTimestampCreationErrorZ ret_hu_conv = Result_PositiveTimestampCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_PrivateRouteCreationErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_PrivateRouteCreationErrorZ.java
@@ -26,7 +26,7 @@ public class Result_PrivateRouteCreationErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_PrivateRouteCreationErrorZ_get_ok(ptr);
 			org.ldk.structs.PrivateRoute res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.PrivateRoute(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -47,7 +47,7 @@ public class Result_PrivateRouteCreationErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PrivateRouteCreationErrorZ ret_hu_conv = Result_PrivateRouteCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ProbabilisticScorerDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ProbabilisticScorerDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ProbabilisticScorerDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ProbabilisticScorerDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ProbabilisticScorer res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ProbabilisticScorer(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ProbabilisticScorerDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ProbabilisticScorerDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -52,9 +52,9 @@ public class Result_ProbabilisticScorerDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o_logger);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ProbabilisticScorerDecodeErrorZ ret_hu_conv = Result_ProbabilisticScorerDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o_params);
-		ret_hu_conv.ptrs_to.add(o_network_graph);
-		ret_hu_conv.ptrs_to.add(o_logger);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o_params); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o_network_graph); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o_logger); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class Result_ProbabilisticScorerDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ProbabilisticScorerDecodeErrorZ ret_hu_conv = Result_ProbabilisticScorerDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_QueryChannelRangeDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_QueryChannelRangeDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_QueryChannelRangeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_QueryChannelRangeDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.QueryChannelRange res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.QueryChannelRange(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_QueryChannelRangeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_QueryChannelRangeDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_QueryChannelRangeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_QueryChannelRangeDecodeErrorZ ret_hu_conv = Result_QueryChannelRangeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_QueryChannelRangeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_QueryChannelRangeDecodeErrorZ ret_hu_conv = Result_QueryChannelRangeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_QueryShortChannelIdsDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_QueryShortChannelIdsDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_QueryShortChannelIdsDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_QueryShortChannelIdsDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.QueryShortChannelIds res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.QueryShortChannelIds(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_QueryShortChannelIdsDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_QueryShortChannelIdsDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_QueryShortChannelIdsDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_QueryShortChannelIdsDecodeErrorZ ret_hu_conv = Result_QueryShortChannelIdsDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_QueryShortChannelIdsDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_QueryShortChannelIdsDecodeErrorZ ret_hu_conv = Result_QueryShortChannelIdsDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ReplyChannelRangeDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ReplyChannelRangeDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ReplyChannelRangeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ReplyChannelRangeDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ReplyChannelRange res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ReplyChannelRange(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ReplyChannelRangeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ReplyChannelRangeDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ReplyChannelRangeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ReplyChannelRangeDecodeErrorZ ret_hu_conv = Result_ReplyChannelRangeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ReplyChannelRangeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ReplyChannelRangeDecodeErrorZ ret_hu_conv = Result_ReplyChannelRangeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ReplyShortChannelIdsEndDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ReplyShortChannelIdsEndDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ReplyShortChannelIdsEndDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ReplyShortChannelIdsEndDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ReplyShortChannelIdsEnd res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ReplyShortChannelIdsEnd(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ReplyShortChannelIdsEndDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ReplyShortChannelIdsEndDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ReplyShortChannelIdsEndDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ReplyShortChannelIdsEndDecodeErrorZ ret_hu_conv = Result_ReplyShortChannelIdsEndDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ReplyShortChannelIdsEndDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ReplyShortChannelIdsEndDecodeErrorZ ret_hu_conv = Result_ReplyShortChannelIdsEndDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_RevokeAndACKDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_RevokeAndACKDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_RevokeAndACKDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_RevokeAndACKDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.RevokeAndACK res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.RevokeAndACK(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_RevokeAndACKDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_RevokeAndACKDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_RevokeAndACKDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RevokeAndACKDecodeErrorZ ret_hu_conv = Result_RevokeAndACKDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_RevokeAndACKDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RevokeAndACKDecodeErrorZ ret_hu_conv = Result_RevokeAndACKDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_RouteDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_RouteDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_RouteDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_RouteDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Route res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Route(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_RouteDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_RouteDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_RouteDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteDecodeErrorZ ret_hu_conv = Result_RouteDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_RouteDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteDecodeErrorZ ret_hu_conv = Result_RouteDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_RouteHintDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_RouteHintDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_RouteHintDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_RouteHintDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.RouteHint res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.RouteHint(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_RouteHintDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_RouteHintDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_RouteHintDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteHintDecodeErrorZ ret_hu_conv = Result_RouteHintDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_RouteHintDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteHintDecodeErrorZ ret_hu_conv = Result_RouteHintDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_RouteHintHopDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_RouteHintHopDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_RouteHintHopDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_RouteHintHopDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.RouteHintHop res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.RouteHintHop(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_RouteHintHopDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_RouteHintHopDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_RouteHintHopDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteHintHopDecodeErrorZ ret_hu_conv = Result_RouteHintHopDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_RouteHintHopDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteHintHopDecodeErrorZ ret_hu_conv = Result_RouteHintHopDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_RouteHopDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_RouteHopDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_RouteHopDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_RouteHopDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.RouteHop res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.RouteHop(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_RouteHopDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_RouteHopDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_RouteHopDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteHopDecodeErrorZ ret_hu_conv = Result_RouteHopDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_RouteHopDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteHopDecodeErrorZ ret_hu_conv = Result_RouteHopDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_RouteLightningErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_RouteLightningErrorZ.java
@@ -26,7 +26,7 @@ public class Result_RouteLightningErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_RouteLightningErrorZ_get_ok(ptr);
 			org.ldk.structs.Route res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Route(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_RouteLightningErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_RouteLightningErrorZ_get_err(ptr);
 			org.ldk.structs.LightningError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.LightningError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_RouteLightningErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteLightningErrorZ ret_hu_conv = Result_RouteLightningErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_RouteLightningErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteLightningErrorZ ret_hu_conv = Result_RouteLightningErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_RouteParametersDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_RouteParametersDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_RouteParametersDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_RouteParametersDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.RouteParameters res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.RouteParameters(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_RouteParametersDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_RouteParametersDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_RouteParametersDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteParametersDecodeErrorZ ret_hu_conv = Result_RouteParametersDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_RouteParametersDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteParametersDecodeErrorZ ret_hu_conv = Result_RouteParametersDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_RoutingFeesDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_RoutingFeesDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_RoutingFeesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_RoutingFeesDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.RoutingFees res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.RoutingFees(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_RoutingFeesDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_RoutingFeesDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_RoutingFeesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RoutingFeesDecodeErrorZ ret_hu_conv = Result_RoutingFeesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_RoutingFeesDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RoutingFeesDecodeErrorZ ret_hu_conv = Result_RoutingFeesDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ShutdownDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ShutdownDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ShutdownDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ShutdownDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.Shutdown res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.Shutdown(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ShutdownDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ShutdownDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ShutdownDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ShutdownDecodeErrorZ ret_hu_conv = Result_ShutdownDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ShutdownDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ShutdownDecodeErrorZ ret_hu_conv = Result_ShutdownDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ShutdownScriptDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_ShutdownScriptDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_ShutdownScriptDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ShutdownScriptDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.ShutdownScript res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ShutdownScript(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ShutdownScriptDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ShutdownScriptDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ShutdownScriptDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ShutdownScriptDecodeErrorZ ret_hu_conv = Result_ShutdownScriptDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ShutdownScriptDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ShutdownScriptDecodeErrorZ ret_hu_conv = Result_ShutdownScriptDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_ShutdownScriptInvalidShutdownScriptZ.java
+++ b/src/main/java/org/ldk/structs/Result_ShutdownScriptInvalidShutdownScriptZ.java
@@ -26,7 +26,7 @@ public class Result_ShutdownScriptInvalidShutdownScriptZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_ShutdownScriptInvalidShutdownScriptZ_get_ok(ptr);
 			org.ldk.structs.ShutdownScript res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.ShutdownScript(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_ShutdownScriptInvalidShutdownScriptZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_ShutdownScriptInvalidShutdownScriptZ_get_err(ptr);
 			org.ldk.structs.InvalidShutdownScript err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.InvalidShutdownScript(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_ShutdownScriptInvalidShutdownScriptZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ShutdownScriptInvalidShutdownScriptZ ret_hu_conv = Result_ShutdownScriptInvalidShutdownScriptZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_ShutdownScriptInvalidShutdownScriptZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_ShutdownScriptInvalidShutdownScriptZ ret_hu_conv = Result_ShutdownScriptInvalidShutdownScriptZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_SiPrefixParseErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_SiPrefixParseErrorZ.java
@@ -34,7 +34,7 @@ public class Result_SiPrefixParseErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_SiPrefixParseErrorZ_get_err(ptr);
 			org.ldk.structs.ParseError err_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_SignDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_SignDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_SignDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_SignDecodeErrorZ_get_ok(ptr);
 			Sign ret_hu_conv = new Sign(null, res);
-			ret_hu_conv.ptrs_to.add(this);
+			if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 			this.res = ret_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_SignDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_SignDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_SignDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_SignDecodeErrorZ ret_hu_conv = Result_SignDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_SignDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_SignDecodeErrorZ ret_hu_conv = Result_SignDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_SignedRawInvoiceParseErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_SignedRawInvoiceParseErrorZ.java
@@ -26,7 +26,7 @@ public class Result_SignedRawInvoiceParseErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_SignedRawInvoiceParseErrorZ_get_ok(ptr);
 			org.ldk.structs.SignedRawInvoice res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.SignedRawInvoice(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_SignedRawInvoiceParseErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_SignedRawInvoiceParseErrorZ_get_err(ptr);
 			org.ldk.structs.ParseError err_hu_conv = org.ldk.structs.ParseError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_SignedRawInvoiceParseErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_SignedRawInvoiceParseErrorZ ret_hu_conv = Result_SignedRawInvoiceParseErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_SpendableOutputDescriptorDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_SpendableOutputDescriptorDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_SpendableOutputDescriptorDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_SpendableOutputDescriptorDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.SpendableOutputDescriptor res_hu_conv = org.ldk.structs.SpendableOutputDescriptor.constr_from_ptr(res);
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_SpendableOutputDescriptorDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_SpendableOutputDescriptorDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -61,7 +61,7 @@ public class Result_SpendableOutputDescriptorDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_SpendableOutputDescriptorDecodeErrorZ ret_hu_conv = Result_SpendableOutputDescriptorDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_StaticPaymentOutputDescriptorDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_StaticPaymentOutputDescriptorDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_StaticPaymentOutputDescriptorDecodeErrorZ extends CommonBase
 			super(_dummy, ptr);
 			long res = bindings.CResult_StaticPaymentOutputDescriptorDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.StaticPaymentOutputDescriptor res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.StaticPaymentOutputDescriptor(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_StaticPaymentOutputDescriptorDecodeErrorZ extends CommonBase
 			super(_dummy, ptr);
 			long err = bindings.CResult_StaticPaymentOutputDescriptorDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_StaticPaymentOutputDescriptorDecodeErrorZ extends CommonBase
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_StaticPaymentOutputDescriptorDecodeErrorZ ret_hu_conv = Result_StaticPaymentOutputDescriptorDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_StaticPaymentOutputDescriptorDecodeErrorZ extends CommonBase
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_StaticPaymentOutputDescriptorDecodeErrorZ ret_hu_conv = Result_StaticPaymentOutputDescriptorDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_TrustedClosingTransactionNoneZ.java
+++ b/src/main/java/org/ldk/structs/Result_TrustedClosingTransactionNoneZ.java
@@ -26,7 +26,7 @@ public class Result_TrustedClosingTransactionNoneZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_TrustedClosingTransactionNoneZ_get_ok(ptr);
 			org.ldk.structs.TrustedClosingTransaction res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.TrustedClosingTransaction(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -45,7 +45,7 @@ public class Result_TrustedClosingTransactionNoneZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_TrustedClosingTransactionNoneZ ret_hu_conv = Result_TrustedClosingTransactionNoneZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		// Due to rust's strict-ownership memory model, in some cases we need to "move"
 		// an object to pass exclusive ownership to the function being called.
 		// In most cases, we avoid ret_hu_conv being visible in GC'd languages by cloning the object

--- a/src/main/java/org/ldk/structs/Result_TrustedCommitmentTransactionNoneZ.java
+++ b/src/main/java/org/ldk/structs/Result_TrustedCommitmentTransactionNoneZ.java
@@ -26,7 +26,7 @@ public class Result_TrustedCommitmentTransactionNoneZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_TrustedCommitmentTransactionNoneZ_get_ok(ptr);
 			org.ldk.structs.TrustedCommitmentTransaction res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.TrustedCommitmentTransaction(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -45,7 +45,7 @@ public class Result_TrustedCommitmentTransactionNoneZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_TrustedCommitmentTransactionNoneZ ret_hu_conv = Result_TrustedCommitmentTransactionNoneZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		// Due to rust's strict-ownership memory model, in some cases we need to "move"
 		// an object to pass exclusive ownership to the function being called.
 		// In most cases, we avoid ret_hu_conv being visible in GC'd languages by cloning the object

--- a/src/main/java/org/ldk/structs/Result_TxCreationKeysDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_TxCreationKeysDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_TxCreationKeysDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_TxCreationKeysDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.TxCreationKeys res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.TxCreationKeys(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_TxCreationKeysDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_TxCreationKeysDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_TxCreationKeysDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_TxCreationKeysDecodeErrorZ ret_hu_conv = Result_TxCreationKeysDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_TxCreationKeysDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_TxCreationKeysDecodeErrorZ ret_hu_conv = Result_TxCreationKeysDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_TxCreationKeysErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_TxCreationKeysErrorZ.java
@@ -26,7 +26,7 @@ public class Result_TxCreationKeysErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_TxCreationKeysErrorZ_get_ok(ptr);
 			org.ldk.structs.TxCreationKeys res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.TxCreationKeys(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -47,7 +47,7 @@ public class Result_TxCreationKeysErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_TxCreationKeysErrorZ ret_hu_conv = Result_TxCreationKeysErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_UnsignedChannelAnnouncementDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_UnsignedChannelAnnouncementDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_UnsignedChannelAnnouncementDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_UnsignedChannelAnnouncementDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.UnsignedChannelAnnouncement res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.UnsignedChannelAnnouncement(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_UnsignedChannelAnnouncementDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_UnsignedChannelAnnouncementDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_UnsignedChannelAnnouncementDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UnsignedChannelAnnouncementDecodeErrorZ ret_hu_conv = Result_UnsignedChannelAnnouncementDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_UnsignedChannelAnnouncementDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UnsignedChannelAnnouncementDecodeErrorZ ret_hu_conv = Result_UnsignedChannelAnnouncementDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_UnsignedChannelUpdateDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_UnsignedChannelUpdateDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_UnsignedChannelUpdateDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_UnsignedChannelUpdateDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.UnsignedChannelUpdate res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.UnsignedChannelUpdate(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_UnsignedChannelUpdateDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_UnsignedChannelUpdateDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_UnsignedChannelUpdateDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UnsignedChannelUpdateDecodeErrorZ ret_hu_conv = Result_UnsignedChannelUpdateDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_UnsignedChannelUpdateDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UnsignedChannelUpdateDecodeErrorZ ret_hu_conv = Result_UnsignedChannelUpdateDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_UnsignedNodeAnnouncementDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_UnsignedNodeAnnouncementDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_UnsignedNodeAnnouncementDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_UnsignedNodeAnnouncementDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.UnsignedNodeAnnouncement res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.UnsignedNodeAnnouncement(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_UnsignedNodeAnnouncementDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_UnsignedNodeAnnouncementDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_UnsignedNodeAnnouncementDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UnsignedNodeAnnouncementDecodeErrorZ ret_hu_conv = Result_UnsignedNodeAnnouncementDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_UnsignedNodeAnnouncementDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UnsignedNodeAnnouncementDecodeErrorZ ret_hu_conv = Result_UnsignedNodeAnnouncementDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_UpdateAddHTLCDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_UpdateAddHTLCDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_UpdateAddHTLCDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_UpdateAddHTLCDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.UpdateAddHTLC res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.UpdateAddHTLC(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_UpdateAddHTLCDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_UpdateAddHTLCDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_UpdateAddHTLCDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateAddHTLCDecodeErrorZ ret_hu_conv = Result_UpdateAddHTLCDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_UpdateAddHTLCDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateAddHTLCDecodeErrorZ ret_hu_conv = Result_UpdateAddHTLCDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_UpdateFailHTLCDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_UpdateFailHTLCDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_UpdateFailHTLCDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_UpdateFailHTLCDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.UpdateFailHTLC res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.UpdateFailHTLC(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_UpdateFailHTLCDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_UpdateFailHTLCDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_UpdateFailHTLCDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateFailHTLCDecodeErrorZ ret_hu_conv = Result_UpdateFailHTLCDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_UpdateFailHTLCDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateFailHTLCDecodeErrorZ ret_hu_conv = Result_UpdateFailHTLCDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_UpdateFailMalformedHTLCDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_UpdateFailMalformedHTLCDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_UpdateFailMalformedHTLCDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_UpdateFailMalformedHTLCDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.UpdateFailMalformedHTLC res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.UpdateFailMalformedHTLC(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_UpdateFailMalformedHTLCDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_UpdateFailMalformedHTLCDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_UpdateFailMalformedHTLCDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateFailMalformedHTLCDecodeErrorZ ret_hu_conv = Result_UpdateFailMalformedHTLCDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_UpdateFailMalformedHTLCDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateFailMalformedHTLCDecodeErrorZ ret_hu_conv = Result_UpdateFailMalformedHTLCDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_UpdateFeeDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_UpdateFeeDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_UpdateFeeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_UpdateFeeDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.UpdateFee res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.UpdateFee(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_UpdateFeeDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_UpdateFeeDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_UpdateFeeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateFeeDecodeErrorZ ret_hu_conv = Result_UpdateFeeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_UpdateFeeDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateFeeDecodeErrorZ ret_hu_conv = Result_UpdateFeeDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_UpdateFulfillHTLCDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_UpdateFulfillHTLCDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_UpdateFulfillHTLCDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_UpdateFulfillHTLCDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.UpdateFulfillHTLC res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.UpdateFulfillHTLC(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_UpdateFulfillHTLCDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_UpdateFulfillHTLCDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_UpdateFulfillHTLCDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateFulfillHTLCDecodeErrorZ ret_hu_conv = Result_UpdateFulfillHTLCDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_UpdateFulfillHTLCDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_UpdateFulfillHTLCDecodeErrorZ ret_hu_conv = Result_UpdateFulfillHTLCDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_WarningMessageDecodeErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_WarningMessageDecodeErrorZ.java
@@ -26,7 +26,7 @@ public class Result_WarningMessageDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long res = bindings.CResult_WarningMessageDecodeErrorZ_get_ok(ptr);
 			org.ldk.structs.WarningMessage res_hu_conv = null; if (res < 0 || res > 4096) { res_hu_conv = new org.ldk.structs.WarningMessage(null, res); }
-			res_hu_conv.ptrs_to.add(this);
+			if (res_hu_conv != null) { res_hu_conv.ptrs_to.add(this); };
 			this.res = res_hu_conv;
 		}
 	}
@@ -37,7 +37,7 @@ public class Result_WarningMessageDecodeErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_WarningMessageDecodeErrorZ_get_err(ptr);
 			org.ldk.structs.DecodeError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.DecodeError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -50,7 +50,7 @@ public class Result_WarningMessageDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(o);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_WarningMessageDecodeErrorZ ret_hu_conv = Result_WarningMessageDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(o);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(o); };
 		return ret_hu_conv;
 	}
 
@@ -62,7 +62,7 @@ public class Result_WarningMessageDecodeErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_WarningMessageDecodeErrorZ ret_hu_conv = Result_WarningMessageDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result__u832APIErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result__u832APIErrorZ.java
@@ -34,7 +34,7 @@ public class Result__u832APIErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult__u832APIErrorZ_get_err(ptr);
 			org.ldk.structs.APIError err_hu_conv = org.ldk.structs.APIError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Result_boolLightningErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_boolLightningErrorZ.java
@@ -34,7 +34,7 @@ public class Result_boolLightningErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_boolLightningErrorZ_get_err(ptr);
 			org.ldk.structs.LightningError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.LightningError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -58,7 +58,7 @@ public class Result_boolLightningErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_boolLightningErrorZ ret_hu_conv = Result_boolLightningErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_boolPeerHandleErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_boolPeerHandleErrorZ.java
@@ -34,7 +34,7 @@ public class Result_boolPeerHandleErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_boolPeerHandleErrorZ_get_err(ptr);
 			org.ldk.structs.PeerHandleError err_hu_conv = null; if (err < 0 || err > 4096) { err_hu_conv = new org.ldk.structs.PeerHandleError(null, err); }
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}
@@ -58,7 +58,7 @@ public class Result_boolPeerHandleErrorZ extends CommonBase {
 		Reference.reachabilityFence(e);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_boolPeerHandleErrorZ ret_hu_conv = Result_boolPeerHandleErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(e);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(e); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Result_u32GraphSyncErrorZ.java
+++ b/src/main/java/org/ldk/structs/Result_u32GraphSyncErrorZ.java
@@ -34,7 +34,7 @@ public class Result_u32GraphSyncErrorZ extends CommonBase {
 			super(_dummy, ptr);
 			long err = bindings.CResult_u32GraphSyncErrorZ_get_err(ptr);
 			org.ldk.structs.GraphSyncError err_hu_conv = org.ldk.structs.GraphSyncError.constr_from_ptr(err);
-			err_hu_conv.ptrs_to.add(this);
+			if (err_hu_conv != null) { err_hu_conv.ptrs_to.add(this); };
 			this.err = err_hu_conv;
 		}
 	}

--- a/src/main/java/org/ldk/structs/Retry.java
+++ b/src/main/java/org/ldk/structs/Retry.java
@@ -68,7 +68,7 @@ public class Retry extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Retry ret_hu_conv = org.ldk.structs.Retry.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -80,7 +80,7 @@ public class Retry extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Retry ret_hu_conv = org.ldk.structs.Retry.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -92,7 +92,7 @@ public class Retry extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Retry ret_hu_conv = org.ldk.structs.Retry.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/RevokeAndACK.java
+++ b/src/main/java/org/ldk/structs/RevokeAndACK.java
@@ -84,7 +84,7 @@ public class RevokeAndACK extends CommonBase {
 		Reference.reachabilityFence(next_per_commitment_point_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RevokeAndACK ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RevokeAndACK(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -102,7 +102,7 @@ public class RevokeAndACK extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RevokeAndACK ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RevokeAndACK(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Route.java
+++ b/src/main/java/org/ldk/structs/Route.java
@@ -40,7 +40,7 @@ public class Route extends CommonBase {
 			for (int k = 0; k < ret_conv_12_conv_10_len; k++) {
 				long ret_conv_12_conv_10 = ret_conv_12[k];
 				org.ldk.structs.RouteHop ret_conv_12_conv_10_hu_conv = null; if (ret_conv_12_conv_10 < 0 || ret_conv_12_conv_10 > 4096) { ret_conv_12_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, ret_conv_12_conv_10); }
-				ret_conv_12_conv_10_hu_conv.ptrs_to.add(this);
+				if (ret_conv_12_conv_10_hu_conv != null) { ret_conv_12_conv_10_hu_conv.ptrs_to.add(this); };
 				ret_conv_12_conv_10_arr[k] = ret_conv_12_conv_10_hu_conv;
 			}
 			ret_conv_12_arr[m] = ret_conv_12_conv_10_arr;
@@ -59,7 +59,7 @@ public class Route extends CommonBase {
 		bindings.Route_set_paths(this.ptr, val != null ? Arrays.stream(val).map(val_conv_12 -> val_conv_12 != null ? Arrays.stream(val_conv_12).mapToLong(val_conv_12_conv_10 -> val_conv_12_conv_10 == null ? 0 : val_conv_12_conv_10.ptr).toArray() : null).toArray(long[][]::new) : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		for (RouteHop[] val_conv_12: val) { for (RouteHop val_conv_12_conv_10: val_conv_12) { this.ptrs_to.add(val_conv_12_conv_10); }; };
+		for (RouteHop[] val_conv_12: val) { for (RouteHop val_conv_12_conv_10: val_conv_12) { if (this != null) { this.ptrs_to.add(val_conv_12_conv_10); }; }; };
 	}
 
 	/**
@@ -77,7 +77,7 @@ public class Route extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PaymentParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -94,7 +94,7 @@ public class Route extends CommonBase {
 		bindings.Route_set_payment_params(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -106,9 +106,9 @@ public class Route extends CommonBase {
 		Reference.reachabilityFence(payment_params_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Route ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Route(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		for (RouteHop[] paths_arg_conv_12: paths_arg) { for (RouteHop paths_arg_conv_12_conv_10: paths_arg_conv_12) { ret_hu_conv.ptrs_to.add(paths_arg_conv_12_conv_10); }; };
-		ret_hu_conv.ptrs_to.add(payment_params_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		for (RouteHop[] paths_arg_conv_12: paths_arg) { for (RouteHop paths_arg_conv_12_conv_10: paths_arg_conv_12) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(paths_arg_conv_12_conv_10); }; }; };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(payment_params_arg); };
 		return ret_hu_conv;
 	}
 
@@ -126,7 +126,7 @@ public class Route extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Route ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Route(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -151,7 +151,7 @@ public class Route extends CommonBase {
 		boolean ret = bindings.Route_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/RouteHint.java
+++ b/src/main/java/org/ldk/structs/RouteHint.java
@@ -28,7 +28,7 @@ public class RouteHint extends CommonBase {
 		for (int o = 0; o < ret_conv_14_len; o++) {
 			long ret_conv_14 = ret[o];
 			org.ldk.structs.RouteHintHop ret_conv_14_hu_conv = null; if (ret_conv_14 < 0 || ret_conv_14 > 4096) { ret_conv_14_hu_conv = new org.ldk.structs.RouteHintHop(null, ret_conv_14); }
-			ret_conv_14_hu_conv.ptrs_to.add(this);
+			if (ret_conv_14_hu_conv != null) { ret_conv_14_hu_conv.ptrs_to.add(this); };
 			ret_conv_14_arr[o] = ret_conv_14_hu_conv;
 		}
 		return ret_conv_14_arr;
@@ -38,7 +38,7 @@ public class RouteHint extends CommonBase {
 		bindings.RouteHint_set_a(this.ptr, val != null ? Arrays.stream(val).mapToLong(val_conv_14 -> val_conv_14 == null ? 0 : val_conv_14.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		for (RouteHintHop val_conv_14: val) { this.ptrs_to.add(val_conv_14); };
+		for (RouteHintHop val_conv_14: val) { if (this != null) { this.ptrs_to.add(val_conv_14); }; };
 	}
 
 	/**
@@ -49,8 +49,8 @@ public class RouteHint extends CommonBase {
 		Reference.reachabilityFence(a_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteHint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteHint(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		for (RouteHintHop a_arg_conv_14: a_arg) { ret_hu_conv.ptrs_to.add(a_arg_conv_14); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		for (RouteHintHop a_arg_conv_14: a_arg) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a_arg_conv_14); }; };
 		return ret_hu_conv;
 	}
 
@@ -68,7 +68,7 @@ public class RouteHint extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteHint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteHint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -93,7 +93,7 @@ public class RouteHint extends CommonBase {
 		boolean ret = bindings.RouteHint_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/RouteHintHop.java
+++ b/src/main/java/org/ldk/structs/RouteHintHop.java
@@ -64,7 +64,7 @@ public class RouteHintHop extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RoutingFees ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RoutingFees(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -75,7 +75,7 @@ public class RouteHintHop extends CommonBase {
 		bindings.RouteHintHop_set_fees(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -104,7 +104,7 @@ public class RouteHintHop extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -125,7 +125,7 @@ public class RouteHintHop extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Option_u64Z ret_hu_conv = org.ldk.structs.Option_u64Z.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -151,8 +151,8 @@ public class RouteHintHop extends CommonBase {
 		Reference.reachabilityFence(htlc_maximum_msat_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteHintHop ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteHintHop(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(fees_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(fees_arg); };
 		return ret_hu_conv;
 	}
 
@@ -170,7 +170,7 @@ public class RouteHintHop extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteHintHop ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteHintHop(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -195,7 +195,7 @@ public class RouteHintHop extends CommonBase {
 		boolean ret = bindings.RouteHintHop_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/RouteHop.java
+++ b/src/main/java/org/ldk/structs/RouteHop.java
@@ -47,7 +47,7 @@ public class RouteHop extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -59,7 +59,7 @@ public class RouteHop extends CommonBase {
 		bindings.RouteHop_set_node_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -89,7 +89,7 @@ public class RouteHop extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -101,7 +101,7 @@ public class RouteHop extends CommonBase {
 		bindings.RouteHop_set_channel_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -159,9 +159,9 @@ public class RouteHop extends CommonBase {
 		Reference.reachabilityFence(cltv_expiry_delta_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteHop ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteHop(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(node_features_arg);
-		ret_hu_conv.ptrs_to.add(channel_features_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(node_features_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channel_features_arg); };
 		return ret_hu_conv;
 	}
 
@@ -179,7 +179,7 @@ public class RouteHop extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteHop ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteHop(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -204,7 +204,7 @@ public class RouteHop extends CommonBase {
 		boolean ret = bindings.RouteHop_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/RouteParameters.java
+++ b/src/main/java/org/ldk/structs/RouteParameters.java
@@ -33,7 +33,7 @@ public class RouteParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.PaymentParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.PaymentParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -44,7 +44,7 @@ public class RouteParameters extends CommonBase {
 		bindings.RouteParameters_set_payment_params(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -93,8 +93,8 @@ public class RouteParameters extends CommonBase {
 		Reference.reachabilityFence(final_cltv_expiry_delta_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(payment_params_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(payment_params_arg); };
 		return ret_hu_conv;
 	}
 
@@ -112,7 +112,7 @@ public class RouteParameters extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RouteParameters ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RouteParameters(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Router.java
+++ b/src/main/java/org/ldk/structs/Router.java
@@ -43,11 +43,11 @@ public class Router extends CommonBase {
 				for (int q = 0; q < first_hops_conv_16_len; q++) {
 					long first_hops_conv_16 = first_hops[q];
 					org.ldk.structs.ChannelDetails first_hops_conv_16_hu_conv = null; if (first_hops_conv_16 < 0 || first_hops_conv_16 > 4096) { first_hops_conv_16_hu_conv = new org.ldk.structs.ChannelDetails(null, first_hops_conv_16); }
-					first_hops_conv_16_hu_conv.ptrs_to.add(this);
+					if (first_hops_conv_16_hu_conv != null) { first_hops_conv_16_hu_conv.ptrs_to.add(this); };
 					first_hops_conv_16_arr[q] = first_hops_conv_16_hu_conv;
 				}
 				Score ret_hu_conv = new Score(null, scorer);
-				ret_hu_conv.ptrs_to.add(this);
+				if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 				Result_RouteLightningErrorZ ret = arg.find_route(payer, route_params_hu_conv, payment_hash, first_hops_conv_16_arr, ret_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -71,9 +71,9 @@ public class Router extends CommonBase {
 		Reference.reachabilityFence(scorer);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteLightningErrorZ ret_hu_conv = Result_RouteLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(route_params);
-		for (ChannelDetails first_hops_conv_16: first_hops) { this.ptrs_to.add(first_hops_conv_16); };
-		this.ptrs_to.add(scorer);
+		if (this != null) { this.ptrs_to.add(route_params); };
+		for (ChannelDetails first_hops_conv_16: first_hops) { if (this != null) { this.ptrs_to.add(first_hops_conv_16); }; };
+		if (this != null) { this.ptrs_to.add(scorer); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/RoutingFees.java
+++ b/src/main/java/org/ldk/structs/RoutingFees.java
@@ -67,7 +67,7 @@ public class RoutingFees extends CommonBase {
 		Reference.reachabilityFence(proportional_millionths_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RoutingFees ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RoutingFees(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -80,7 +80,7 @@ public class RoutingFees extends CommonBase {
 		boolean ret = bindings.RoutingFees_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -102,7 +102,7 @@ public class RoutingFees extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RoutingFees ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RoutingFees(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/RoutingMessageHandler.java
+++ b/src/main/java/org/ldk/structs/RoutingMessageHandler.java
@@ -136,7 +136,7 @@ public class RoutingMessageHandler extends CommonBase {
 			}
 			@Override public long handle_reply_channel_range(byte[] their_node_id, long msg) {
 				org.ldk.structs.ReplyChannelRange msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ReplyChannelRange(null, msg); }
-				msg_hu_conv.ptrs_to.add(this);
+				if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 				Result_NoneLightningErrorZ ret = arg.handle_reply_channel_range(their_node_id, msg_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -144,7 +144,7 @@ public class RoutingMessageHandler extends CommonBase {
 			}
 			@Override public long handle_reply_short_channel_ids_end(byte[] their_node_id, long msg) {
 				org.ldk.structs.ReplyShortChannelIdsEnd msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.ReplyShortChannelIdsEnd(null, msg); }
-				msg_hu_conv.ptrs_to.add(this);
+				if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 				Result_NoneLightningErrorZ ret = arg.handle_reply_short_channel_ids_end(their_node_id, msg_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -152,7 +152,7 @@ public class RoutingMessageHandler extends CommonBase {
 			}
 			@Override public long handle_query_channel_range(byte[] their_node_id, long msg) {
 				org.ldk.structs.QueryChannelRange msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.QueryChannelRange(null, msg); }
-				msg_hu_conv.ptrs_to.add(this);
+				if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 				Result_NoneLightningErrorZ ret = arg.handle_query_channel_range(their_node_id, msg_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -160,7 +160,7 @@ public class RoutingMessageHandler extends CommonBase {
 			}
 			@Override public long handle_query_short_channel_ids(byte[] their_node_id, long msg) {
 				org.ldk.structs.QueryShortChannelIds msg_hu_conv = null; if (msg < 0 || msg > 4096) { msg_hu_conv = new org.ldk.structs.QueryShortChannelIds(null, msg); }
-				msg_hu_conv.ptrs_to.add(this);
+				if (msg_hu_conv != null) { msg_hu_conv.ptrs_to.add(this); };
 				Result_NoneLightningErrorZ ret = arg.handle_query_short_channel_ids(their_node_id, msg_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -189,7 +189,7 @@ public class RoutingMessageHandler extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_boolLightningErrorZ ret_hu_conv = Result_boolLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -203,7 +203,7 @@ public class RoutingMessageHandler extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_boolLightningErrorZ ret_hu_conv = Result_boolLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -217,7 +217,7 @@ public class RoutingMessageHandler extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_boolLightningErrorZ ret_hu_conv = Result_boolLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -236,7 +236,7 @@ public class RoutingMessageHandler extends CommonBase {
 		for (int h = 0; h < ret_conv_59_len; h++) {
 			long ret_conv_59 = ret[h];
 			ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ ret_conv_59_hu_conv = new ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ(null, ret_conv_59);
-			ret_conv_59_hu_conv.ptrs_to.add(this);
+			if (ret_conv_59_hu_conv != null) { ret_conv_59_hu_conv.ptrs_to.add(this); };
 			ret_conv_59_arr[h] = ret_conv_59_hu_conv;
 		}
 		return ret_conv_59_arr;
@@ -260,7 +260,7 @@ public class RoutingMessageHandler extends CommonBase {
 		for (int s = 0; s < ret_conv_18_len; s++) {
 			long ret_conv_18 = ret[s];
 			org.ldk.structs.NodeAnnouncement ret_conv_18_hu_conv = null; if (ret_conv_18 < 0 || ret_conv_18 > 4096) { ret_conv_18_hu_conv = new org.ldk.structs.NodeAnnouncement(null, ret_conv_18); }
-			ret_conv_18_hu_conv.ptrs_to.add(this);
+			if (ret_conv_18_hu_conv != null) { ret_conv_18_hu_conv.ptrs_to.add(this); };
 			ret_conv_18_arr[s] = ret_conv_18_hu_conv;
 		}
 		return ret_conv_18_arr;
@@ -276,7 +276,7 @@ public class RoutingMessageHandler extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(their_node_id);
 		Reference.reachabilityFence(init);
-		this.ptrs_to.add(init);
+		if (this != null) { this.ptrs_to.add(init); };
 	}
 
 	/**
@@ -291,7 +291,7 @@ public class RoutingMessageHandler extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -308,7 +308,7 @@ public class RoutingMessageHandler extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -323,7 +323,7 @@ public class RoutingMessageHandler extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 
@@ -338,7 +338,7 @@ public class RoutingMessageHandler extends CommonBase {
 		Reference.reachabilityFence(msg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneLightningErrorZ ret_hu_conv = Result_NoneLightningErrorZ.constr_from_ptr(ret);
-		this.ptrs_to.add(msg);
+		if (this != null) { this.ptrs_to.add(msg); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Score.java
+++ b/src/main/java/org/ldk/structs/Score.java
@@ -67,7 +67,7 @@ public class Score extends CommonBase {
 				org.ldk.structs.NodeId source_hu_conv = null; if (source < 0 || source > 4096) { source_hu_conv = new org.ldk.structs.NodeId(null, source); }
 				org.ldk.structs.NodeId target_hu_conv = null; if (target < 0 || target > 4096) { target_hu_conv = new org.ldk.structs.NodeId(null, target); }
 				org.ldk.structs.ChannelUsage usage_hu_conv = null; if (usage < 0 || usage > 4096) { usage_hu_conv = new org.ldk.structs.ChannelUsage(null, usage); }
-				usage_hu_conv.ptrs_to.add(this);
+				if (usage_hu_conv != null) { usage_hu_conv.ptrs_to.add(this); };
 				long ret = arg.channel_penalty_msat(short_channel_id, source_hu_conv, target_hu_conv, usage_hu_conv);
 				Reference.reachabilityFence(arg);
 				return ret;
@@ -78,7 +78,7 @@ public class Score extends CommonBase {
 				for (int k = 0; k < path_conv_10_len; k++) {
 					long path_conv_10 = path[k];
 					org.ldk.structs.RouteHop path_conv_10_hu_conv = null; if (path_conv_10 < 0 || path_conv_10 > 4096) { path_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, path_conv_10); }
-					path_conv_10_hu_conv.ptrs_to.add(this);
+					if (path_conv_10_hu_conv != null) { path_conv_10_hu_conv.ptrs_to.add(this); };
 					path_conv_10_arr[k] = path_conv_10_hu_conv;
 				}
 				arg.payment_path_failed(path_conv_10_arr, short_channel_id);
@@ -90,7 +90,7 @@ public class Score extends CommonBase {
 				for (int k = 0; k < path_conv_10_len; k++) {
 					long path_conv_10 = path[k];
 					org.ldk.structs.RouteHop path_conv_10_hu_conv = null; if (path_conv_10 < 0 || path_conv_10 > 4096) { path_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, path_conv_10); }
-					path_conv_10_hu_conv.ptrs_to.add(this);
+					if (path_conv_10_hu_conv != null) { path_conv_10_hu_conv.ptrs_to.add(this); };
 					path_conv_10_arr[k] = path_conv_10_hu_conv;
 				}
 				arg.payment_path_successful(path_conv_10_arr);
@@ -102,7 +102,7 @@ public class Score extends CommonBase {
 				for (int k = 0; k < path_conv_10_len; k++) {
 					long path_conv_10 = path[k];
 					org.ldk.structs.RouteHop path_conv_10_hu_conv = null; if (path_conv_10 < 0 || path_conv_10 > 4096) { path_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, path_conv_10); }
-					path_conv_10_hu_conv.ptrs_to.add(this);
+					if (path_conv_10_hu_conv != null) { path_conv_10_hu_conv.ptrs_to.add(this); };
 					path_conv_10_arr[k] = path_conv_10_hu_conv;
 				}
 				arg.probe_failed(path_conv_10_arr, short_channel_id);
@@ -114,7 +114,7 @@ public class Score extends CommonBase {
 				for (int k = 0; k < path_conv_10_len; k++) {
 					long path_conv_10 = path[k];
 					org.ldk.structs.RouteHop path_conv_10_hu_conv = null; if (path_conv_10 < 0 || path_conv_10 > 4096) { path_conv_10_hu_conv = new org.ldk.structs.RouteHop(null, path_conv_10); }
-					path_conv_10_hu_conv.ptrs_to.add(this);
+					if (path_conv_10_hu_conv != null) { path_conv_10_hu_conv.ptrs_to.add(this); };
 					path_conv_10_arr[k] = path_conv_10_hu_conv;
 				}
 				arg.probe_successful(path_conv_10_arr);
@@ -145,9 +145,9 @@ public class Score extends CommonBase {
 		Reference.reachabilityFence(source);
 		Reference.reachabilityFence(target);
 		Reference.reachabilityFence(usage);
-		this.ptrs_to.add(source);
-		this.ptrs_to.add(target);
-		this.ptrs_to.add(usage);
+		if (this != null) { this.ptrs_to.add(source); };
+		if (this != null) { this.ptrs_to.add(target); };
+		if (this != null) { this.ptrs_to.add(usage); };
 		return ret;
 	}
 
@@ -159,7 +159,7 @@ public class Score extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(path);
 		Reference.reachabilityFence(short_channel_id);
-		for (RouteHop path_conv_10: path) { this.ptrs_to.add(path_conv_10); };
+		for (RouteHop path_conv_10: path) { if (this != null) { this.ptrs_to.add(path_conv_10); }; };
 	}
 
 	/**
@@ -169,7 +169,7 @@ public class Score extends CommonBase {
 		bindings.Score_payment_path_successful(this.ptr, path != null ? Arrays.stream(path).mapToLong(path_conv_10 -> path_conv_10 == null ? 0 : path_conv_10.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(path);
-		for (RouteHop path_conv_10: path) { this.ptrs_to.add(path_conv_10); };
+		for (RouteHop path_conv_10: path) { if (this != null) { this.ptrs_to.add(path_conv_10); }; };
 	}
 
 	/**
@@ -180,7 +180,7 @@ public class Score extends CommonBase {
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(path);
 		Reference.reachabilityFence(short_channel_id);
-		for (RouteHop path_conv_10: path) { this.ptrs_to.add(path_conv_10); };
+		for (RouteHop path_conv_10: path) { if (this != null) { this.ptrs_to.add(path_conv_10); }; };
 	}
 
 	/**
@@ -190,7 +190,7 @@ public class Score extends CommonBase {
 		bindings.Score_probe_successful(this.ptr, path != null ? Arrays.stream(path).mapToLong(path_conv_10 -> path_conv_10 == null ? 0 : path_conv_10.ptr).toArray() : null);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(path);
-		for (RouteHop path_conv_10: path) { this.ptrs_to.add(path_conv_10); };
+		for (RouteHop path_conv_10: path) { if (this != null) { this.ptrs_to.add(path_conv_10); }; };
 	}
 
 	/**

--- a/src/main/java/org/ldk/structs/Sha256.java
+++ b/src/main/java/org/ldk/structs/Sha256.java
@@ -34,7 +34,7 @@ public class Sha256 extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Sha256 ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Sha256(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -59,7 +59,7 @@ public class Sha256 extends CommonBase {
 		boolean ret = bindings.Sha256_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/Shutdown.java
+++ b/src/main/java/org/ldk/structs/Shutdown.java
@@ -67,7 +67,7 @@ public class Shutdown extends CommonBase {
 		Reference.reachabilityFence(scriptpubkey_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Shutdown ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Shutdown(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -85,7 +85,7 @@ public class Shutdown extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.Shutdown ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.Shutdown(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ShutdownScript.java
+++ b/src/main/java/org/ldk/structs/ShutdownScript.java
@@ -36,7 +36,7 @@ public class ShutdownScript extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ShutdownScript ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ShutdownScript(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -68,7 +68,7 @@ public class ShutdownScript extends CommonBase {
 		Reference.reachabilityFence(pubkey_hash);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ShutdownScript ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ShutdownScript(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -80,7 +80,7 @@ public class ShutdownScript extends CommonBase {
 		Reference.reachabilityFence(script_hash);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ShutdownScript ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ShutdownScript(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -109,7 +109,7 @@ public class ShutdownScript extends CommonBase {
 	public byte[] into_inner() {
 		byte[] ret = bindings.ShutdownScript_into_inner(this.ptr);
 		Reference.reachabilityFence(this);
-		this.ptrs_to.add(this);
+		if (this != null) { this.ptrs_to.add(this); };
 		return ret;
 	}
 
@@ -134,7 +134,7 @@ public class ShutdownScript extends CommonBase {
 		boolean ret = bindings.ShutdownScript_is_compatible(this.ptr, features == null ? 0 : features.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(features);
-		this.ptrs_to.add(features);
+		if (this != null) { this.ptrs_to.add(features); };
 		return ret;
 	}
 

--- a/src/main/java/org/ldk/structs/Sign.java
+++ b/src/main/java/org/ldk/structs/Sign.java
@@ -80,7 +80,7 @@ public class Sign extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Sign ret_hu_conv = new Sign(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/SignOrCreationError.java
+++ b/src/main/java/org/ldk/structs/SignOrCreationError.java
@@ -63,7 +63,7 @@ public class SignOrCreationError extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SignOrCreationError ret_hu_conv = org.ldk.structs.SignOrCreationError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -74,7 +74,7 @@ public class SignOrCreationError extends CommonBase {
 		long ret = bindings.SignOrCreationError_sign_error();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SignOrCreationError ret_hu_conv = org.ldk.structs.SignOrCreationError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -86,7 +86,7 @@ public class SignOrCreationError extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SignOrCreationError ret_hu_conv = org.ldk.structs.SignOrCreationError.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/SignedRawInvoice.java
+++ b/src/main/java/org/ldk/structs/SignedRawInvoice.java
@@ -33,7 +33,7 @@ public class SignedRawInvoice extends CommonBase {
 		boolean ret = bindings.SignedRawInvoice_eq(this.ptr, b == null ? 0 : b.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(b);
-		this.ptrs_to.add(b);
+		if (this != null) { this.ptrs_to.add(b); };
 		return ret;
 	}
 
@@ -55,7 +55,7 @@ public class SignedRawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SignedRawInvoice ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.SignedRawInvoice(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -70,8 +70,8 @@ public class SignedRawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ThreeTuple_RawInvoice_u832InvoiceSignatureZ ret_hu_conv = new ThreeTuple_RawInvoice_u832InvoiceSignatureZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
-		this.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
+		if (this != null) { this.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -83,7 +83,7 @@ public class SignedRawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RawInvoice ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RawInvoice(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -104,7 +104,7 @@ public class SignedRawInvoice extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceSignature ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceSignature(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/SocketDescriptor.java
+++ b/src/main/java/org/ldk/structs/SocketDescriptor.java
@@ -88,7 +88,7 @@ public class SocketDescriptor extends CommonBase {
 			}
 			@Override public boolean eq(long other_arg) {
 				SocketDescriptor ret_hu_conv = new SocketDescriptor(null, other_arg);
-				ret_hu_conv.ptrs_to.add(this);
+				if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 				boolean ret = arg.eq(ret_hu_conv);
 				Reference.reachabilityFence(arg);
 				return ret;
@@ -166,7 +166,7 @@ public class SocketDescriptor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		SocketDescriptor ret_hu_conv = new SocketDescriptor(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/SpendableOutputDescriptor.java
+++ b/src/main/java/org/ldk/structs/SpendableOutputDescriptor.java
@@ -57,7 +57,7 @@ public class SpendableOutputDescriptor extends CommonBase {
 			super(null, ptr);
 			long outpoint = obj.outpoint;
 			org.ldk.structs.OutPoint outpoint_hu_conv = null; if (outpoint < 0 || outpoint > 4096) { outpoint_hu_conv = new org.ldk.structs.OutPoint(null, outpoint); }
-			outpoint_hu_conv.ptrs_to.add(this);
+			if (outpoint_hu_conv != null) { outpoint_hu_conv.ptrs_to.add(this); };
 			this.outpoint = outpoint_hu_conv;
 			long output = obj.output;
 			TxOut output_conv = new TxOut(null, output);
@@ -100,7 +100,7 @@ public class SpendableOutputDescriptor extends CommonBase {
 			super(null, ptr);
 			long delayed_payment_output = obj.delayed_payment_output;
 			org.ldk.structs.DelayedPaymentOutputDescriptor delayed_payment_output_hu_conv = null; if (delayed_payment_output < 0 || delayed_payment_output > 4096) { delayed_payment_output_hu_conv = new org.ldk.structs.DelayedPaymentOutputDescriptor(null, delayed_payment_output); }
-			delayed_payment_output_hu_conv.ptrs_to.add(this);
+			if (delayed_payment_output_hu_conv != null) { delayed_payment_output_hu_conv.ptrs_to.add(this); };
 			this.delayed_payment_output = delayed_payment_output_hu_conv;
 		}
 	}
@@ -119,7 +119,7 @@ public class SpendableOutputDescriptor extends CommonBase {
 			super(null, ptr);
 			long static_payment_output = obj.static_payment_output;
 			org.ldk.structs.StaticPaymentOutputDescriptor static_payment_output_hu_conv = null; if (static_payment_output < 0 || static_payment_output > 4096) { static_payment_output_hu_conv = new org.ldk.structs.StaticPaymentOutputDescriptor(null, static_payment_output); }
-			static_payment_output_hu_conv.ptrs_to.add(this);
+			if (static_payment_output_hu_conv != null) { static_payment_output_hu_conv.ptrs_to.add(this); };
 			this.static_payment_output = static_payment_output_hu_conv;
 		}
 	}
@@ -137,7 +137,7 @@ public class SpendableOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SpendableOutputDescriptor ret_hu_conv = org.ldk.structs.SpendableOutputDescriptor.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -150,8 +150,8 @@ public class SpendableOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(output);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SpendableOutputDescriptor ret_hu_conv = org.ldk.structs.SpendableOutputDescriptor.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(outpoint);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(outpoint); };
 		return ret_hu_conv;
 	}
 
@@ -163,8 +163,8 @@ public class SpendableOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SpendableOutputDescriptor ret_hu_conv = org.ldk.structs.SpendableOutputDescriptor.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 
@@ -176,8 +176,8 @@ public class SpendableOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(a);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.SpendableOutputDescriptor ret_hu_conv = org.ldk.structs.SpendableOutputDescriptor.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/StaticPaymentOutputDescriptor.java
+++ b/src/main/java/org/ldk/structs/StaticPaymentOutputDescriptor.java
@@ -29,7 +29,7 @@ public class StaticPaymentOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -40,7 +40,7 @@ public class StaticPaymentOutputDescriptor extends CommonBase {
 		bindings.StaticPaymentOutputDescriptor_set_outpoint(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -116,8 +116,8 @@ public class StaticPaymentOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(channel_value_satoshis_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.StaticPaymentOutputDescriptor ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.StaticPaymentOutputDescriptor(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(outpoint_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(outpoint_arg); };
 		return ret_hu_conv;
 	}
 
@@ -135,7 +135,7 @@ public class StaticPaymentOutputDescriptor extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.StaticPaymentOutputDescriptor ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.StaticPaymentOutputDescriptor(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ.java
+++ b/src/main/java/org/ldk/structs/ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ.java
@@ -28,7 +28,7 @@ public class ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ extends C
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -40,7 +40,7 @@ public class ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ extends C
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -52,7 +52,7 @@ public class ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ extends C
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -71,7 +71,7 @@ public class ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ extends C
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ ret_hu_conv = new ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -85,10 +85,10 @@ public class ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ extends C
 		Reference.reachabilityFence(c);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ ret_hu_conv = new ThreeTuple_ChannelAnnouncementChannelUpdateChannelUpdateZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
-		ret_hu_conv.ptrs_to.add(b);
-		ret_hu_conv.ptrs_to.add(c);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(c); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ.java
+++ b/src/main/java/org/ldk/structs/ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ.java
@@ -28,7 +28,7 @@ public class ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ extends CommonBase 
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -43,7 +43,7 @@ public class ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ extends CommonBase 
 		for (int o = 0; o < ret_conv_14_len; o++) {
 			long ret_conv_14 = ret[o];
 			org.ldk.structs.MonitorEvent ret_conv_14_hu_conv = org.ldk.structs.MonitorEvent.constr_from_ptr(ret_conv_14);
-			ret_conv_14_hu_conv.ptrs_to.add(this);
+			if (ret_conv_14_hu_conv != null) { ret_conv_14_hu_conv.ptrs_to.add(this); };
 			ret_conv_14_arr[o] = ret_conv_14_hu_conv;
 		}
 		return ret_conv_14_arr;
@@ -73,7 +73,7 @@ public class ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ extends CommonBase 
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ ret_hu_conv = new ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -87,8 +87,8 @@ public class ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ extends CommonBase 
 		Reference.reachabilityFence(c);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ ret_hu_conv = new ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/ThreeTuple_RawInvoice_u832InvoiceSignatureZ.java
+++ b/src/main/java/org/ldk/structs/ThreeTuple_RawInvoice_u832InvoiceSignatureZ.java
@@ -28,7 +28,7 @@ public class ThreeTuple_RawInvoice_u832InvoiceSignatureZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.RawInvoice ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.RawInvoice(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -49,7 +49,7 @@ public class ThreeTuple_RawInvoice_u832InvoiceSignatureZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.InvoiceSignature ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.InvoiceSignature(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -68,7 +68,7 @@ public class ThreeTuple_RawInvoice_u832InvoiceSignatureZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ThreeTuple_RawInvoice_u832InvoiceSignatureZ ret_hu_conv = new ThreeTuple_RawInvoice_u832InvoiceSignatureZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -82,9 +82,9 @@ public class ThreeTuple_RawInvoice_u832InvoiceSignatureZ extends CommonBase {
 		Reference.reachabilityFence(c);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		ThreeTuple_RawInvoice_u832InvoiceSignatureZ ret_hu_conv = new ThreeTuple_RawInvoice_u832InvoiceSignatureZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
-		ret_hu_conv.ptrs_to.add(c);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(c); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TrustedCommitmentTransaction.java
+++ b/src/main/java/org/ldk/structs/TrustedCommitmentTransaction.java
@@ -42,7 +42,7 @@ public class TrustedCommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.BuiltCommitmentTransaction ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.BuiltCommitmentTransaction(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -54,7 +54,7 @@ public class TrustedCommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.TxCreationKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.TxCreationKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -82,7 +82,7 @@ public class TrustedCommitmentTransaction extends CommonBase {
 		Reference.reachabilityFence(channel_parameters);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_CVec_SignatureZNoneZ ret_hu_conv = Result_CVec_SignatureZNoneZ.constr_from_ptr(ret);
-		this.ptrs_to.add(channel_parameters);
+		if (this != null) { this.ptrs_to.add(channel_parameters); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_BlockHashChannelManagerZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_BlockHashChannelManagerZ.java
@@ -37,7 +37,7 @@ public class TwoTuple_BlockHashChannelManagerZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelManager ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelManager(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -56,14 +56,14 @@ public class TwoTuple_BlockHashChannelManagerZ extends CommonBase {
 		Reference.reachabilityFence(b_params);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_BlockHashChannelManagerZ ret_hu_conv = new TwoTuple_BlockHashChannelManagerZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(b_fee_est);
-		ret_hu_conv.ptrs_to.add(b_chain_monitor);
-		ret_hu_conv.ptrs_to.add(b_tx_broadcaster);
-		ret_hu_conv.ptrs_to.add(b_logger);
-		ret_hu_conv.ptrs_to.add(b_keys_manager);
-		ret_hu_conv.ptrs_to.add(b_config);
-		ret_hu_conv.ptrs_to.add(b_params);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b_fee_est); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b_chain_monitor); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b_tx_broadcaster); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b_logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b_keys_manager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b_config); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b_params); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_BlockHashChannelMonitorZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_BlockHashChannelMonitorZ.java
@@ -37,7 +37,7 @@ public class TwoTuple_BlockHashChannelMonitorZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelMonitor ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelMonitor(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -56,7 +56,7 @@ public class TwoTuple_BlockHashChannelMonitorZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_BlockHashChannelMonitorZ ret_hu_conv = new TwoTuple_BlockHashChannelMonitorZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -69,8 +69,8 @@ public class TwoTuple_BlockHashChannelMonitorZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_BlockHashChannelMonitorZ ret_hu_conv = new TwoTuple_BlockHashChannelMonitorZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(b);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_OutPointScriptZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_OutPointScriptZ.java
@@ -28,7 +28,7 @@ public class TwoTuple_OutPointScriptZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -56,7 +56,7 @@ public class TwoTuple_OutPointScriptZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_OutPointScriptZ ret_hu_conv = new TwoTuple_OutPointScriptZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -69,8 +69,8 @@ public class TwoTuple_OutPointScriptZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_OutPointScriptZ ret_hu_conv = new TwoTuple_OutPointScriptZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(a);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(a); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_PaymentHashPaymentIdZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_PaymentHashPaymentIdZ.java
@@ -53,7 +53,7 @@ public class TwoTuple_PaymentHashPaymentIdZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_PaymentHashPaymentIdZ ret_hu_conv = new TwoTuple_PaymentHashPaymentIdZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class TwoTuple_PaymentHashPaymentIdZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_PaymentHashPaymentIdZ ret_hu_conv = new TwoTuple_PaymentHashPaymentIdZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_PaymentHashPaymentSecretZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_PaymentHashPaymentSecretZ.java
@@ -53,7 +53,7 @@ public class TwoTuple_PaymentHashPaymentSecretZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_PaymentHashPaymentSecretZ ret_hu_conv = new TwoTuple_PaymentHashPaymentSecretZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class TwoTuple_PaymentHashPaymentSecretZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_PaymentHashPaymentSecretZ ret_hu_conv = new TwoTuple_PaymentHashPaymentSecretZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_PublicKeyTypeZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_PublicKeyTypeZ.java
@@ -37,7 +37,7 @@ public class TwoTuple_PublicKeyTypeZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Type ret_hu_conv = new Type(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -56,7 +56,7 @@ public class TwoTuple_PublicKeyTypeZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_PublicKeyTypeZ ret_hu_conv = new TwoTuple_PublicKeyTypeZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -69,8 +69,8 @@ public class TwoTuple_PublicKeyTypeZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_PublicKeyTypeZ ret_hu_conv = new TwoTuple_PublicKeyTypeZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(b);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(b); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_SignatureCVec_SignatureZZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_SignatureCVec_SignatureZZ.java
@@ -53,7 +53,7 @@ public class TwoTuple_SignatureCVec_SignatureZZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_SignatureCVec_SignatureZZ ret_hu_conv = new TwoTuple_SignatureCVec_SignatureZZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class TwoTuple_SignatureCVec_SignatureZZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_SignatureCVec_SignatureZZ ret_hu_conv = new TwoTuple_SignatureCVec_SignatureZZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_SignatureSignatureZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_SignatureSignatureZ.java
@@ -53,7 +53,7 @@ public class TwoTuple_SignatureSignatureZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_SignatureSignatureZ ret_hu_conv = new TwoTuple_SignatureSignatureZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class TwoTuple_SignatureSignatureZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_SignatureSignatureZ ret_hu_conv = new TwoTuple_SignatureSignatureZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ.java
@@ -40,7 +40,7 @@ public class TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ extends CommonBase {
 		for (int v = 0; v < ret_conv_21_len; v++) {
 			long ret_conv_21 = ret[v];
 			TwoTuple_u32ScriptZ ret_conv_21_hu_conv = new TwoTuple_u32ScriptZ(null, ret_conv_21);
-			ret_conv_21_hu_conv.ptrs_to.add(this);
+			if (ret_conv_21_hu_conv != null) { ret_conv_21_hu_conv.ptrs_to.add(this); };
 			ret_conv_21_arr[v] = ret_conv_21_hu_conv;
 		}
 		return ret_conv_21_arr;
@@ -61,7 +61,7 @@ public class TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ ret_hu_conv = new TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -74,7 +74,7 @@ public class TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ ret_hu_conv = new TwoTuple_TxidCVec_C2Tuple_u32ScriptZZZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ.java
@@ -40,7 +40,7 @@ public class TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ extends CommonBase {
 		for (int u = 0; u < ret_conv_20_len; u++) {
 			long ret_conv_20 = ret[u];
 			TwoTuple_u32TxOutZ ret_conv_20_hu_conv = new TwoTuple_u32TxOutZ(null, ret_conv_20);
-			ret_conv_20_hu_conv.ptrs_to.add(this);
+			if (ret_conv_20_hu_conv != null) { ret_conv_20_hu_conv.ptrs_to.add(this); };
 			ret_conv_20_arr[u] = ret_conv_20_hu_conv;
 		}
 		return ret_conv_20_arr;
@@ -61,7 +61,7 @@ public class TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ ret_hu_conv = new TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -74,7 +74,7 @@ public class TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ ret_hu_conv = new TwoTuple_TxidCVec_C2Tuple_u32TxOutZZZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_u32ScriptZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_u32ScriptZ.java
@@ -53,7 +53,7 @@ public class TwoTuple_u32ScriptZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_u32ScriptZ ret_hu_conv = new TwoTuple_u32ScriptZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class TwoTuple_u32ScriptZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_u32ScriptZ ret_hu_conv = new TwoTuple_u32ScriptZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_u32TxOutZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_u32TxOutZ.java
@@ -55,7 +55,7 @@ public class TwoTuple_u32TxOutZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_u32TxOutZ ret_hu_conv = new TwoTuple_u32TxOutZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -68,7 +68,7 @@ public class TwoTuple_u32TxOutZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_u32TxOutZ ret_hu_conv = new TwoTuple_u32TxOutZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_u64u64Z.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_u64u64Z.java
@@ -53,7 +53,7 @@ public class TwoTuple_u64u64Z extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_u64u64Z ret_hu_conv = new TwoTuple_u64u64Z(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class TwoTuple_u64u64Z extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_u64u64Z ret_hu_conv = new TwoTuple_u64u64Z(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TwoTuple_usizeTransactionZ.java
+++ b/src/main/java/org/ldk/structs/TwoTuple_usizeTransactionZ.java
@@ -53,7 +53,7 @@ public class TwoTuple_usizeTransactionZ extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_usizeTransactionZ ret_hu_conv = new TwoTuple_usizeTransactionZ(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -66,7 +66,7 @@ public class TwoTuple_usizeTransactionZ extends CommonBase {
 		Reference.reachabilityFence(b);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		TwoTuple_usizeTransactionZ ret_hu_conv = new TwoTuple_usizeTransactionZ(null, ret);
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/TxCreationKeys.java
+++ b/src/main/java/org/ldk/structs/TxCreationKeys.java
@@ -136,7 +136,7 @@ public class TxCreationKeys extends CommonBase {
 		Reference.reachabilityFence(broadcaster_delayed_payment_key_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.TxCreationKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.TxCreationKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -154,7 +154,7 @@ public class TxCreationKeys extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.TxCreationKeys ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.TxCreationKeys(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -205,8 +205,8 @@ public class TxCreationKeys extends CommonBase {
 		Reference.reachabilityFence(countersignatory_keys);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_TxCreationKeysErrorZ ret_hu_conv = Result_TxCreationKeysErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(broadcaster_keys);
-		ret_hu_conv.ptrs_to.add(countersignatory_keys);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(broadcaster_keys); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(countersignatory_keys); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Type.java
+++ b/src/main/java/org/ldk/structs/Type.java
@@ -103,7 +103,7 @@ public class Type extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Type ret_hu_conv = new Type(null, ret);
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UnsignedChannelAnnouncement.java
+++ b/src/main/java/org/ldk/structs/UnsignedChannelAnnouncement.java
@@ -28,7 +28,7 @@ public class UnsignedChannelAnnouncement extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -39,7 +39,7 @@ public class UnsignedChannelAnnouncement extends CommonBase {
 		bindings.UnsignedChannelAnnouncement_set_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -164,7 +164,7 @@ public class UnsignedChannelAnnouncement extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UnsignedChannelAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UnsignedChannelAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UnsignedChannelUpdate.java
+++ b/src/main/java/org/ldk/structs/UnsignedChannelUpdate.java
@@ -237,7 +237,7 @@ public class UnsignedChannelUpdate extends CommonBase {
 		Reference.reachabilityFence(excess_data_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UnsignedChannelUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UnsignedChannelUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -255,7 +255,7 @@ public class UnsignedChannelUpdate extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UnsignedChannelUpdate ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UnsignedChannelUpdate(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UnsignedNodeAnnouncement.java
+++ b/src/main/java/org/ldk/structs/UnsignedNodeAnnouncement.java
@@ -28,7 +28,7 @@ public class UnsignedNodeAnnouncement extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.NodeFeatures ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.NodeFeatures(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -39,7 +39,7 @@ public class UnsignedNodeAnnouncement extends CommonBase {
 		bindings.UnsignedNodeAnnouncement_set_features(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -131,7 +131,7 @@ public class UnsignedNodeAnnouncement extends CommonBase {
 		for (int m = 0; m < ret_conv_12_len; m++) {
 			long ret_conv_12 = ret[m];
 			org.ldk.structs.NetAddress ret_conv_12_hu_conv = org.ldk.structs.NetAddress.constr_from_ptr(ret_conv_12);
-			ret_conv_12_hu_conv.ptrs_to.add(this);
+			if (ret_conv_12_hu_conv != null) { ret_conv_12_hu_conv.ptrs_to.add(this); };
 			ret_conv_12_arr[m] = ret_conv_12_hu_conv;
 		}
 		return ret_conv_12_arr;
@@ -160,7 +160,7 @@ public class UnsignedNodeAnnouncement extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UnsignedNodeAnnouncement ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UnsignedNodeAnnouncement(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UpdateAddHTLC.java
+++ b/src/main/java/org/ldk/structs/UpdateAddHTLC.java
@@ -124,7 +124,7 @@ public class UpdateAddHTLC extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UpdateAddHTLC ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UpdateAddHTLC(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UpdateFailHTLC.java
+++ b/src/main/java/org/ldk/structs/UpdateFailHTLC.java
@@ -70,7 +70,7 @@ public class UpdateFailHTLC extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UpdateFailHTLC ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UpdateFailHTLC(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UpdateFailMalformedHTLC.java
+++ b/src/main/java/org/ldk/structs/UpdateFailMalformedHTLC.java
@@ -88,7 +88,7 @@ public class UpdateFailMalformedHTLC extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UpdateFailMalformedHTLC ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UpdateFailMalformedHTLC(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UpdateFee.java
+++ b/src/main/java/org/ldk/structs/UpdateFee.java
@@ -65,7 +65,7 @@ public class UpdateFee extends CommonBase {
 		Reference.reachabilityFence(feerate_per_kw_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UpdateFee ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UpdateFee(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -83,7 +83,7 @@ public class UpdateFee extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UpdateFee ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UpdateFee(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UpdateFulfillHTLC.java
+++ b/src/main/java/org/ldk/structs/UpdateFulfillHTLC.java
@@ -84,7 +84,7 @@ public class UpdateFulfillHTLC extends CommonBase {
 		Reference.reachabilityFence(payment_preimage_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UpdateFulfillHTLC ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UpdateFulfillHTLC(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -102,7 +102,7 @@ public class UpdateFulfillHTLC extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UpdateFulfillHTLC ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UpdateFulfillHTLC(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UserConfig.java
+++ b/src/main/java/org/ldk/structs/UserConfig.java
@@ -31,7 +31,7 @@ public class UserConfig extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelHandshakeConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelHandshakeConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -42,7 +42,7 @@ public class UserConfig extends CommonBase {
 		bindings.UserConfig_set_channel_handshake_config(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -53,7 +53,7 @@ public class UserConfig extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelHandshakeLimits ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelHandshakeLimits(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -64,7 +64,7 @@ public class UserConfig extends CommonBase {
 		bindings.UserConfig_set_channel_handshake_limits(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -75,7 +75,7 @@ public class UserConfig extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.ChannelConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.ChannelConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -86,7 +86,7 @@ public class UserConfig extends CommonBase {
 		bindings.UserConfig_set_channel_config(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -212,10 +212,10 @@ public class UserConfig extends CommonBase {
 		Reference.reachabilityFence(manually_accept_inbound_channels_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UserConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UserConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(channel_handshake_config_arg);
-		ret_hu_conv.ptrs_to.add(channel_handshake_limits_arg);
-		ret_hu_conv.ptrs_to.add(channel_config_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channel_handshake_config_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channel_handshake_limits_arg); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channel_config_arg); };
 		return ret_hu_conv;
 	}
 
@@ -233,7 +233,7 @@ public class UserConfig extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UserConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UserConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -244,7 +244,7 @@ public class UserConfig extends CommonBase {
 		long ret = bindings.UserConfig_default();
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.UserConfig ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.UserConfig(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/UtilMethods.java
+++ b/src/main/java/org/ldk/structs/UtilMethods.java
@@ -124,7 +124,7 @@ public class UtilMethods {
 		Reference.reachabilityFence(arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ ret_hu_conv = Result_C2Tuple_BlockHashChannelMonitorZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg); };
 		return ret_hu_conv;
 	}
 
@@ -143,13 +143,13 @@ public class UtilMethods {
 		Reference.reachabilityFence(arg_channel_monitors);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ ret_hu_conv = Result_C2Tuple_BlockHashChannelManagerZDecodeErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(arg_keys_manager);
-		ret_hu_conv.ptrs_to.add(arg_fee_estimator);
-		ret_hu_conv.ptrs_to.add(arg_chain_monitor);
-		ret_hu_conv.ptrs_to.add(arg_tx_broadcaster);
-		ret_hu_conv.ptrs_to.add(arg_logger);
-		ret_hu_conv.ptrs_to.add(arg_default_config);
-		for (ChannelMonitor arg_channel_monitors_conv_16: arg_channel_monitors) { ret_hu_conv.ptrs_to.add(arg_channel_monitors_conv_16); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_keys_manager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_fee_estimator); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_chain_monitor); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_tx_broadcaster); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_default_config); };
+		for (ChannelMonitor arg_channel_monitors_conv_16: arg_channel_monitors) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(arg_channel_monitors_conv_16); }; };
 		return ret_hu_conv;
 	}
 
@@ -175,8 +175,8 @@ public class UtilMethods {
 		Reference.reachabilityFence(current_time);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_C2Tuple_PaymentHashPaymentSecretZNoneZ ret_hu_conv = Result_C2Tuple_PaymentHashPaymentSecretZNoneZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(keys);
-		ret_hu_conv.ptrs_to.add(keys_manager);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
 		return ret_hu_conv;
 	}
 
@@ -198,7 +198,7 @@ public class UtilMethods {
 		Reference.reachabilityFence(current_time);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_PaymentSecretNoneZ ret_hu_conv = Result_PaymentSecretNoneZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(keys);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys); };
 		return ret_hu_conv;
 	}
 
@@ -460,11 +460,11 @@ public class UtilMethods {
 		Reference.reachabilityFence(random_seed_bytes);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteLightningErrorZ ret_hu_conv = Result_RouteLightningErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(route_params);
-		ret_hu_conv.ptrs_to.add(network_graph);
-		for (ChannelDetails first_hops_conv_16: first_hops) { ret_hu_conv.ptrs_to.add(first_hops_conv_16); };
-		ret_hu_conv.ptrs_to.add(logger);
-		ret_hu_conv.ptrs_to.add(scorer);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(route_params); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(network_graph); };
+		for (ChannelDetails first_hops_conv_16: first_hops) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(first_hops_conv_16); }; };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(scorer); };
 		return ret_hu_conv;
 	}
 
@@ -484,9 +484,9 @@ public class UtilMethods {
 		Reference.reachabilityFence(random_seed_bytes);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_RouteLightningErrorZ ret_hu_conv = Result_RouteLightningErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(route_params);
-		ret_hu_conv.ptrs_to.add(network_graph);
-		ret_hu_conv.ptrs_to.add(logger);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(route_params); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(network_graph); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(logger); };
 		return ret_hu_conv;
 	}
 
@@ -534,8 +534,8 @@ public class UtilMethods {
 		Reference.reachabilityFence(network);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSignOrCreationErrorZ ret_hu_conv = Result_InvoiceSignOrCreationErrorZ.constr_from_ptr(ret);
-		for (PhantomRouteHints phantom_route_hints_conv_19: phantom_route_hints) { ret_hu_conv.ptrs_to.add(phantom_route_hints_conv_19); };
-		ret_hu_conv.ptrs_to.add(keys_manager);
+		for (PhantomRouteHints phantom_route_hints_conv_19: phantom_route_hints) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(phantom_route_hints_conv_19); }; };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
 		return ret_hu_conv;
 	}
 
@@ -585,9 +585,9 @@ public class UtilMethods {
 		Reference.reachabilityFence(network);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSignOrCreationErrorZ ret_hu_conv = Result_InvoiceSignOrCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(description_hash);
-		for (PhantomRouteHints phantom_route_hints_conv_19: phantom_route_hints) { ret_hu_conv.ptrs_to.add(phantom_route_hints_conv_19); };
-		ret_hu_conv.ptrs_to.add(keys_manager);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(description_hash); };
+		for (PhantomRouteHints phantom_route_hints_conv_19: phantom_route_hints) { if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(phantom_route_hints_conv_19); }; };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
 		return ret_hu_conv;
 	}
 
@@ -611,8 +611,8 @@ public class UtilMethods {
 		Reference.reachabilityFence(invoice_expiry_delta_secs);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSignOrCreationErrorZ ret_hu_conv = Result_InvoiceSignOrCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(channelmanager);
-		ret_hu_conv.ptrs_to.add(keys_manager);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channelmanager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
 		return ret_hu_conv;
 	}
 
@@ -637,9 +637,9 @@ public class UtilMethods {
 		Reference.reachabilityFence(invoice_expiry_delta_secs);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSignOrCreationErrorZ ret_hu_conv = Result_InvoiceSignOrCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(channelmanager);
-		ret_hu_conv.ptrs_to.add(keys_manager);
-		ret_hu_conv.ptrs_to.add(description_hash);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channelmanager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(description_hash); };
 		return ret_hu_conv;
 	}
 
@@ -659,9 +659,9 @@ public class UtilMethods {
 		Reference.reachabilityFence(invoice_expiry_delta_secs);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSignOrCreationErrorZ ret_hu_conv = Result_InvoiceSignOrCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(channelmanager);
-		ret_hu_conv.ptrs_to.add(keys_manager);
-		ret_hu_conv.ptrs_to.add(description_hash);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channelmanager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(description_hash); };
 		return ret_hu_conv;
 	}
 
@@ -681,8 +681,8 @@ public class UtilMethods {
 		Reference.reachabilityFence(invoice_expiry_delta_secs);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_InvoiceSignOrCreationErrorZ ret_hu_conv = Result_InvoiceSignOrCreationErrorZ.constr_from_ptr(ret);
-		ret_hu_conv.ptrs_to.add(channelmanager);
-		ret_hu_conv.ptrs_to.add(keys_manager);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(channelmanager); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(keys_manager); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/WarningMessage.java
+++ b/src/main/java/org/ldk/structs/WarningMessage.java
@@ -75,7 +75,7 @@ public class WarningMessage extends CommonBase {
 		Reference.reachabilityFence(data_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.WarningMessage ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.WarningMessage(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
 		return ret_hu_conv;
 	}
 
@@ -93,7 +93,7 @@ public class WarningMessage extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.WarningMessage ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.WarningMessage(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/src/main/java/org/ldk/structs/Watch.java
+++ b/src/main/java/org/ldk/structs/Watch.java
@@ -86,9 +86,9 @@ public class Watch extends CommonBase {
 		impl_holder.held = new Watch(new bindings.LDKWatch() {
 			@Override public long watch_channel(long funding_txo, long monitor) {
 				org.ldk.structs.OutPoint funding_txo_hu_conv = null; if (funding_txo < 0 || funding_txo > 4096) { funding_txo_hu_conv = new org.ldk.structs.OutPoint(null, funding_txo); }
-				funding_txo_hu_conv.ptrs_to.add(this);
+				if (funding_txo_hu_conv != null) { funding_txo_hu_conv.ptrs_to.add(this); };
 				org.ldk.structs.ChannelMonitor monitor_hu_conv = null; if (monitor < 0 || monitor > 4096) { monitor_hu_conv = new org.ldk.structs.ChannelMonitor(null, monitor); }
-				monitor_hu_conv.ptrs_to.add(this);
+				if (monitor_hu_conv != null) { monitor_hu_conv.ptrs_to.add(this); };
 				Result_NoneChannelMonitorUpdateErrZ ret = arg.watch_channel(funding_txo_hu_conv, monitor_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -96,9 +96,9 @@ public class Watch extends CommonBase {
 			}
 			@Override public long update_channel(long funding_txo, long update) {
 				org.ldk.structs.OutPoint funding_txo_hu_conv = null; if (funding_txo < 0 || funding_txo > 4096) { funding_txo_hu_conv = new org.ldk.structs.OutPoint(null, funding_txo); }
-				funding_txo_hu_conv.ptrs_to.add(this);
+				if (funding_txo_hu_conv != null) { funding_txo_hu_conv.ptrs_to.add(this); };
 				org.ldk.structs.ChannelMonitorUpdate update_hu_conv = null; if (update < 0 || update > 4096) { update_hu_conv = new org.ldk.structs.ChannelMonitorUpdate(null, update); }
-				update_hu_conv.ptrs_to.add(this);
+				if (update_hu_conv != null) { update_hu_conv.ptrs_to.add(this); };
 				Result_NoneChannelMonitorUpdateErrZ ret = arg.update_channel(funding_txo_hu_conv, update_hu_conv);
 				Reference.reachabilityFence(arg);
 				long result = ret == null ? 0 : ret.clone_ptr();
@@ -134,8 +134,8 @@ public class Watch extends CommonBase {
 		Reference.reachabilityFence(monitor);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneChannelMonitorUpdateErrZ ret_hu_conv = Result_NoneChannelMonitorUpdateErrZ.constr_from_ptr(ret);
-		this.ptrs_to.add(funding_txo);
-		this.ptrs_to.add(monitor);
+		if (this != null) { this.ptrs_to.add(funding_txo); };
+		if (this != null) { this.ptrs_to.add(monitor); };
 		return ret_hu_conv;
 	}
 
@@ -154,8 +154,8 @@ public class Watch extends CommonBase {
 		Reference.reachabilityFence(update);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		Result_NoneChannelMonitorUpdateErrZ ret_hu_conv = Result_NoneChannelMonitorUpdateErrZ.constr_from_ptr(ret);
-		this.ptrs_to.add(funding_txo);
-		this.ptrs_to.add(update);
+		if (this != null) { this.ptrs_to.add(funding_txo); };
+		if (this != null) { this.ptrs_to.add(update); };
 		return ret_hu_conv;
 	}
 
@@ -178,7 +178,7 @@ public class Watch extends CommonBase {
 		for (int x = 0; x < ret_conv_49_len; x++) {
 			long ret_conv_49 = ret[x];
 			ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ ret_conv_49_hu_conv = new ThreeTuple_OutPointCVec_MonitorEventZPublicKeyZ(null, ret_conv_49);
-			ret_conv_49_hu_conv.ptrs_to.add(this);
+			if (ret_conv_49_hu_conv != null) { ret_conv_49_hu_conv.ptrs_to.add(this); };
 			ret_conv_49_arr[x] = ret_conv_49_hu_conv;
 		}
 		return ret_conv_49_arr;

--- a/src/main/java/org/ldk/structs/WatchedOutput.java
+++ b/src/main/java/org/ldk/structs/WatchedOutput.java
@@ -61,7 +61,7 @@ public class WatchedOutput extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.OutPoint ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.OutPoint(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 
@@ -72,7 +72,7 @@ public class WatchedOutput extends CommonBase {
 		bindings.WatchedOutput_set_outpoint(this.ptr, val == null ? 0 : val.ptr);
 		Reference.reachabilityFence(this);
 		Reference.reachabilityFence(val);
-		this.ptrs_to.add(val);
+		if (this != null) { this.ptrs_to.add(val); };
 	}
 
 	/**
@@ -103,8 +103,8 @@ public class WatchedOutput extends CommonBase {
 		Reference.reachabilityFence(script_pubkey_arg);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.WatchedOutput ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.WatchedOutput(null, ret); }
-		ret_hu_conv.ptrs_to.add(ret_hu_conv);
-		ret_hu_conv.ptrs_to.add(outpoint_arg);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(ret_hu_conv); };
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(outpoint_arg); };
 		return ret_hu_conv;
 	}
 
@@ -122,7 +122,7 @@ public class WatchedOutput extends CommonBase {
 		Reference.reachabilityFence(this);
 		if (ret >= 0 && ret <= 4096) { return null; }
 		org.ldk.structs.WatchedOutput ret_hu_conv = null; if (ret < 0 || ret > 4096) { ret_hu_conv = new org.ldk.structs.WatchedOutput(null, ret); }
-		ret_hu_conv.ptrs_to.add(this);
+		if (ret_hu_conv != null) { ret_hu_conv.ptrs_to.add(this); };
 		return ret_hu_conv;
 	}
 

--- a/ts/structs/CommonBase.mts
+++ b/ts/structs/CommonBase.mts
@@ -374,7 +374,7 @@ export class CommonBase {
 	// In TypeScript, protected means "any subclass can access parent fields on instances of itself"
 	// To work around this, we add accessors for other instances' protected fields here.
 	protected static add_ref_from(holder: CommonBase, referent: object) {
-		holder.ptrs_to.push(referent);
+		if (holder !== null) { holder.ptrs_to.push(referent); }
 	}
 	protected static get_ptr_of(o: CommonBase) {
 		return o.ptr;

--- a/typescript_strings.py
+++ b/typescript_strings.py
@@ -348,7 +348,7 @@ export class CommonBase {
 	// In TypeScript, protected means "any subclass can access parent fields on instances of itself"
 	// To work around this, we add accessors for other instances' protected fields here.
 	protected static add_ref_from(holder: CommonBase, referent: object) {
-		holder.ptrs_to.push(referent);
+		if (holder !== null) { holder.ptrs_to.push(referent); }
 	}
 	protected static get_ptr_of(o: CommonBase) {
 		return o.ptr;


### PR DESCRIPTION
At least in `Event::PaymentPathFailed` if we try to map an event
with no `retry` we'll hit a `NullPointerException` as we'll try to
add a reference from the `null` retry back to the `Event` itself.

The simple fix is to simply exhaustively check for `null` before
adding references everywhere.