### PR TITLE
CI: fix typo in git clone command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -698,7 +698,7 @@ jobs:
           git config --global user.email "ldk-ci@example.com"
           git config --global user.name "LDK CI"
           # Note this is a different endpoint, as we need one non-upstream commit!
-          git clone https://github.com/rghtningdevkit/ust-lightning
+          git clone https://github.com/lightningdevkit/rust-lightning
           cd rust-lightning
           git checkout origin/0.0.121-bindings
           cd ..


### PR DESCRIPTION
Introduced in:
94ae3f5ecc951f3d527f97ea10a8a4d897e6b696