### PR TITLE
Add missing cargo env load for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -459,6 +459,7 @@ jobs:
           cd ldk-c-bindings
           git checkout 0.0.117
           cd lightning-c-bindings
+          . $HOME/.cargo/env
           cargo update -p memchr --precise "2.5.0" --verbose
       - name: Checkout Android AAR binaries and artifacts
         run: |


### PR DESCRIPTION
The 0.0.117 release determinism tests ended up using a version different from what was merged by a CI update, which is re-added here.