### PR TITLE
CSharp: fix LDKStr array decoding

### DIFF
--- a/c_sharp/src/org/ldk/structs/Bolt11Invoice.cs
+++ b/c_sharp/src/org/ldk/structs/Bolt11Invoice.cs
@@ -307,7 +307,7 @@ public class Bolt11Invoice : CommonBase {
 		int ret_conv_8_len = InternalUtils.getArrayLength(ret);
 		string[] ret_conv_8_arr = new string[ret_conv_8_len];
 		for (int i = 0; i < ret_conv_8_len; i++) {
-			long ret_conv_8 = InternalUtils.getU32ArrayElem(ret, i);
+			long ret_conv_8 = InternalUtils.getU64ArrayElem(ret, i);
 			string ret_conv_8_conv = InternalUtils.decodeString(ret_conv_8);
 			ret_conv_8_arr[i] = ret_conv_8_conv;
 		}

--- a/c_sharp/src/org/ldk/structs/Result_CVec_StrZIOErrorZ.cs
+++ b/c_sharp/src/org/ldk/structs/Result_CVec_StrZIOErrorZ.cs
@@ -25,7 +25,7 @@ public class Result_CVec_StrZIOErrorZ : CommonBase {
 			int res_conv_8_len = InternalUtils.getArrayLength(res);
 			string[] res_conv_8_arr = new string[res_conv_8_len];
 			for (int i = 0; i < res_conv_8_len; i++) {
-				long res_conv_8 = InternalUtils.getU32ArrayElem(res, i);
+				long res_conv_8 = InternalUtils.getU64ArrayElem(res, i);
 				string res_conv_8_conv = InternalUtils.decodeString(res_conv_8);
 				res_conv_8_arr[i] = res_conv_8_conv;
 			}

--- a/csharp_strings.py
+++ b/csharp_strings.py
@@ -581,7 +581,7 @@ int CS_LDK_register_{fn_suffix}_invoker(invoker_{fn_suffix} invoker) {{
         elif elem_ty.rust_obj == "LDKU5":
             return "InternalUtils.getU8ArrayElem(" + arr_name + ", " + idx + ")"
         elif elem_ty.rust_obj == "LDKStr":
-            return "InternalUtils.getU32ArrayElem(" + arr_name + ", " + idx + ")"
+            return "InternalUtils.getU64ArrayElem(" + arr_name + ", " + idx + ")"
         else:
             assert False
 


### PR DESCRIPTION
Strings are encoded as array of string references, those references are actually pointers to the string location and have 64bit in size, but decoding logic was decoding those pointers as 32bit which caused the following exception, this commit fixes that.

Exception:

Fatal error. System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at InternalUtils.getArrayLength(Int64)
   at InternalUtils.decodeUint8Array(Int64)
   at InternalUtils.decodeString(Int64)
   at org.ldk.structs.Result_CVec_StrZIOErrorZ+Result_CVec_StrZIOErrorZ_OK..ctor(System.Object, Int64)
   at org.ldk.structs.Result_CVec_StrZIOErrorZ.constr_from_ptr(Int64)
   at org.ldk.structs.KVStore.list(System.String, System.String)