### PR TITLE
ci: repair stale CI (MSRV pins, retired runners, regenerated C# bindings)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,21 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # Pin deps in the rust-lightning workspace too: genbindings.sh runs
+          # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
+          # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
+          cd ../../rust-lightning
+          cargo update -p syn --precise "2.0.106" --verbose
+          cargo update -p quote --precise "1.0.41" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose
+          cargo update -p serde_json --precise "1.0.145" --verbose
+          cargo update -p itoa --precise "1.0.15" --verbose
+          cargo update -p ryu --precise "1.0.20" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cargo update -p libc --precise "0.2.183" --verbose
+          GETRANDOM_VERSION="$(cargo tree 2>&1 | grep -o 'getrandom v0.4.*' | tr -d ' `' | tr 'v' '@' || echo -n)"
+          if [ -n "$GETRANDOM_VERSION" ]; then cargo update -p "$GETRANDOM_VERSION" --precise 0.3.4 --verbose; fi
       - name: Rebuild C bindings without STD
         run: |
           cd ldk-c-bindings
@@ -157,6 +172,21 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # Pin deps in the rust-lightning workspace too: genbindings.sh runs
+          # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
+          # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
+          cd ../../rust-lightning
+          cargo update -p syn --precise "2.0.106" --verbose
+          cargo update -p quote --precise "1.0.41" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose
+          cargo update -p serde_json --precise "1.0.145" --verbose
+          cargo update -p itoa --precise "1.0.15" --verbose
+          cargo update -p ryu --precise "1.0.20" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cargo update -p libc --precise "0.2.183" --verbose
+          GETRANDOM_VERSION="$(cargo tree 2>&1 | grep -o 'getrandom v0.4.*' | tr -d ' `' | tr 'v' '@' || echo -n)"
+          if [ -n "$GETRANDOM_VERSION" ]; then cargo update -p "$GETRANDOM_VERSION" --precise 0.3.4 --verbose; fi
       - name: Rebuild C bindings with STD
         run: |
           cd ldk-c-bindings
@@ -390,6 +420,21 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # Pin deps in the rust-lightning workspace too: genbindings.sh runs
+          # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
+          # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
+          cd ../../rust-lightning
+          cargo update -p syn --precise "2.0.106" --verbose
+          cargo update -p quote --precise "1.0.41" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose
+          cargo update -p serde_json --precise "1.0.145" --verbose
+          cargo update -p itoa --precise "1.0.15" --verbose
+          cargo update -p ryu --precise "1.0.20" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cargo update -p libc --precise "0.2.183" --verbose
+          GETRANDOM_VERSION="$(cargo tree 2>&1 | grep -o 'getrandom v0.4.*' | tr -d ' `' | tr 'v' '@' || echo -n)"
+          if [ -n "$GETRANDOM_VERSION" ]; then cargo update -p "$GETRANDOM_VERSION" --precise 0.3.4 --verbose; fi
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           cd ldk-c-bindings
@@ -454,6 +499,21 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # Pin deps in the rust-lightning workspace too: genbindings.sh runs
+          # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
+          # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
+          cd ../../rust-lightning
+          cargo update -p syn --precise "2.0.106" --verbose
+          cargo update -p quote --precise "1.0.41" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose
+          cargo update -p serde_json --precise "1.0.145" --verbose
+          cargo update -p itoa --precise "1.0.15" --verbose
+          cargo update -p ryu --precise "1.0.20" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cargo update -p libc --precise "0.2.183" --verbose
+          GETRANDOM_VERSION="$(cargo tree 2>&1 | grep -o 'getrandom v0.4.*' | tr -d ' `' | tr 'v' '@' || echo -n)"
+          if [ -n "$GETRANDOM_VERSION" ]; then cargo update -p "$GETRANDOM_VERSION" --precise 0.3.4 --verbose; fi
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           cd ldk-c-bindings
@@ -588,6 +648,21 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # Pin deps in the rust-lightning workspace too: genbindings.sh runs
+          # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
+          # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
+          cd ../../rust-lightning
+          cargo update -p syn --precise "2.0.106" --verbose
+          cargo update -p quote --precise "1.0.41" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose
+          cargo update -p serde_json --precise "1.0.145" --verbose
+          cargo update -p itoa --precise "1.0.15" --verbose
+          cargo update -p ryu --precise "1.0.20" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cargo update -p libc --precise "0.2.183" --verbose
+          GETRANDOM_VERSION="$(cargo tree 2>&1 | grep -o 'getrandom v0.4.*' | tr -d ' `' | tr 'v' '@' || echo -n)"
+          if [ -n "$GETRANDOM_VERSION" ]; then cargo update -p "$GETRANDOM_VERSION" --precise 0.3.4 --verbose; fi
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           # rust-src doesn't distribute the rustlib Cargo.lock, but an empty
@@ -724,6 +799,21 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # Pin deps in the rust-lightning workspace too: genbindings.sh runs
+          # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
+          # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
+          cd ../../rust-lightning
+          cargo update -p syn --precise "2.0.106" --verbose
+          cargo update -p quote --precise "1.0.41" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose
+          cargo update -p serde_json --precise "1.0.145" --verbose
+          cargo update -p itoa --precise "1.0.15" --verbose
+          cargo update -p ryu --precise "1.0.20" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cargo update -p libc --precise "0.2.183" --verbose
+          GETRANDOM_VERSION="$(cargo tree 2>&1 | grep -o 'getrandom v0.4.*' | tr -d ' `' | tr 'v' '@' || echo -n)"
+          if [ -n "$GETRANDOM_VERSION" ]; then cargo update -p "$GETRANDOM_VERSION" --precise 0.3.4 --verbose; fi
       - name: Checkout Android AAR binaries and artifacts
         run: |
           # Gitweb only allows snapshots of folders by providing the object hash, which we have to extract:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,13 +53,31 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out and the syn pin below
+          # is unambiguous. These enter this workspace via lightning /
+          # lightning-liquidity; guard with || true where a package may be
+          # absent from the graph.
+          cargo update -p serde --precise "1.0.228" --verbose || true
+          cargo update -p tokio --precise "1.38.1" --verbose || true
+          cargo update -p syn --precise "2.0.106" --verbose || true
+          cargo update -p quote --precise "1.0.41" --verbose || true
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose || true
+          cargo update -p unicode-ident --precise "1.0.22" --verbose || true
+          cargo update -p serde_json --precise "1.0.145" --verbose || true
+          cargo update -p itoa --precise "1.0.15" --verbose || true
+          cargo update -p ryu --precise "1.0.20" --verbose || true
           # Pin deps in the rust-lightning workspace too: genbindings.sh runs
           # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
           # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
           cd ../../rust-lightning
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out of the graph and the
+          # bare syn pin below is unambiguous.
+          cargo update -p serde --precise "1.0.228" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p syn --precise "2.0.106" --verbose
           cargo update -p quote --precise "1.0.41" --verbose
-          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p proc-macro2 --precise "1.0.103" --verbose
           cargo update -p serde_json --precise "1.0.145" --verbose
           cargo update -p itoa --precise "1.0.15" --verbose
@@ -172,13 +190,31 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out and the syn pin below
+          # is unambiguous. These enter this workspace via lightning /
+          # lightning-liquidity; guard with || true where a package may be
+          # absent from the graph.
+          cargo update -p serde --precise "1.0.228" --verbose || true
+          cargo update -p tokio --precise "1.38.1" --verbose || true
+          cargo update -p syn --precise "2.0.106" --verbose || true
+          cargo update -p quote --precise "1.0.41" --verbose || true
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose || true
+          cargo update -p unicode-ident --precise "1.0.22" --verbose || true
+          cargo update -p serde_json --precise "1.0.145" --verbose || true
+          cargo update -p itoa --precise "1.0.15" --verbose || true
+          cargo update -p ryu --precise "1.0.20" --verbose || true
           # Pin deps in the rust-lightning workspace too: genbindings.sh runs
           # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
           # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
           cd ../../rust-lightning
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out of the graph and the
+          # bare syn pin below is unambiguous.
+          cargo update -p serde --precise "1.0.228" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p syn --precise "2.0.106" --verbose
           cargo update -p quote --precise "1.0.41" --verbose
-          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p proc-macro2 --precise "1.0.103" --verbose
           cargo update -p serde_json --precise "1.0.145" --verbose
           cargo update -p itoa --precise "1.0.15" --verbose
@@ -420,13 +456,31 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out and the syn pin below
+          # is unambiguous. These enter this workspace via lightning /
+          # lightning-liquidity; guard with || true where a package may be
+          # absent from the graph.
+          cargo update -p serde --precise "1.0.228" --verbose || true
+          cargo update -p tokio --precise "1.38.1" --verbose || true
+          cargo update -p syn --precise "2.0.106" --verbose || true
+          cargo update -p quote --precise "1.0.41" --verbose || true
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose || true
+          cargo update -p unicode-ident --precise "1.0.22" --verbose || true
+          cargo update -p serde_json --precise "1.0.145" --verbose || true
+          cargo update -p itoa --precise "1.0.15" --verbose || true
+          cargo update -p ryu --precise "1.0.20" --verbose || true
           # Pin deps in the rust-lightning workspace too: genbindings.sh runs
           # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
           # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
           cd ../../rust-lightning
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out of the graph and the
+          # bare syn pin below is unambiguous.
+          cargo update -p serde --precise "1.0.228" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p syn --precise "2.0.106" --verbose
           cargo update -p quote --precise "1.0.41" --verbose
-          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p proc-macro2 --precise "1.0.103" --verbose
           cargo update -p serde_json --precise "1.0.145" --verbose
           cargo update -p itoa --precise "1.0.15" --verbose
@@ -499,13 +553,31 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out and the syn pin below
+          # is unambiguous. These enter this workspace via lightning /
+          # lightning-liquidity; guard with || true where a package may be
+          # absent from the graph.
+          cargo update -p serde --precise "1.0.228" --verbose || true
+          cargo update -p tokio --precise "1.38.1" --verbose || true
+          cargo update -p syn --precise "2.0.106" --verbose || true
+          cargo update -p quote --precise "1.0.41" --verbose || true
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose || true
+          cargo update -p unicode-ident --precise "1.0.22" --verbose || true
+          cargo update -p serde_json --precise "1.0.145" --verbose || true
+          cargo update -p itoa --precise "1.0.15" --verbose || true
+          cargo update -p ryu --precise "1.0.20" --verbose || true
           # Pin deps in the rust-lightning workspace too: genbindings.sh runs
           # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
           # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
           cd ../../rust-lightning
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out of the graph and the
+          # bare syn pin below is unambiguous.
+          cargo update -p serde --precise "1.0.228" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p syn --precise "2.0.106" --verbose
           cargo update -p quote --precise "1.0.41" --verbose
-          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p proc-macro2 --precise "1.0.103" --verbose
           cargo update -p serde_json --precise "1.0.145" --verbose
           cargo update -p itoa --precise "1.0.15" --verbose
@@ -648,13 +720,31 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out and the syn pin below
+          # is unambiguous. These enter this workspace via lightning /
+          # lightning-liquidity; guard with || true where a package may be
+          # absent from the graph.
+          cargo update -p serde --precise "1.0.228" --verbose || true
+          cargo update -p tokio --precise "1.38.1" --verbose || true
+          cargo update -p syn --precise "2.0.106" --verbose || true
+          cargo update -p quote --precise "1.0.41" --verbose || true
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose || true
+          cargo update -p unicode-ident --precise "1.0.22" --verbose || true
+          cargo update -p serde_json --precise "1.0.145" --verbose || true
+          cargo update -p itoa --precise "1.0.15" --verbose || true
+          cargo update -p ryu --precise "1.0.20" --verbose || true
           # Pin deps in the rust-lightning workspace too: genbindings.sh runs
           # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
           # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
           cd ../../rust-lightning
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out of the graph and the
+          # bare syn pin below is unambiguous.
+          cargo update -p serde --precise "1.0.228" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p syn --precise "2.0.106" --verbose
           cargo update -p quote --precise "1.0.41" --verbose
-          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p proc-macro2 --precise "1.0.103" --verbose
           cargo update -p serde_json --precise "1.0.145" --verbose
           cargo update -p itoa --precise "1.0.15" --verbose
@@ -799,13 +889,31 @@ jobs:
           cargo update -p unicode-ident --precise "1.0.22" --verbose
           cd ../lightning-c-bindings
           cargo update -p libc --precise "0.2.183" --verbose
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out and the syn pin below
+          # is unambiguous. These enter this workspace via lightning /
+          # lightning-liquidity; guard with || true where a package may be
+          # absent from the graph.
+          cargo update -p serde --precise "1.0.228" --verbose || true
+          cargo update -p tokio --precise "1.38.1" --verbose || true
+          cargo update -p syn --precise "2.0.106" --verbose || true
+          cargo update -p quote --precise "1.0.41" --verbose || true
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose || true
+          cargo update -p unicode-ident --precise "1.0.22" --verbose || true
+          cargo update -p serde_json --precise "1.0.145" --verbose || true
+          cargo update -p itoa --precise "1.0.15" --verbose || true
+          cargo update -p ryu --precise "1.0.20" --verbose || true
           # Pin deps in the rust-lightning workspace too: genbindings.sh runs
           # `cargo rustc -Zunpretty=expanded` inside it. Mirrors PIN_RELEASE_DEPS
           # in rust-lightning's ci/ci-tests.sh for rustc 1.63.
           cd ../../rust-lightning
+          # serde_derive 1.0.229+ and tokio-macros 2.7+ pull syn 3 (MSRV 1.71);
+          # pin serde and tokio first so syn 3 drops out of the graph and the
+          # bare syn pin below is unambiguous.
+          cargo update -p serde --precise "1.0.228" --verbose
+          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p syn --precise "2.0.106" --verbose
           cargo update -p quote --precise "1.0.41" --verbose
-          cargo update -p tokio --precise "1.38.1" --verbose
           cargo update -p proc-macro2 --precise "1.0.103" --verbose
           cargo update -p serde_json --precise "1.0.145" --verbose
           cargo update -p itoa --precise "1.0.15" --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
           cargo update -p quote --precise "1.0.30" --verbose
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
           cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cd ../lightning-c-bindings
+          cargo update -p libc --precise "0.2.183" --verbose
       - name: Rebuild C bindings without STD
         run: |
           cd ldk-c-bindings
@@ -153,6 +155,8 @@ jobs:
           cargo update -p quote --precise "1.0.30" --verbose
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
           cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cd ../lightning-c-bindings
+          cargo update -p libc --precise "0.2.183" --verbose
       - name: Rebuild C bindings with STD
         run: |
           cd ldk-c-bindings
@@ -384,6 +388,8 @@ jobs:
           cargo update -p quote --precise "1.0.30" --verbose
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
           cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cd ../lightning-c-bindings
+          cargo update -p libc --precise "0.2.183" --verbose
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           cd ldk-c-bindings
@@ -446,6 +452,8 @@ jobs:
           cargo update -p quote --precise "1.0.30" --verbose
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
           cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cd ../lightning-c-bindings
+          cargo update -p libc --precise "0.2.183" --verbose
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           cd ldk-c-bindings
@@ -578,6 +586,8 @@ jobs:
           cargo update -p quote --precise "1.0.30" --verbose
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
           cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cd ../lightning-c-bindings
+          cargo update -p libc --precise "0.2.183" --verbose
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           # rust-src doesn't distribute the rustlib Cargo.lock, but an empty
@@ -712,6 +722,8 @@ jobs:
           cargo update -p quote --precise "1.0.30" --verbose
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
           cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cd ../lightning-c-bindings
+          cargo update -p libc --precise "0.2.183" --verbose
       - name: Checkout Android AAR binaries and artifacts
         run: |
           # Gitweb only allows snapshots of folders by providing the object hash, which we have to extract:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
           git clone https://github.com/lightningdevkit/ldk-c-bindings
           cd ldk-c-bindings
           git checkout 0.1
+      - name: Pin proc-macro and quote to meet MSRV
+        run: |
+          cd ldk-c-bindings/c-bindings-gen
+          cargo update -p quote --precise "1.0.30" --verbose
+          cargo update -p proc-macro2 --precise "1.0.65" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
       - name: Rebuild C bindings without STD
         run: |
           cd ldk-c-bindings
@@ -141,6 +147,12 @@ jobs:
           git clone https://github.com/lightningdevkit/ldk-c-bindings
           cd ldk-c-bindings
           git checkout 0.1
+      - name: Pin proc-macro and quote to meet MSRV
+        run: |
+          cd ldk-c-bindings/c-bindings-gen
+          cargo update -p quote --precise "1.0.30" --verbose
+          cargo update -p proc-macro2 --precise "1.0.65" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
       - name: Rebuild C bindings with STD
         run: |
           cd ldk-c-bindings
@@ -292,7 +304,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: macos-13
           - platform: macos-14
       fail-fast: false
     runs-on: ${{ matrix.platform }}
@@ -372,6 +383,7 @@ jobs:
           cd ldk-c-bindings/c-bindings-gen
           cargo update -p quote --precise "1.0.30" --verbose
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           cd ldk-c-bindings
@@ -433,6 +445,7 @@ jobs:
           cd ldk-c-bindings/c-bindings-gen
           cargo update -p quote --precise "1.0.30" --verbose
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           cd ldk-c-bindings
@@ -559,6 +572,12 @@ jobs:
         run: |
           curl -o Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz https://bitcoincore.org/depends-sources/sdks/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
           tar xvvf Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz
+      - name: Pin proc-macro and quote to meet MSRV
+        run: |
+          cd ldk-c-bindings/c-bindings-gen
+          cargo update -p quote --precise "1.0.30" --verbose
+          cargo update -p proc-macro2 --precise "1.0.65" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
       - name: Rebuild C bindings, and check the sample app builds + links
         run: |
           # rust-src doesn't distribute the rustlib Cargo.lock, but an empty
@@ -687,6 +706,12 @@ jobs:
           git clone https://github.com/lightningdevkit/ldk-c-bindings
           cd ldk-c-bindings
           git checkout 0.1
+      - name: Pin proc-macro and quote to meet MSRV
+        run: |
+          cd ldk-c-bindings/c-bindings-gen
+          cargo update -p quote --precise "1.0.30" --verbose
+          cargo update -p proc-macro2 --precise "1.0.65" --verbose
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
       - name: Checkout Android AAR binaries and artifacts
         run: |
           # Gitweb only allows snapshots of folders by providing the object hash, which we have to extract:
@@ -738,7 +763,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: macos-13
           - platform: macos-14
       fail-fast: false
     runs-on: ${{ matrix.platform }}

--- a/c_sharp/bindings.c
+++ b/c_sharp/bindings.c
@@ -366,68 +366,6 @@ static inline uint64_t tag_ptr(const void* ptr, bool is_owned) {
 	}
 }
 
-static inline LDKBalanceSource LDKBalanceSource_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKBalanceSource_HolderForceClosed;
-		case 1: return LDKBalanceSource_CounterpartyForceClosed;
-		case 2: return LDKBalanceSource_CoopClose;
-		case 3: return LDKBalanceSource_Htlc;
-		default: abort();
-	}
-}
-static inline int32_t LDKBalanceSource_to_cs(LDKBalanceSource val) {
-	switch (val) {
-		case LDKBalanceSource_HolderForceClosed: return 0;
-		case LDKBalanceSource_CounterpartyForceClosed: return 1;
-		case LDKBalanceSource_CoopClose: return 2;
-		case LDKBalanceSource_Htlc: return 3;
-		default: abort();
-	}
-}
-static inline LDKBlindedFailure LDKBlindedFailure_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKBlindedFailure_FromIntroductionNode;
-		case 1: return LDKBlindedFailure_FromBlindedNode;
-		default: abort();
-	}
-}
-static inline int32_t LDKBlindedFailure_to_cs(LDKBlindedFailure val) {
-	switch (val) {
-		case LDKBlindedFailure_FromIntroductionNode: return 0;
-		case LDKBlindedFailure_FromBlindedNode: return 1;
-		default: abort();
-	}
-}
-static inline LDKBolt11SemanticError LDKBolt11SemanticError_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKBolt11SemanticError_NoPaymentHash;
-		case 1: return LDKBolt11SemanticError_MultiplePaymentHashes;
-		case 2: return LDKBolt11SemanticError_NoDescription;
-		case 3: return LDKBolt11SemanticError_MultipleDescriptions;
-		case 4: return LDKBolt11SemanticError_NoPaymentSecret;
-		case 5: return LDKBolt11SemanticError_MultiplePaymentSecrets;
-		case 6: return LDKBolt11SemanticError_InvalidFeatures;
-		case 7: return LDKBolt11SemanticError_InvalidRecoveryId;
-		case 8: return LDKBolt11SemanticError_InvalidSignature;
-		case 9: return LDKBolt11SemanticError_ImpreciseAmount;
-		default: abort();
-	}
-}
-static inline int32_t LDKBolt11SemanticError_to_cs(LDKBolt11SemanticError val) {
-	switch (val) {
-		case LDKBolt11SemanticError_NoPaymentHash: return 0;
-		case LDKBolt11SemanticError_MultiplePaymentHashes: return 1;
-		case LDKBolt11SemanticError_NoDescription: return 2;
-		case LDKBolt11SemanticError_MultipleDescriptions: return 3;
-		case LDKBolt11SemanticError_NoPaymentSecret: return 4;
-		case LDKBolt11SemanticError_MultiplePaymentSecrets: return 5;
-		case LDKBolt11SemanticError_InvalidFeatures: return 6;
-		case LDKBolt11SemanticError_InvalidRecoveryId: return 7;
-		case LDKBolt11SemanticError_InvalidSignature: return 8;
-		case LDKBolt11SemanticError_ImpreciseAmount: return 9;
-		default: abort();
-	}
-}
 static inline LDKBolt12SemanticError LDKBolt12SemanticError_from_cs(int32_t ord) {
 	switch (ord) {
 		case 0: return LDKBolt12SemanticError_AlreadyExpired;
@@ -500,158 +438,6 @@ static inline int32_t LDKBolt12SemanticError_to_cs(LDKBolt12SemanticError val) {
 		default: abort();
 	}
 }
-static inline LDKCOption_NoneZ LDKCOption_NoneZ_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKCOption_NoneZ_Some;
-		case 1: return LDKCOption_NoneZ_None;
-		default: abort();
-	}
-}
-static inline int32_t LDKCOption_NoneZ_to_cs(LDKCOption_NoneZ val) {
-	switch (val) {
-		case LDKCOption_NoneZ_Some: return 0;
-		case LDKCOption_NoneZ_None: return 1;
-		default: abort();
-	}
-}
-static inline LDKChannelMonitorUpdateStatus LDKChannelMonitorUpdateStatus_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKChannelMonitorUpdateStatus_Completed;
-		case 1: return LDKChannelMonitorUpdateStatus_InProgress;
-		case 2: return LDKChannelMonitorUpdateStatus_UnrecoverableError;
-		default: abort();
-	}
-}
-static inline int32_t LDKChannelMonitorUpdateStatus_to_cs(LDKChannelMonitorUpdateStatus val) {
-	switch (val) {
-		case LDKChannelMonitorUpdateStatus_Completed: return 0;
-		case LDKChannelMonitorUpdateStatus_InProgress: return 1;
-		case LDKChannelMonitorUpdateStatus_UnrecoverableError: return 2;
-		default: abort();
-	}
-}
-static inline LDKChannelShutdownState LDKChannelShutdownState_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKChannelShutdownState_NotShuttingDown;
-		case 1: return LDKChannelShutdownState_ShutdownInitiated;
-		case 2: return LDKChannelShutdownState_ResolvingHTLCs;
-		case 3: return LDKChannelShutdownState_NegotiatingClosingFee;
-		case 4: return LDKChannelShutdownState_ShutdownComplete;
-		default: abort();
-	}
-}
-static inline int32_t LDKChannelShutdownState_to_cs(LDKChannelShutdownState val) {
-	switch (val) {
-		case LDKChannelShutdownState_NotShuttingDown: return 0;
-		case LDKChannelShutdownState_ShutdownInitiated: return 1;
-		case LDKChannelShutdownState_ResolvingHTLCs: return 2;
-		case LDKChannelShutdownState_NegotiatingClosingFee: return 3;
-		case LDKChannelShutdownState_ShutdownComplete: return 4;
-		default: abort();
-	}
-}
-static inline LDKConfirmationTarget LDKConfirmationTarget_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKConfirmationTarget_MaximumFeeEstimate;
-		case 1: return LDKConfirmationTarget_UrgentOnChainSweep;
-		case 2: return LDKConfirmationTarget_MinAllowedAnchorChannelRemoteFee;
-		case 3: return LDKConfirmationTarget_MinAllowedNonAnchorChannelRemoteFee;
-		case 4: return LDKConfirmationTarget_AnchorChannelFee;
-		case 5: return LDKConfirmationTarget_NonAnchorChannelFee;
-		case 6: return LDKConfirmationTarget_ChannelCloseMinimum;
-		case 7: return LDKConfirmationTarget_OutputSpendingFee;
-		default: abort();
-	}
-}
-static inline int32_t LDKConfirmationTarget_to_cs(LDKConfirmationTarget val) {
-	switch (val) {
-		case LDKConfirmationTarget_MaximumFeeEstimate: return 0;
-		case LDKConfirmationTarget_UrgentOnChainSweep: return 1;
-		case LDKConfirmationTarget_MinAllowedAnchorChannelRemoteFee: return 2;
-		case LDKConfirmationTarget_MinAllowedNonAnchorChannelRemoteFee: return 3;
-		case LDKConfirmationTarget_AnchorChannelFee: return 4;
-		case LDKConfirmationTarget_NonAnchorChannelFee: return 5;
-		case LDKConfirmationTarget_ChannelCloseMinimum: return 6;
-		case LDKConfirmationTarget_OutputSpendingFee: return 7;
-		default: abort();
-	}
-}
-static inline LDKCreationError LDKCreationError_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKCreationError_DescriptionTooLong;
-		case 1: return LDKCreationError_RouteTooLong;
-		case 2: return LDKCreationError_TimestampOutOfBounds;
-		case 3: return LDKCreationError_InvalidAmount;
-		case 4: return LDKCreationError_MissingRouteHints;
-		case 5: return LDKCreationError_MinFinalCltvExpiryDeltaTooShort;
-		default: abort();
-	}
-}
-static inline int32_t LDKCreationError_to_cs(LDKCreationError val) {
-	switch (val) {
-		case LDKCreationError_DescriptionTooLong: return 0;
-		case LDKCreationError_RouteTooLong: return 1;
-		case LDKCreationError_TimestampOutOfBounds: return 2;
-		case LDKCreationError_InvalidAmount: return 3;
-		case LDKCreationError_MissingRouteHints: return 4;
-		case LDKCreationError_MinFinalCltvExpiryDeltaTooShort: return 5;
-		default: abort();
-	}
-}
-static inline LDKCurrency LDKCurrency_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKCurrency_Bitcoin;
-		case 1: return LDKCurrency_BitcoinTestnet;
-		case 2: return LDKCurrency_Regtest;
-		case 3: return LDKCurrency_Simnet;
-		case 4: return LDKCurrency_Signet;
-		default: abort();
-	}
-}
-static inline int32_t LDKCurrency_to_cs(LDKCurrency val) {
-	switch (val) {
-		case LDKCurrency_Bitcoin: return 0;
-		case LDKCurrency_BitcoinTestnet: return 1;
-		case LDKCurrency_Regtest: return 2;
-		case LDKCurrency_Simnet: return 3;
-		case LDKCurrency_Signet: return 4;
-		default: abort();
-	}
-}
-static inline LDKDirection LDKDirection_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKDirection_NodeOne;
-		case 1: return LDKDirection_NodeTwo;
-		default: abort();
-	}
-}
-static inline int32_t LDKDirection_to_cs(LDKDirection val) {
-	switch (val) {
-		case LDKDirection_NodeOne: return 0;
-		case LDKDirection_NodeTwo: return 1;
-		default: abort();
-	}
-}
-static inline LDKHTLCClaim LDKHTLCClaim_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKHTLCClaim_OfferedTimeout;
-		case 1: return LDKHTLCClaim_OfferedPreimage;
-		case 2: return LDKHTLCClaim_AcceptedTimeout;
-		case 3: return LDKHTLCClaim_AcceptedPreimage;
-		case 4: return LDKHTLCClaim_Revocation;
-		default: abort();
-	}
-}
-static inline int32_t LDKHTLCClaim_to_cs(LDKHTLCClaim val) {
-	switch (val) {
-		case LDKHTLCClaim_OfferedTimeout: return 0;
-		case LDKHTLCClaim_OfferedPreimage: return 1;
-		case LDKHTLCClaim_AcceptedTimeout: return 2;
-		case LDKHTLCClaim_AcceptedPreimage: return 3;
-		case LDKHTLCClaim_Revocation: return 4;
-		default: abort();
-	}
-}
 static inline LDKIOError LDKIOError_from_cs(int32_t ord) {
 	switch (ord) {
 		case 0: return LDKIOError_NotFound;
@@ -698,175 +484,19 @@ static inline int32_t LDKIOError_to_cs(LDKIOError val) {
 		default: abort();
 	}
 }
-static inline LDKInboundHTLCStateDetails LDKInboundHTLCStateDetails_from_cs(int32_t ord) {
+static inline LDKChannelMonitorUpdateStatus LDKChannelMonitorUpdateStatus_from_cs(int32_t ord) {
 	switch (ord) {
-		case 0: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToAdd;
-		case 1: return LDKInboundHTLCStateDetails_Committed;
-		case 2: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFulfill;
-		case 3: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFail;
+		case 0: return LDKChannelMonitorUpdateStatus_Completed;
+		case 1: return LDKChannelMonitorUpdateStatus_InProgress;
+		case 2: return LDKChannelMonitorUpdateStatus_UnrecoverableError;
 		default: abort();
 	}
 }
-static inline int32_t LDKInboundHTLCStateDetails_to_cs(LDKInboundHTLCStateDetails val) {
+static inline int32_t LDKChannelMonitorUpdateStatus_to_cs(LDKChannelMonitorUpdateStatus val) {
 	switch (val) {
-		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToAdd: return 0;
-		case LDKInboundHTLCStateDetails_Committed: return 1;
-		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFulfill: return 2;
-		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFail: return 3;
-		default: abort();
-	}
-}
-static inline LDKLSPS1OrderState LDKLSPS1OrderState_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKLSPS1OrderState_Created;
-		case 1: return LDKLSPS1OrderState_Completed;
-		case 2: return LDKLSPS1OrderState_Failed;
-		default: abort();
-	}
-}
-static inline int32_t LDKLSPS1OrderState_to_cs(LDKLSPS1OrderState val) {
-	switch (val) {
-		case LDKLSPS1OrderState_Created: return 0;
-		case LDKLSPS1OrderState_Completed: return 1;
-		case LDKLSPS1OrderState_Failed: return 2;
-		default: abort();
-	}
-}
-static inline LDKLSPS1PaymentState LDKLSPS1PaymentState_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKLSPS1PaymentState_ExpectPayment;
-		case 1: return LDKLSPS1PaymentState_Paid;
-		case 2: return LDKLSPS1PaymentState_Refunded;
-		default: abort();
-	}
-}
-static inline int32_t LDKLSPS1PaymentState_to_cs(LDKLSPS1PaymentState val) {
-	switch (val) {
-		case LDKLSPS1PaymentState_ExpectPayment: return 0;
-		case LDKLSPS1PaymentState_Paid: return 1;
-		case LDKLSPS1PaymentState_Refunded: return 2;
-		default: abort();
-	}
-}
-static inline LDKLevel LDKLevel_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKLevel_Gossip;
-		case 1: return LDKLevel_Trace;
-		case 2: return LDKLevel_Debug;
-		case 3: return LDKLevel_Info;
-		case 4: return LDKLevel_Warn;
-		case 5: return LDKLevel_Error;
-		default: abort();
-	}
-}
-static inline int32_t LDKLevel_to_cs(LDKLevel val) {
-	switch (val) {
-		case LDKLevel_Gossip: return 0;
-		case LDKLevel_Trace: return 1;
-		case LDKLevel_Debug: return 2;
-		case LDKLevel_Info: return 3;
-		case LDKLevel_Warn: return 4;
-		case LDKLevel_Error: return 5;
-		default: abort();
-	}
-}
-static inline LDKNetwork LDKNetwork_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKNetwork_Bitcoin;
-		case 1: return LDKNetwork_Testnet3;
-		case 2: return LDKNetwork_Testnet4;
-		case 3: return LDKNetwork_Regtest;
-		case 4: return LDKNetwork_Signet;
-		default: abort();
-	}
-}
-static inline int32_t LDKNetwork_to_cs(LDKNetwork val) {
-	switch (val) {
-		case LDKNetwork_Bitcoin: return 0;
-		case LDKNetwork_Testnet3: return 1;
-		case LDKNetwork_Testnet4: return 2;
-		case LDKNetwork_Regtest: return 3;
-		case LDKNetwork_Signet: return 4;
-		default: abort();
-	}
-}
-static inline LDKOutboundHTLCStateDetails LDKOutboundHTLCStateDetails_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToAdd;
-		case 1: return LDKOutboundHTLCStateDetails_Committed;
-		case 2: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveSuccess;
-		case 3: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFailure;
-		default: abort();
-	}
-}
-static inline int32_t LDKOutboundHTLCStateDetails_to_cs(LDKOutboundHTLCStateDetails val) {
-	switch (val) {
-		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToAdd: return 0;
-		case LDKOutboundHTLCStateDetails_Committed: return 1;
-		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveSuccess: return 2;
-		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFailure: return 3;
-		default: abort();
-	}
-}
-static inline LDKPaymentFailureReason LDKPaymentFailureReason_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKPaymentFailureReason_RecipientRejected;
-		case 1: return LDKPaymentFailureReason_UserAbandoned;
-		case 2: return LDKPaymentFailureReason_RetriesExhausted;
-		case 3: return LDKPaymentFailureReason_PaymentExpired;
-		case 4: return LDKPaymentFailureReason_RouteNotFound;
-		case 5: return LDKPaymentFailureReason_UnexpectedError;
-		case 6: return LDKPaymentFailureReason_UnknownRequiredFeatures;
-		case 7: return LDKPaymentFailureReason_InvoiceRequestExpired;
-		case 8: return LDKPaymentFailureReason_InvoiceRequestRejected;
-		case 9: return LDKPaymentFailureReason_BlindedPathCreationFailed;
-		default: abort();
-	}
-}
-static inline int32_t LDKPaymentFailureReason_to_cs(LDKPaymentFailureReason val) {
-	switch (val) {
-		case LDKPaymentFailureReason_RecipientRejected: return 0;
-		case LDKPaymentFailureReason_UserAbandoned: return 1;
-		case LDKPaymentFailureReason_RetriesExhausted: return 2;
-		case LDKPaymentFailureReason_PaymentExpired: return 3;
-		case LDKPaymentFailureReason_RouteNotFound: return 4;
-		case LDKPaymentFailureReason_UnexpectedError: return 5;
-		case LDKPaymentFailureReason_UnknownRequiredFeatures: return 6;
-		case LDKPaymentFailureReason_InvoiceRequestExpired: return 7;
-		case LDKPaymentFailureReason_InvoiceRequestRejected: return 8;
-		case LDKPaymentFailureReason_BlindedPathCreationFailed: return 9;
-		default: abort();
-	}
-}
-static inline LDKRecipient LDKRecipient_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKRecipient_Node;
-		case 1: return LDKRecipient_PhantomNode;
-		default: abort();
-	}
-}
-static inline int32_t LDKRecipient_to_cs(LDKRecipient val) {
-	switch (val) {
-		case LDKRecipient_Node: return 0;
-		case LDKRecipient_PhantomNode: return 1;
-		default: abort();
-	}
-}
-static inline LDKRetryableSendFailure LDKRetryableSendFailure_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKRetryableSendFailure_PaymentExpired;
-		case 1: return LDKRetryableSendFailure_RouteNotFound;
-		case 2: return LDKRetryableSendFailure_DuplicatePayment;
-		case 3: return LDKRetryableSendFailure_OnionPacketSizeExceeded;
-		default: abort();
-	}
-}
-static inline int32_t LDKRetryableSendFailure_to_cs(LDKRetryableSendFailure val) {
-	switch (val) {
-		case LDKRetryableSendFailure_PaymentExpired: return 0;
-		case LDKRetryableSendFailure_RouteNotFound: return 1;
-		case LDKRetryableSendFailure_DuplicatePayment: return 2;
-		case LDKRetryableSendFailure_OnionPacketSizeExceeded: return 3;
+		case LDKChannelMonitorUpdateStatus_Completed: return 0;
+		case LDKChannelMonitorUpdateStatus_InProgress: return 1;
+		case LDKChannelMonitorUpdateStatus_UnrecoverableError: return 2;
 		default: abort();
 	}
 }
@@ -904,6 +534,42 @@ static inline int32_t LDKSecp256k1Error_to_cs(LDKSecp256k1Error val) {
 		default: abort();
 	}
 }
+static inline LDKUtxoLookupError LDKUtxoLookupError_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKUtxoLookupError_UnknownChain;
+		case 1: return LDKUtxoLookupError_UnknownTx;
+		default: abort();
+	}
+}
+static inline int32_t LDKUtxoLookupError_to_cs(LDKUtxoLookupError val) {
+	switch (val) {
+		case LDKUtxoLookupError_UnknownChain: return 0;
+		case LDKUtxoLookupError_UnknownTx: return 1;
+		default: abort();
+	}
+}
+static inline LDKLevel LDKLevel_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKLevel_Gossip;
+		case 1: return LDKLevel_Trace;
+		case 2: return LDKLevel_Debug;
+		case 3: return LDKLevel_Info;
+		case 4: return LDKLevel_Warn;
+		case 5: return LDKLevel_Error;
+		default: abort();
+	}
+}
+static inline int32_t LDKLevel_to_cs(LDKLevel val) {
+	switch (val) {
+		case LDKLevel_Gossip: return 0;
+		case LDKLevel_Trace: return 1;
+		case LDKLevel_Debug: return 2;
+		case LDKLevel_Info: return 3;
+		case LDKLevel_Warn: return 4;
+		case LDKLevel_Error: return 5;
+		default: abort();
+	}
+}
 static inline LDKShortChannelIdError LDKShortChannelIdError_from_cs(int32_t ord) {
 	switch (ord) {
 		case 0: return LDKShortChannelIdError_BlockOverflow;
@@ -920,21 +586,129 @@ static inline int32_t LDKShortChannelIdError_to_cs(LDKShortChannelIdError val) {
 		default: abort();
 	}
 }
-static inline LDKSiPrefix LDKSiPrefix_from_cs(int32_t ord) {
+static inline LDKRetryableSendFailure LDKRetryableSendFailure_from_cs(int32_t ord) {
 	switch (ord) {
-		case 0: return LDKSiPrefix_Milli;
-		case 1: return LDKSiPrefix_Micro;
-		case 2: return LDKSiPrefix_Nano;
-		case 3: return LDKSiPrefix_Pico;
+		case 0: return LDKRetryableSendFailure_PaymentExpired;
+		case 1: return LDKRetryableSendFailure_RouteNotFound;
+		case 2: return LDKRetryableSendFailure_DuplicatePayment;
+		case 3: return LDKRetryableSendFailure_OnionPacketSizeExceeded;
 		default: abort();
 	}
 }
-static inline int32_t LDKSiPrefix_to_cs(LDKSiPrefix val) {
+static inline int32_t LDKRetryableSendFailure_to_cs(LDKRetryableSendFailure val) {
 	switch (val) {
-		case LDKSiPrefix_Milli: return 0;
-		case LDKSiPrefix_Micro: return 1;
-		case LDKSiPrefix_Nano: return 2;
-		case LDKSiPrefix_Pico: return 3;
+		case LDKRetryableSendFailure_PaymentExpired: return 0;
+		case LDKRetryableSendFailure_RouteNotFound: return 1;
+		case LDKRetryableSendFailure_DuplicatePayment: return 2;
+		case LDKRetryableSendFailure_OnionPacketSizeExceeded: return 3;
+		default: abort();
+	}
+}
+static inline LDKCreationError LDKCreationError_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKCreationError_DescriptionTooLong;
+		case 1: return LDKCreationError_RouteTooLong;
+		case 2: return LDKCreationError_TimestampOutOfBounds;
+		case 3: return LDKCreationError_InvalidAmount;
+		case 4: return LDKCreationError_MissingRouteHints;
+		case 5: return LDKCreationError_MinFinalCltvExpiryDeltaTooShort;
+		default: abort();
+	}
+}
+static inline int32_t LDKCreationError_to_cs(LDKCreationError val) {
+	switch (val) {
+		case LDKCreationError_DescriptionTooLong: return 0;
+		case LDKCreationError_RouteTooLong: return 1;
+		case LDKCreationError_TimestampOutOfBounds: return 2;
+		case LDKCreationError_InvalidAmount: return 3;
+		case LDKCreationError_MissingRouteHints: return 4;
+		case LDKCreationError_MinFinalCltvExpiryDeltaTooShort: return 5;
+		default: abort();
+	}
+}
+static inline LDKBlindedFailure LDKBlindedFailure_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKBlindedFailure_FromIntroductionNode;
+		case 1: return LDKBlindedFailure_FromBlindedNode;
+		default: abort();
+	}
+}
+static inline int32_t LDKBlindedFailure_to_cs(LDKBlindedFailure val) {
+	switch (val) {
+		case LDKBlindedFailure_FromIntroductionNode: return 0;
+		case LDKBlindedFailure_FromBlindedNode: return 1;
+		default: abort();
+	}
+}
+static inline LDKRecipient LDKRecipient_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKRecipient_Node;
+		case 1: return LDKRecipient_PhantomNode;
+		default: abort();
+	}
+}
+static inline int32_t LDKRecipient_to_cs(LDKRecipient val) {
+	switch (val) {
+		case LDKRecipient_Node: return 0;
+		case LDKRecipient_PhantomNode: return 1;
+		default: abort();
+	}
+}
+static inline LDKConfirmationTarget LDKConfirmationTarget_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKConfirmationTarget_MaximumFeeEstimate;
+		case 1: return LDKConfirmationTarget_UrgentOnChainSweep;
+		case 2: return LDKConfirmationTarget_MinAllowedAnchorChannelRemoteFee;
+		case 3: return LDKConfirmationTarget_MinAllowedNonAnchorChannelRemoteFee;
+		case 4: return LDKConfirmationTarget_AnchorChannelFee;
+		case 5: return LDKConfirmationTarget_NonAnchorChannelFee;
+		case 6: return LDKConfirmationTarget_ChannelCloseMinimum;
+		case 7: return LDKConfirmationTarget_OutputSpendingFee;
+		default: abort();
+	}
+}
+static inline int32_t LDKConfirmationTarget_to_cs(LDKConfirmationTarget val) {
+	switch (val) {
+		case LDKConfirmationTarget_MaximumFeeEstimate: return 0;
+		case LDKConfirmationTarget_UrgentOnChainSweep: return 1;
+		case LDKConfirmationTarget_MinAllowedAnchorChannelRemoteFee: return 2;
+		case LDKConfirmationTarget_MinAllowedNonAnchorChannelRemoteFee: return 3;
+		case LDKConfirmationTarget_AnchorChannelFee: return 4;
+		case LDKConfirmationTarget_NonAnchorChannelFee: return 5;
+		case LDKConfirmationTarget_ChannelCloseMinimum: return 6;
+		case LDKConfirmationTarget_OutputSpendingFee: return 7;
+		default: abort();
+	}
+}
+static inline LDKBalanceSource LDKBalanceSource_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKBalanceSource_HolderForceClosed;
+		case 1: return LDKBalanceSource_CounterpartyForceClosed;
+		case 2: return LDKBalanceSource_CoopClose;
+		case 3: return LDKBalanceSource_Htlc;
+		default: abort();
+	}
+}
+static inline int32_t LDKBalanceSource_to_cs(LDKBalanceSource val) {
+	switch (val) {
+		case LDKBalanceSource_HolderForceClosed: return 0;
+		case LDKBalanceSource_CounterpartyForceClosed: return 1;
+		case LDKBalanceSource_CoopClose: return 2;
+		case LDKBalanceSource_Htlc: return 3;
+		default: abort();
+	}
+}
+static inline LDKCOption_NoneZ LDKCOption_NoneZ_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKCOption_NoneZ_Some;
+		case 1: return LDKCOption_NoneZ_None;
+		default: abort();
+	}
+}
+static inline int32_t LDKCOption_NoneZ_to_cs(LDKCOption_NoneZ val) {
+	switch (val) {
+		case LDKCOption_NoneZ_Some: return 0;
+		case LDKCOption_NoneZ_None: return 1;
 		default: abort();
 	}
 }
@@ -956,17 +730,243 @@ static inline int32_t LDKSocketAddressParseError_to_cs(LDKSocketAddressParseErro
 		default: abort();
 	}
 }
-static inline LDKUtxoLookupError LDKUtxoLookupError_from_cs(int32_t ord) {
+static inline LDKInboundHTLCStateDetails LDKInboundHTLCStateDetails_from_cs(int32_t ord) {
 	switch (ord) {
-		case 0: return LDKUtxoLookupError_UnknownChain;
-		case 1: return LDKUtxoLookupError_UnknownTx;
+		case 0: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToAdd;
+		case 1: return LDKInboundHTLCStateDetails_Committed;
+		case 2: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFulfill;
+		case 3: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFail;
 		default: abort();
 	}
 }
-static inline int32_t LDKUtxoLookupError_to_cs(LDKUtxoLookupError val) {
+static inline int32_t LDKInboundHTLCStateDetails_to_cs(LDKInboundHTLCStateDetails val) {
 	switch (val) {
-		case LDKUtxoLookupError_UnknownChain: return 0;
-		case LDKUtxoLookupError_UnknownTx: return 1;
+		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToAdd: return 0;
+		case LDKInboundHTLCStateDetails_Committed: return 1;
+		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFulfill: return 2;
+		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFail: return 3;
+		default: abort();
+	}
+}
+static inline LDKOutboundHTLCStateDetails LDKOutboundHTLCStateDetails_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToAdd;
+		case 1: return LDKOutboundHTLCStateDetails_Committed;
+		case 2: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveSuccess;
+		case 3: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFailure;
+		default: abort();
+	}
+}
+static inline int32_t LDKOutboundHTLCStateDetails_to_cs(LDKOutboundHTLCStateDetails val) {
+	switch (val) {
+		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToAdd: return 0;
+		case LDKOutboundHTLCStateDetails_Committed: return 1;
+		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveSuccess: return 2;
+		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFailure: return 3;
+		default: abort();
+	}
+}
+static inline LDKChannelShutdownState LDKChannelShutdownState_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKChannelShutdownState_NotShuttingDown;
+		case 1: return LDKChannelShutdownState_ShutdownInitiated;
+		case 2: return LDKChannelShutdownState_ResolvingHTLCs;
+		case 3: return LDKChannelShutdownState_NegotiatingClosingFee;
+		case 4: return LDKChannelShutdownState_ShutdownComplete;
+		default: abort();
+	}
+}
+static inline int32_t LDKChannelShutdownState_to_cs(LDKChannelShutdownState val) {
+	switch (val) {
+		case LDKChannelShutdownState_NotShuttingDown: return 0;
+		case LDKChannelShutdownState_ShutdownInitiated: return 1;
+		case LDKChannelShutdownState_ResolvingHTLCs: return 2;
+		case LDKChannelShutdownState_NegotiatingClosingFee: return 3;
+		case LDKChannelShutdownState_ShutdownComplete: return 4;
+		default: abort();
+	}
+}
+static inline LDKHTLCClaim LDKHTLCClaim_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKHTLCClaim_OfferedTimeout;
+		case 1: return LDKHTLCClaim_OfferedPreimage;
+		case 2: return LDKHTLCClaim_AcceptedTimeout;
+		case 3: return LDKHTLCClaim_AcceptedPreimage;
+		case 4: return LDKHTLCClaim_Revocation;
+		default: abort();
+	}
+}
+static inline int32_t LDKHTLCClaim_to_cs(LDKHTLCClaim val) {
+	switch (val) {
+		case LDKHTLCClaim_OfferedTimeout: return 0;
+		case LDKHTLCClaim_OfferedPreimage: return 1;
+		case LDKHTLCClaim_AcceptedTimeout: return 2;
+		case LDKHTLCClaim_AcceptedPreimage: return 3;
+		case LDKHTLCClaim_Revocation: return 4;
+		default: abort();
+	}
+}
+static inline LDKPaymentFailureReason LDKPaymentFailureReason_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKPaymentFailureReason_RecipientRejected;
+		case 1: return LDKPaymentFailureReason_UserAbandoned;
+		case 2: return LDKPaymentFailureReason_RetriesExhausted;
+		case 3: return LDKPaymentFailureReason_PaymentExpired;
+		case 4: return LDKPaymentFailureReason_RouteNotFound;
+		case 5: return LDKPaymentFailureReason_UnexpectedError;
+		case 6: return LDKPaymentFailureReason_UnknownRequiredFeatures;
+		case 7: return LDKPaymentFailureReason_InvoiceRequestExpired;
+		case 8: return LDKPaymentFailureReason_InvoiceRequestRejected;
+		case 9: return LDKPaymentFailureReason_BlindedPathCreationFailed;
+		default: abort();
+	}
+}
+static inline int32_t LDKPaymentFailureReason_to_cs(LDKPaymentFailureReason val) {
+	switch (val) {
+		case LDKPaymentFailureReason_RecipientRejected: return 0;
+		case LDKPaymentFailureReason_UserAbandoned: return 1;
+		case LDKPaymentFailureReason_RetriesExhausted: return 2;
+		case LDKPaymentFailureReason_PaymentExpired: return 3;
+		case LDKPaymentFailureReason_RouteNotFound: return 4;
+		case LDKPaymentFailureReason_UnexpectedError: return 5;
+		case LDKPaymentFailureReason_UnknownRequiredFeatures: return 6;
+		case LDKPaymentFailureReason_InvoiceRequestExpired: return 7;
+		case LDKPaymentFailureReason_InvoiceRequestRejected: return 8;
+		case LDKPaymentFailureReason_BlindedPathCreationFailed: return 9;
+		default: abort();
+	}
+}
+static inline LDKSiPrefix LDKSiPrefix_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKSiPrefix_Milli;
+		case 1: return LDKSiPrefix_Micro;
+		case 2: return LDKSiPrefix_Nano;
+		case 3: return LDKSiPrefix_Pico;
+		default: abort();
+	}
+}
+static inline int32_t LDKSiPrefix_to_cs(LDKSiPrefix val) {
+	switch (val) {
+		case LDKSiPrefix_Milli: return 0;
+		case LDKSiPrefix_Micro: return 1;
+		case LDKSiPrefix_Nano: return 2;
+		case LDKSiPrefix_Pico: return 3;
+		default: abort();
+	}
+}
+static inline LDKBolt11SemanticError LDKBolt11SemanticError_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKBolt11SemanticError_NoPaymentHash;
+		case 1: return LDKBolt11SemanticError_MultiplePaymentHashes;
+		case 2: return LDKBolt11SemanticError_NoDescription;
+		case 3: return LDKBolt11SemanticError_MultipleDescriptions;
+		case 4: return LDKBolt11SemanticError_NoPaymentSecret;
+		case 5: return LDKBolt11SemanticError_MultiplePaymentSecrets;
+		case 6: return LDKBolt11SemanticError_InvalidFeatures;
+		case 7: return LDKBolt11SemanticError_InvalidRecoveryId;
+		case 8: return LDKBolt11SemanticError_InvalidSignature;
+		case 9: return LDKBolt11SemanticError_ImpreciseAmount;
+		default: abort();
+	}
+}
+static inline int32_t LDKBolt11SemanticError_to_cs(LDKBolt11SemanticError val) {
+	switch (val) {
+		case LDKBolt11SemanticError_NoPaymentHash: return 0;
+		case LDKBolt11SemanticError_MultiplePaymentHashes: return 1;
+		case LDKBolt11SemanticError_NoDescription: return 2;
+		case LDKBolt11SemanticError_MultipleDescriptions: return 3;
+		case LDKBolt11SemanticError_NoPaymentSecret: return 4;
+		case LDKBolt11SemanticError_MultiplePaymentSecrets: return 5;
+		case LDKBolt11SemanticError_InvalidFeatures: return 6;
+		case LDKBolt11SemanticError_InvalidRecoveryId: return 7;
+		case LDKBolt11SemanticError_InvalidSignature: return 8;
+		case LDKBolt11SemanticError_ImpreciseAmount: return 9;
+		default: abort();
+	}
+}
+static inline LDKNetwork LDKNetwork_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKNetwork_Bitcoin;
+		case 1: return LDKNetwork_Testnet3;
+		case 2: return LDKNetwork_Testnet4;
+		case 3: return LDKNetwork_Regtest;
+		case 4: return LDKNetwork_Signet;
+		default: abort();
+	}
+}
+static inline int32_t LDKNetwork_to_cs(LDKNetwork val) {
+	switch (val) {
+		case LDKNetwork_Bitcoin: return 0;
+		case LDKNetwork_Testnet3: return 1;
+		case LDKNetwork_Testnet4: return 2;
+		case LDKNetwork_Regtest: return 3;
+		case LDKNetwork_Signet: return 4;
+		default: abort();
+	}
+}
+static inline LDKCurrency LDKCurrency_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKCurrency_Bitcoin;
+		case 1: return LDKCurrency_BitcoinTestnet;
+		case 2: return LDKCurrency_Regtest;
+		case 3: return LDKCurrency_Simnet;
+		case 4: return LDKCurrency_Signet;
+		default: abort();
+	}
+}
+static inline int32_t LDKCurrency_to_cs(LDKCurrency val) {
+	switch (val) {
+		case LDKCurrency_Bitcoin: return 0;
+		case LDKCurrency_BitcoinTestnet: return 1;
+		case LDKCurrency_Regtest: return 2;
+		case LDKCurrency_Simnet: return 3;
+		case LDKCurrency_Signet: return 4;
+		default: abort();
+	}
+}
+static inline LDKDirection LDKDirection_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKDirection_NodeOne;
+		case 1: return LDKDirection_NodeTwo;
+		default: abort();
+	}
+}
+static inline int32_t LDKDirection_to_cs(LDKDirection val) {
+	switch (val) {
+		case LDKDirection_NodeOne: return 0;
+		case LDKDirection_NodeTwo: return 1;
+		default: abort();
+	}
+}
+static inline LDKLSPS1OrderState LDKLSPS1OrderState_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKLSPS1OrderState_Created;
+		case 1: return LDKLSPS1OrderState_Completed;
+		case 2: return LDKLSPS1OrderState_Failed;
+		default: abort();
+	}
+}
+static inline int32_t LDKLSPS1OrderState_to_cs(LDKLSPS1OrderState val) {
+	switch (val) {
+		case LDKLSPS1OrderState_Created: return 0;
+		case LDKLSPS1OrderState_Completed: return 1;
+		case LDKLSPS1OrderState_Failed: return 2;
+		default: abort();
+	}
+}
+static inline LDKLSPS1PaymentState LDKLSPS1PaymentState_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKLSPS1PaymentState_ExpectPayment;
+		case 1: return LDKLSPS1PaymentState_Paid;
+		case 2: return LDKLSPS1PaymentState_Refunded;
+		default: abort();
+	}
+}
+static inline int32_t LDKLSPS1PaymentState_to_cs(LDKLSPS1PaymentState val) {
+	switch (val) {
+		case LDKLSPS1PaymentState_ExpectPayment: return 0;
+		case LDKLSPS1PaymentState_Paid: return 1;
+		case LDKLSPS1PaymentState_Refunded: return 2;
 		default: abort();
 	}
 }

--- a/c_sharp/bindings.c.body
+++ b/c_sharp/bindings.c.body
@@ -362,68 +362,6 @@ static inline uint64_t tag_ptr(const void* ptr, bool is_owned) {
 	}
 }
 
-static inline LDKBalanceSource LDKBalanceSource_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKBalanceSource_HolderForceClosed;
-		case 1: return LDKBalanceSource_CounterpartyForceClosed;
-		case 2: return LDKBalanceSource_CoopClose;
-		case 3: return LDKBalanceSource_Htlc;
-		default: abort();
-	}
-}
-static inline int32_t LDKBalanceSource_to_cs(LDKBalanceSource val) {
-	switch (val) {
-		case LDKBalanceSource_HolderForceClosed: return 0;
-		case LDKBalanceSource_CounterpartyForceClosed: return 1;
-		case LDKBalanceSource_CoopClose: return 2;
-		case LDKBalanceSource_Htlc: return 3;
-		default: abort();
-	}
-}
-static inline LDKBlindedFailure LDKBlindedFailure_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKBlindedFailure_FromIntroductionNode;
-		case 1: return LDKBlindedFailure_FromBlindedNode;
-		default: abort();
-	}
-}
-static inline int32_t LDKBlindedFailure_to_cs(LDKBlindedFailure val) {
-	switch (val) {
-		case LDKBlindedFailure_FromIntroductionNode: return 0;
-		case LDKBlindedFailure_FromBlindedNode: return 1;
-		default: abort();
-	}
-}
-static inline LDKBolt11SemanticError LDKBolt11SemanticError_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKBolt11SemanticError_NoPaymentHash;
-		case 1: return LDKBolt11SemanticError_MultiplePaymentHashes;
-		case 2: return LDKBolt11SemanticError_NoDescription;
-		case 3: return LDKBolt11SemanticError_MultipleDescriptions;
-		case 4: return LDKBolt11SemanticError_NoPaymentSecret;
-		case 5: return LDKBolt11SemanticError_MultiplePaymentSecrets;
-		case 6: return LDKBolt11SemanticError_InvalidFeatures;
-		case 7: return LDKBolt11SemanticError_InvalidRecoveryId;
-		case 8: return LDKBolt11SemanticError_InvalidSignature;
-		case 9: return LDKBolt11SemanticError_ImpreciseAmount;
-		default: abort();
-	}
-}
-static inline int32_t LDKBolt11SemanticError_to_cs(LDKBolt11SemanticError val) {
-	switch (val) {
-		case LDKBolt11SemanticError_NoPaymentHash: return 0;
-		case LDKBolt11SemanticError_MultiplePaymentHashes: return 1;
-		case LDKBolt11SemanticError_NoDescription: return 2;
-		case LDKBolt11SemanticError_MultipleDescriptions: return 3;
-		case LDKBolt11SemanticError_NoPaymentSecret: return 4;
-		case LDKBolt11SemanticError_MultiplePaymentSecrets: return 5;
-		case LDKBolt11SemanticError_InvalidFeatures: return 6;
-		case LDKBolt11SemanticError_InvalidRecoveryId: return 7;
-		case LDKBolt11SemanticError_InvalidSignature: return 8;
-		case LDKBolt11SemanticError_ImpreciseAmount: return 9;
-		default: abort();
-	}
-}
 static inline LDKBolt12SemanticError LDKBolt12SemanticError_from_cs(int32_t ord) {
 	switch (ord) {
 		case 0: return LDKBolt12SemanticError_AlreadyExpired;
@@ -496,158 +434,6 @@ static inline int32_t LDKBolt12SemanticError_to_cs(LDKBolt12SemanticError val) {
 		default: abort();
 	}
 }
-static inline LDKCOption_NoneZ LDKCOption_NoneZ_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKCOption_NoneZ_Some;
-		case 1: return LDKCOption_NoneZ_None;
-		default: abort();
-	}
-}
-static inline int32_t LDKCOption_NoneZ_to_cs(LDKCOption_NoneZ val) {
-	switch (val) {
-		case LDKCOption_NoneZ_Some: return 0;
-		case LDKCOption_NoneZ_None: return 1;
-		default: abort();
-	}
-}
-static inline LDKChannelMonitorUpdateStatus LDKChannelMonitorUpdateStatus_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKChannelMonitorUpdateStatus_Completed;
-		case 1: return LDKChannelMonitorUpdateStatus_InProgress;
-		case 2: return LDKChannelMonitorUpdateStatus_UnrecoverableError;
-		default: abort();
-	}
-}
-static inline int32_t LDKChannelMonitorUpdateStatus_to_cs(LDKChannelMonitorUpdateStatus val) {
-	switch (val) {
-		case LDKChannelMonitorUpdateStatus_Completed: return 0;
-		case LDKChannelMonitorUpdateStatus_InProgress: return 1;
-		case LDKChannelMonitorUpdateStatus_UnrecoverableError: return 2;
-		default: abort();
-	}
-}
-static inline LDKChannelShutdownState LDKChannelShutdownState_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKChannelShutdownState_NotShuttingDown;
-		case 1: return LDKChannelShutdownState_ShutdownInitiated;
-		case 2: return LDKChannelShutdownState_ResolvingHTLCs;
-		case 3: return LDKChannelShutdownState_NegotiatingClosingFee;
-		case 4: return LDKChannelShutdownState_ShutdownComplete;
-		default: abort();
-	}
-}
-static inline int32_t LDKChannelShutdownState_to_cs(LDKChannelShutdownState val) {
-	switch (val) {
-		case LDKChannelShutdownState_NotShuttingDown: return 0;
-		case LDKChannelShutdownState_ShutdownInitiated: return 1;
-		case LDKChannelShutdownState_ResolvingHTLCs: return 2;
-		case LDKChannelShutdownState_NegotiatingClosingFee: return 3;
-		case LDKChannelShutdownState_ShutdownComplete: return 4;
-		default: abort();
-	}
-}
-static inline LDKConfirmationTarget LDKConfirmationTarget_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKConfirmationTarget_MaximumFeeEstimate;
-		case 1: return LDKConfirmationTarget_UrgentOnChainSweep;
-		case 2: return LDKConfirmationTarget_MinAllowedAnchorChannelRemoteFee;
-		case 3: return LDKConfirmationTarget_MinAllowedNonAnchorChannelRemoteFee;
-		case 4: return LDKConfirmationTarget_AnchorChannelFee;
-		case 5: return LDKConfirmationTarget_NonAnchorChannelFee;
-		case 6: return LDKConfirmationTarget_ChannelCloseMinimum;
-		case 7: return LDKConfirmationTarget_OutputSpendingFee;
-		default: abort();
-	}
-}
-static inline int32_t LDKConfirmationTarget_to_cs(LDKConfirmationTarget val) {
-	switch (val) {
-		case LDKConfirmationTarget_MaximumFeeEstimate: return 0;
-		case LDKConfirmationTarget_UrgentOnChainSweep: return 1;
-		case LDKConfirmationTarget_MinAllowedAnchorChannelRemoteFee: return 2;
-		case LDKConfirmationTarget_MinAllowedNonAnchorChannelRemoteFee: return 3;
-		case LDKConfirmationTarget_AnchorChannelFee: return 4;
-		case LDKConfirmationTarget_NonAnchorChannelFee: return 5;
-		case LDKConfirmationTarget_ChannelCloseMinimum: return 6;
-		case LDKConfirmationTarget_OutputSpendingFee: return 7;
-		default: abort();
-	}
-}
-static inline LDKCreationError LDKCreationError_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKCreationError_DescriptionTooLong;
-		case 1: return LDKCreationError_RouteTooLong;
-		case 2: return LDKCreationError_TimestampOutOfBounds;
-		case 3: return LDKCreationError_InvalidAmount;
-		case 4: return LDKCreationError_MissingRouteHints;
-		case 5: return LDKCreationError_MinFinalCltvExpiryDeltaTooShort;
-		default: abort();
-	}
-}
-static inline int32_t LDKCreationError_to_cs(LDKCreationError val) {
-	switch (val) {
-		case LDKCreationError_DescriptionTooLong: return 0;
-		case LDKCreationError_RouteTooLong: return 1;
-		case LDKCreationError_TimestampOutOfBounds: return 2;
-		case LDKCreationError_InvalidAmount: return 3;
-		case LDKCreationError_MissingRouteHints: return 4;
-		case LDKCreationError_MinFinalCltvExpiryDeltaTooShort: return 5;
-		default: abort();
-	}
-}
-static inline LDKCurrency LDKCurrency_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKCurrency_Bitcoin;
-		case 1: return LDKCurrency_BitcoinTestnet;
-		case 2: return LDKCurrency_Regtest;
-		case 3: return LDKCurrency_Simnet;
-		case 4: return LDKCurrency_Signet;
-		default: abort();
-	}
-}
-static inline int32_t LDKCurrency_to_cs(LDKCurrency val) {
-	switch (val) {
-		case LDKCurrency_Bitcoin: return 0;
-		case LDKCurrency_BitcoinTestnet: return 1;
-		case LDKCurrency_Regtest: return 2;
-		case LDKCurrency_Simnet: return 3;
-		case LDKCurrency_Signet: return 4;
-		default: abort();
-	}
-}
-static inline LDKDirection LDKDirection_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKDirection_NodeOne;
-		case 1: return LDKDirection_NodeTwo;
-		default: abort();
-	}
-}
-static inline int32_t LDKDirection_to_cs(LDKDirection val) {
-	switch (val) {
-		case LDKDirection_NodeOne: return 0;
-		case LDKDirection_NodeTwo: return 1;
-		default: abort();
-	}
-}
-static inline LDKHTLCClaim LDKHTLCClaim_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKHTLCClaim_OfferedTimeout;
-		case 1: return LDKHTLCClaim_OfferedPreimage;
-		case 2: return LDKHTLCClaim_AcceptedTimeout;
-		case 3: return LDKHTLCClaim_AcceptedPreimage;
-		case 4: return LDKHTLCClaim_Revocation;
-		default: abort();
-	}
-}
-static inline int32_t LDKHTLCClaim_to_cs(LDKHTLCClaim val) {
-	switch (val) {
-		case LDKHTLCClaim_OfferedTimeout: return 0;
-		case LDKHTLCClaim_OfferedPreimage: return 1;
-		case LDKHTLCClaim_AcceptedTimeout: return 2;
-		case LDKHTLCClaim_AcceptedPreimage: return 3;
-		case LDKHTLCClaim_Revocation: return 4;
-		default: abort();
-	}
-}
 static inline LDKIOError LDKIOError_from_cs(int32_t ord) {
 	switch (ord) {
 		case 0: return LDKIOError_NotFound;
@@ -694,175 +480,19 @@ static inline int32_t LDKIOError_to_cs(LDKIOError val) {
 		default: abort();
 	}
 }
-static inline LDKInboundHTLCStateDetails LDKInboundHTLCStateDetails_from_cs(int32_t ord) {
+static inline LDKChannelMonitorUpdateStatus LDKChannelMonitorUpdateStatus_from_cs(int32_t ord) {
 	switch (ord) {
-		case 0: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToAdd;
-		case 1: return LDKInboundHTLCStateDetails_Committed;
-		case 2: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFulfill;
-		case 3: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFail;
+		case 0: return LDKChannelMonitorUpdateStatus_Completed;
+		case 1: return LDKChannelMonitorUpdateStatus_InProgress;
+		case 2: return LDKChannelMonitorUpdateStatus_UnrecoverableError;
 		default: abort();
 	}
 }
-static inline int32_t LDKInboundHTLCStateDetails_to_cs(LDKInboundHTLCStateDetails val) {
+static inline int32_t LDKChannelMonitorUpdateStatus_to_cs(LDKChannelMonitorUpdateStatus val) {
 	switch (val) {
-		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToAdd: return 0;
-		case LDKInboundHTLCStateDetails_Committed: return 1;
-		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFulfill: return 2;
-		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFail: return 3;
-		default: abort();
-	}
-}
-static inline LDKLSPS1OrderState LDKLSPS1OrderState_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKLSPS1OrderState_Created;
-		case 1: return LDKLSPS1OrderState_Completed;
-		case 2: return LDKLSPS1OrderState_Failed;
-		default: abort();
-	}
-}
-static inline int32_t LDKLSPS1OrderState_to_cs(LDKLSPS1OrderState val) {
-	switch (val) {
-		case LDKLSPS1OrderState_Created: return 0;
-		case LDKLSPS1OrderState_Completed: return 1;
-		case LDKLSPS1OrderState_Failed: return 2;
-		default: abort();
-	}
-}
-static inline LDKLSPS1PaymentState LDKLSPS1PaymentState_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKLSPS1PaymentState_ExpectPayment;
-		case 1: return LDKLSPS1PaymentState_Paid;
-		case 2: return LDKLSPS1PaymentState_Refunded;
-		default: abort();
-	}
-}
-static inline int32_t LDKLSPS1PaymentState_to_cs(LDKLSPS1PaymentState val) {
-	switch (val) {
-		case LDKLSPS1PaymentState_ExpectPayment: return 0;
-		case LDKLSPS1PaymentState_Paid: return 1;
-		case LDKLSPS1PaymentState_Refunded: return 2;
-		default: abort();
-	}
-}
-static inline LDKLevel LDKLevel_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKLevel_Gossip;
-		case 1: return LDKLevel_Trace;
-		case 2: return LDKLevel_Debug;
-		case 3: return LDKLevel_Info;
-		case 4: return LDKLevel_Warn;
-		case 5: return LDKLevel_Error;
-		default: abort();
-	}
-}
-static inline int32_t LDKLevel_to_cs(LDKLevel val) {
-	switch (val) {
-		case LDKLevel_Gossip: return 0;
-		case LDKLevel_Trace: return 1;
-		case LDKLevel_Debug: return 2;
-		case LDKLevel_Info: return 3;
-		case LDKLevel_Warn: return 4;
-		case LDKLevel_Error: return 5;
-		default: abort();
-	}
-}
-static inline LDKNetwork LDKNetwork_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKNetwork_Bitcoin;
-		case 1: return LDKNetwork_Testnet3;
-		case 2: return LDKNetwork_Testnet4;
-		case 3: return LDKNetwork_Regtest;
-		case 4: return LDKNetwork_Signet;
-		default: abort();
-	}
-}
-static inline int32_t LDKNetwork_to_cs(LDKNetwork val) {
-	switch (val) {
-		case LDKNetwork_Bitcoin: return 0;
-		case LDKNetwork_Testnet3: return 1;
-		case LDKNetwork_Testnet4: return 2;
-		case LDKNetwork_Regtest: return 3;
-		case LDKNetwork_Signet: return 4;
-		default: abort();
-	}
-}
-static inline LDKOutboundHTLCStateDetails LDKOutboundHTLCStateDetails_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToAdd;
-		case 1: return LDKOutboundHTLCStateDetails_Committed;
-		case 2: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveSuccess;
-		case 3: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFailure;
-		default: abort();
-	}
-}
-static inline int32_t LDKOutboundHTLCStateDetails_to_cs(LDKOutboundHTLCStateDetails val) {
-	switch (val) {
-		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToAdd: return 0;
-		case LDKOutboundHTLCStateDetails_Committed: return 1;
-		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveSuccess: return 2;
-		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFailure: return 3;
-		default: abort();
-	}
-}
-static inline LDKPaymentFailureReason LDKPaymentFailureReason_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKPaymentFailureReason_RecipientRejected;
-		case 1: return LDKPaymentFailureReason_UserAbandoned;
-		case 2: return LDKPaymentFailureReason_RetriesExhausted;
-		case 3: return LDKPaymentFailureReason_PaymentExpired;
-		case 4: return LDKPaymentFailureReason_RouteNotFound;
-		case 5: return LDKPaymentFailureReason_UnexpectedError;
-		case 6: return LDKPaymentFailureReason_UnknownRequiredFeatures;
-		case 7: return LDKPaymentFailureReason_InvoiceRequestExpired;
-		case 8: return LDKPaymentFailureReason_InvoiceRequestRejected;
-		case 9: return LDKPaymentFailureReason_BlindedPathCreationFailed;
-		default: abort();
-	}
-}
-static inline int32_t LDKPaymentFailureReason_to_cs(LDKPaymentFailureReason val) {
-	switch (val) {
-		case LDKPaymentFailureReason_RecipientRejected: return 0;
-		case LDKPaymentFailureReason_UserAbandoned: return 1;
-		case LDKPaymentFailureReason_RetriesExhausted: return 2;
-		case LDKPaymentFailureReason_PaymentExpired: return 3;
-		case LDKPaymentFailureReason_RouteNotFound: return 4;
-		case LDKPaymentFailureReason_UnexpectedError: return 5;
-		case LDKPaymentFailureReason_UnknownRequiredFeatures: return 6;
-		case LDKPaymentFailureReason_InvoiceRequestExpired: return 7;
-		case LDKPaymentFailureReason_InvoiceRequestRejected: return 8;
-		case LDKPaymentFailureReason_BlindedPathCreationFailed: return 9;
-		default: abort();
-	}
-}
-static inline LDKRecipient LDKRecipient_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKRecipient_Node;
-		case 1: return LDKRecipient_PhantomNode;
-		default: abort();
-	}
-}
-static inline int32_t LDKRecipient_to_cs(LDKRecipient val) {
-	switch (val) {
-		case LDKRecipient_Node: return 0;
-		case LDKRecipient_PhantomNode: return 1;
-		default: abort();
-	}
-}
-static inline LDKRetryableSendFailure LDKRetryableSendFailure_from_cs(int32_t ord) {
-	switch (ord) {
-		case 0: return LDKRetryableSendFailure_PaymentExpired;
-		case 1: return LDKRetryableSendFailure_RouteNotFound;
-		case 2: return LDKRetryableSendFailure_DuplicatePayment;
-		case 3: return LDKRetryableSendFailure_OnionPacketSizeExceeded;
-		default: abort();
-	}
-}
-static inline int32_t LDKRetryableSendFailure_to_cs(LDKRetryableSendFailure val) {
-	switch (val) {
-		case LDKRetryableSendFailure_PaymentExpired: return 0;
-		case LDKRetryableSendFailure_RouteNotFound: return 1;
-		case LDKRetryableSendFailure_DuplicatePayment: return 2;
-		case LDKRetryableSendFailure_OnionPacketSizeExceeded: return 3;
+		case LDKChannelMonitorUpdateStatus_Completed: return 0;
+		case LDKChannelMonitorUpdateStatus_InProgress: return 1;
+		case LDKChannelMonitorUpdateStatus_UnrecoverableError: return 2;
 		default: abort();
 	}
 }
@@ -900,6 +530,42 @@ static inline int32_t LDKSecp256k1Error_to_cs(LDKSecp256k1Error val) {
 		default: abort();
 	}
 }
+static inline LDKUtxoLookupError LDKUtxoLookupError_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKUtxoLookupError_UnknownChain;
+		case 1: return LDKUtxoLookupError_UnknownTx;
+		default: abort();
+	}
+}
+static inline int32_t LDKUtxoLookupError_to_cs(LDKUtxoLookupError val) {
+	switch (val) {
+		case LDKUtxoLookupError_UnknownChain: return 0;
+		case LDKUtxoLookupError_UnknownTx: return 1;
+		default: abort();
+	}
+}
+static inline LDKLevel LDKLevel_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKLevel_Gossip;
+		case 1: return LDKLevel_Trace;
+		case 2: return LDKLevel_Debug;
+		case 3: return LDKLevel_Info;
+		case 4: return LDKLevel_Warn;
+		case 5: return LDKLevel_Error;
+		default: abort();
+	}
+}
+static inline int32_t LDKLevel_to_cs(LDKLevel val) {
+	switch (val) {
+		case LDKLevel_Gossip: return 0;
+		case LDKLevel_Trace: return 1;
+		case LDKLevel_Debug: return 2;
+		case LDKLevel_Info: return 3;
+		case LDKLevel_Warn: return 4;
+		case LDKLevel_Error: return 5;
+		default: abort();
+	}
+}
 static inline LDKShortChannelIdError LDKShortChannelIdError_from_cs(int32_t ord) {
 	switch (ord) {
 		case 0: return LDKShortChannelIdError_BlockOverflow;
@@ -916,21 +582,129 @@ static inline int32_t LDKShortChannelIdError_to_cs(LDKShortChannelIdError val) {
 		default: abort();
 	}
 }
-static inline LDKSiPrefix LDKSiPrefix_from_cs(int32_t ord) {
+static inline LDKRetryableSendFailure LDKRetryableSendFailure_from_cs(int32_t ord) {
 	switch (ord) {
-		case 0: return LDKSiPrefix_Milli;
-		case 1: return LDKSiPrefix_Micro;
-		case 2: return LDKSiPrefix_Nano;
-		case 3: return LDKSiPrefix_Pico;
+		case 0: return LDKRetryableSendFailure_PaymentExpired;
+		case 1: return LDKRetryableSendFailure_RouteNotFound;
+		case 2: return LDKRetryableSendFailure_DuplicatePayment;
+		case 3: return LDKRetryableSendFailure_OnionPacketSizeExceeded;
 		default: abort();
 	}
 }
-static inline int32_t LDKSiPrefix_to_cs(LDKSiPrefix val) {
+static inline int32_t LDKRetryableSendFailure_to_cs(LDKRetryableSendFailure val) {
 	switch (val) {
-		case LDKSiPrefix_Milli: return 0;
-		case LDKSiPrefix_Micro: return 1;
-		case LDKSiPrefix_Nano: return 2;
-		case LDKSiPrefix_Pico: return 3;
+		case LDKRetryableSendFailure_PaymentExpired: return 0;
+		case LDKRetryableSendFailure_RouteNotFound: return 1;
+		case LDKRetryableSendFailure_DuplicatePayment: return 2;
+		case LDKRetryableSendFailure_OnionPacketSizeExceeded: return 3;
+		default: abort();
+	}
+}
+static inline LDKCreationError LDKCreationError_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKCreationError_DescriptionTooLong;
+		case 1: return LDKCreationError_RouteTooLong;
+		case 2: return LDKCreationError_TimestampOutOfBounds;
+		case 3: return LDKCreationError_InvalidAmount;
+		case 4: return LDKCreationError_MissingRouteHints;
+		case 5: return LDKCreationError_MinFinalCltvExpiryDeltaTooShort;
+		default: abort();
+	}
+}
+static inline int32_t LDKCreationError_to_cs(LDKCreationError val) {
+	switch (val) {
+		case LDKCreationError_DescriptionTooLong: return 0;
+		case LDKCreationError_RouteTooLong: return 1;
+		case LDKCreationError_TimestampOutOfBounds: return 2;
+		case LDKCreationError_InvalidAmount: return 3;
+		case LDKCreationError_MissingRouteHints: return 4;
+		case LDKCreationError_MinFinalCltvExpiryDeltaTooShort: return 5;
+		default: abort();
+	}
+}
+static inline LDKBlindedFailure LDKBlindedFailure_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKBlindedFailure_FromIntroductionNode;
+		case 1: return LDKBlindedFailure_FromBlindedNode;
+		default: abort();
+	}
+}
+static inline int32_t LDKBlindedFailure_to_cs(LDKBlindedFailure val) {
+	switch (val) {
+		case LDKBlindedFailure_FromIntroductionNode: return 0;
+		case LDKBlindedFailure_FromBlindedNode: return 1;
+		default: abort();
+	}
+}
+static inline LDKRecipient LDKRecipient_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKRecipient_Node;
+		case 1: return LDKRecipient_PhantomNode;
+		default: abort();
+	}
+}
+static inline int32_t LDKRecipient_to_cs(LDKRecipient val) {
+	switch (val) {
+		case LDKRecipient_Node: return 0;
+		case LDKRecipient_PhantomNode: return 1;
+		default: abort();
+	}
+}
+static inline LDKConfirmationTarget LDKConfirmationTarget_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKConfirmationTarget_MaximumFeeEstimate;
+		case 1: return LDKConfirmationTarget_UrgentOnChainSweep;
+		case 2: return LDKConfirmationTarget_MinAllowedAnchorChannelRemoteFee;
+		case 3: return LDKConfirmationTarget_MinAllowedNonAnchorChannelRemoteFee;
+		case 4: return LDKConfirmationTarget_AnchorChannelFee;
+		case 5: return LDKConfirmationTarget_NonAnchorChannelFee;
+		case 6: return LDKConfirmationTarget_ChannelCloseMinimum;
+		case 7: return LDKConfirmationTarget_OutputSpendingFee;
+		default: abort();
+	}
+}
+static inline int32_t LDKConfirmationTarget_to_cs(LDKConfirmationTarget val) {
+	switch (val) {
+		case LDKConfirmationTarget_MaximumFeeEstimate: return 0;
+		case LDKConfirmationTarget_UrgentOnChainSweep: return 1;
+		case LDKConfirmationTarget_MinAllowedAnchorChannelRemoteFee: return 2;
+		case LDKConfirmationTarget_MinAllowedNonAnchorChannelRemoteFee: return 3;
+		case LDKConfirmationTarget_AnchorChannelFee: return 4;
+		case LDKConfirmationTarget_NonAnchorChannelFee: return 5;
+		case LDKConfirmationTarget_ChannelCloseMinimum: return 6;
+		case LDKConfirmationTarget_OutputSpendingFee: return 7;
+		default: abort();
+	}
+}
+static inline LDKBalanceSource LDKBalanceSource_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKBalanceSource_HolderForceClosed;
+		case 1: return LDKBalanceSource_CounterpartyForceClosed;
+		case 2: return LDKBalanceSource_CoopClose;
+		case 3: return LDKBalanceSource_Htlc;
+		default: abort();
+	}
+}
+static inline int32_t LDKBalanceSource_to_cs(LDKBalanceSource val) {
+	switch (val) {
+		case LDKBalanceSource_HolderForceClosed: return 0;
+		case LDKBalanceSource_CounterpartyForceClosed: return 1;
+		case LDKBalanceSource_CoopClose: return 2;
+		case LDKBalanceSource_Htlc: return 3;
+		default: abort();
+	}
+}
+static inline LDKCOption_NoneZ LDKCOption_NoneZ_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKCOption_NoneZ_Some;
+		case 1: return LDKCOption_NoneZ_None;
+		default: abort();
+	}
+}
+static inline int32_t LDKCOption_NoneZ_to_cs(LDKCOption_NoneZ val) {
+	switch (val) {
+		case LDKCOption_NoneZ_Some: return 0;
+		case LDKCOption_NoneZ_None: return 1;
 		default: abort();
 	}
 }
@@ -952,17 +726,243 @@ static inline int32_t LDKSocketAddressParseError_to_cs(LDKSocketAddressParseErro
 		default: abort();
 	}
 }
-static inline LDKUtxoLookupError LDKUtxoLookupError_from_cs(int32_t ord) {
+static inline LDKInboundHTLCStateDetails LDKInboundHTLCStateDetails_from_cs(int32_t ord) {
 	switch (ord) {
-		case 0: return LDKUtxoLookupError_UnknownChain;
-		case 1: return LDKUtxoLookupError_UnknownTx;
+		case 0: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToAdd;
+		case 1: return LDKInboundHTLCStateDetails_Committed;
+		case 2: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFulfill;
+		case 3: return LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFail;
 		default: abort();
 	}
 }
-static inline int32_t LDKUtxoLookupError_to_cs(LDKUtxoLookupError val) {
+static inline int32_t LDKInboundHTLCStateDetails_to_cs(LDKInboundHTLCStateDetails val) {
 	switch (val) {
-		case LDKUtxoLookupError_UnknownChain: return 0;
-		case LDKUtxoLookupError_UnknownTx: return 1;
+		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToAdd: return 0;
+		case LDKInboundHTLCStateDetails_Committed: return 1;
+		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFulfill: return 2;
+		case LDKInboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFail: return 3;
+		default: abort();
+	}
+}
+static inline LDKOutboundHTLCStateDetails LDKOutboundHTLCStateDetails_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToAdd;
+		case 1: return LDKOutboundHTLCStateDetails_Committed;
+		case 2: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveSuccess;
+		case 3: return LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFailure;
+		default: abort();
+	}
+}
+static inline int32_t LDKOutboundHTLCStateDetails_to_cs(LDKOutboundHTLCStateDetails val) {
+	switch (val) {
+		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToAdd: return 0;
+		case LDKOutboundHTLCStateDetails_Committed: return 1;
+		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveSuccess: return 2;
+		case LDKOutboundHTLCStateDetails_AwaitingRemoteRevokeToRemoveFailure: return 3;
+		default: abort();
+	}
+}
+static inline LDKChannelShutdownState LDKChannelShutdownState_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKChannelShutdownState_NotShuttingDown;
+		case 1: return LDKChannelShutdownState_ShutdownInitiated;
+		case 2: return LDKChannelShutdownState_ResolvingHTLCs;
+		case 3: return LDKChannelShutdownState_NegotiatingClosingFee;
+		case 4: return LDKChannelShutdownState_ShutdownComplete;
+		default: abort();
+	}
+}
+static inline int32_t LDKChannelShutdownState_to_cs(LDKChannelShutdownState val) {
+	switch (val) {
+		case LDKChannelShutdownState_NotShuttingDown: return 0;
+		case LDKChannelShutdownState_ShutdownInitiated: return 1;
+		case LDKChannelShutdownState_ResolvingHTLCs: return 2;
+		case LDKChannelShutdownState_NegotiatingClosingFee: return 3;
+		case LDKChannelShutdownState_ShutdownComplete: return 4;
+		default: abort();
+	}
+}
+static inline LDKHTLCClaim LDKHTLCClaim_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKHTLCClaim_OfferedTimeout;
+		case 1: return LDKHTLCClaim_OfferedPreimage;
+		case 2: return LDKHTLCClaim_AcceptedTimeout;
+		case 3: return LDKHTLCClaim_AcceptedPreimage;
+		case 4: return LDKHTLCClaim_Revocation;
+		default: abort();
+	}
+}
+static inline int32_t LDKHTLCClaim_to_cs(LDKHTLCClaim val) {
+	switch (val) {
+		case LDKHTLCClaim_OfferedTimeout: return 0;
+		case LDKHTLCClaim_OfferedPreimage: return 1;
+		case LDKHTLCClaim_AcceptedTimeout: return 2;
+		case LDKHTLCClaim_AcceptedPreimage: return 3;
+		case LDKHTLCClaim_Revocation: return 4;
+		default: abort();
+	}
+}
+static inline LDKPaymentFailureReason LDKPaymentFailureReason_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKPaymentFailureReason_RecipientRejected;
+		case 1: return LDKPaymentFailureReason_UserAbandoned;
+		case 2: return LDKPaymentFailureReason_RetriesExhausted;
+		case 3: return LDKPaymentFailureReason_PaymentExpired;
+		case 4: return LDKPaymentFailureReason_RouteNotFound;
+		case 5: return LDKPaymentFailureReason_UnexpectedError;
+		case 6: return LDKPaymentFailureReason_UnknownRequiredFeatures;
+		case 7: return LDKPaymentFailureReason_InvoiceRequestExpired;
+		case 8: return LDKPaymentFailureReason_InvoiceRequestRejected;
+		case 9: return LDKPaymentFailureReason_BlindedPathCreationFailed;
+		default: abort();
+	}
+}
+static inline int32_t LDKPaymentFailureReason_to_cs(LDKPaymentFailureReason val) {
+	switch (val) {
+		case LDKPaymentFailureReason_RecipientRejected: return 0;
+		case LDKPaymentFailureReason_UserAbandoned: return 1;
+		case LDKPaymentFailureReason_RetriesExhausted: return 2;
+		case LDKPaymentFailureReason_PaymentExpired: return 3;
+		case LDKPaymentFailureReason_RouteNotFound: return 4;
+		case LDKPaymentFailureReason_UnexpectedError: return 5;
+		case LDKPaymentFailureReason_UnknownRequiredFeatures: return 6;
+		case LDKPaymentFailureReason_InvoiceRequestExpired: return 7;
+		case LDKPaymentFailureReason_InvoiceRequestRejected: return 8;
+		case LDKPaymentFailureReason_BlindedPathCreationFailed: return 9;
+		default: abort();
+	}
+}
+static inline LDKSiPrefix LDKSiPrefix_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKSiPrefix_Milli;
+		case 1: return LDKSiPrefix_Micro;
+		case 2: return LDKSiPrefix_Nano;
+		case 3: return LDKSiPrefix_Pico;
+		default: abort();
+	}
+}
+static inline int32_t LDKSiPrefix_to_cs(LDKSiPrefix val) {
+	switch (val) {
+		case LDKSiPrefix_Milli: return 0;
+		case LDKSiPrefix_Micro: return 1;
+		case LDKSiPrefix_Nano: return 2;
+		case LDKSiPrefix_Pico: return 3;
+		default: abort();
+	}
+}
+static inline LDKBolt11SemanticError LDKBolt11SemanticError_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKBolt11SemanticError_NoPaymentHash;
+		case 1: return LDKBolt11SemanticError_MultiplePaymentHashes;
+		case 2: return LDKBolt11SemanticError_NoDescription;
+		case 3: return LDKBolt11SemanticError_MultipleDescriptions;
+		case 4: return LDKBolt11SemanticError_NoPaymentSecret;
+		case 5: return LDKBolt11SemanticError_MultiplePaymentSecrets;
+		case 6: return LDKBolt11SemanticError_InvalidFeatures;
+		case 7: return LDKBolt11SemanticError_InvalidRecoveryId;
+		case 8: return LDKBolt11SemanticError_InvalidSignature;
+		case 9: return LDKBolt11SemanticError_ImpreciseAmount;
+		default: abort();
+	}
+}
+static inline int32_t LDKBolt11SemanticError_to_cs(LDKBolt11SemanticError val) {
+	switch (val) {
+		case LDKBolt11SemanticError_NoPaymentHash: return 0;
+		case LDKBolt11SemanticError_MultiplePaymentHashes: return 1;
+		case LDKBolt11SemanticError_NoDescription: return 2;
+		case LDKBolt11SemanticError_MultipleDescriptions: return 3;
+		case LDKBolt11SemanticError_NoPaymentSecret: return 4;
+		case LDKBolt11SemanticError_MultiplePaymentSecrets: return 5;
+		case LDKBolt11SemanticError_InvalidFeatures: return 6;
+		case LDKBolt11SemanticError_InvalidRecoveryId: return 7;
+		case LDKBolt11SemanticError_InvalidSignature: return 8;
+		case LDKBolt11SemanticError_ImpreciseAmount: return 9;
+		default: abort();
+	}
+}
+static inline LDKNetwork LDKNetwork_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKNetwork_Bitcoin;
+		case 1: return LDKNetwork_Testnet3;
+		case 2: return LDKNetwork_Testnet4;
+		case 3: return LDKNetwork_Regtest;
+		case 4: return LDKNetwork_Signet;
+		default: abort();
+	}
+}
+static inline int32_t LDKNetwork_to_cs(LDKNetwork val) {
+	switch (val) {
+		case LDKNetwork_Bitcoin: return 0;
+		case LDKNetwork_Testnet3: return 1;
+		case LDKNetwork_Testnet4: return 2;
+		case LDKNetwork_Regtest: return 3;
+		case LDKNetwork_Signet: return 4;
+		default: abort();
+	}
+}
+static inline LDKCurrency LDKCurrency_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKCurrency_Bitcoin;
+		case 1: return LDKCurrency_BitcoinTestnet;
+		case 2: return LDKCurrency_Regtest;
+		case 3: return LDKCurrency_Simnet;
+		case 4: return LDKCurrency_Signet;
+		default: abort();
+	}
+}
+static inline int32_t LDKCurrency_to_cs(LDKCurrency val) {
+	switch (val) {
+		case LDKCurrency_Bitcoin: return 0;
+		case LDKCurrency_BitcoinTestnet: return 1;
+		case LDKCurrency_Regtest: return 2;
+		case LDKCurrency_Simnet: return 3;
+		case LDKCurrency_Signet: return 4;
+		default: abort();
+	}
+}
+static inline LDKDirection LDKDirection_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKDirection_NodeOne;
+		case 1: return LDKDirection_NodeTwo;
+		default: abort();
+	}
+}
+static inline int32_t LDKDirection_to_cs(LDKDirection val) {
+	switch (val) {
+		case LDKDirection_NodeOne: return 0;
+		case LDKDirection_NodeTwo: return 1;
+		default: abort();
+	}
+}
+static inline LDKLSPS1OrderState LDKLSPS1OrderState_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKLSPS1OrderState_Created;
+		case 1: return LDKLSPS1OrderState_Completed;
+		case 2: return LDKLSPS1OrderState_Failed;
+		default: abort();
+	}
+}
+static inline int32_t LDKLSPS1OrderState_to_cs(LDKLSPS1OrderState val) {
+	switch (val) {
+		case LDKLSPS1OrderState_Created: return 0;
+		case LDKLSPS1OrderState_Completed: return 1;
+		case LDKLSPS1OrderState_Failed: return 2;
+		default: abort();
+	}
+}
+static inline LDKLSPS1PaymentState LDKLSPS1PaymentState_from_cs(int32_t ord) {
+	switch (ord) {
+		case 0: return LDKLSPS1PaymentState_ExpectPayment;
+		case 1: return LDKLSPS1PaymentState_Paid;
+		case 2: return LDKLSPS1PaymentState_Refunded;
+		default: abort();
+	}
+}
+static inline int32_t LDKLSPS1PaymentState_to_cs(LDKLSPS1PaymentState val) {
+	switch (val) {
+		case LDKLSPS1PaymentState_ExpectPayment: return 0;
+		case LDKLSPS1PaymentState_Paid: return 1;
+		case LDKLSPS1PaymentState_Refunded: return 2;
 		default: abort();
 	}
 }

--- a/c_sharp/src/org/ldk/structs/Bolt11Invoice.cs
+++ b/c_sharp/src/org/ldk/structs/Bolt11Invoice.cs
@@ -214,7 +214,10 @@ public class Bolt11Invoice : CommonBase {
 	}
 
 	/**
-	 * Recover the payee's public key (only to be used if none was included in the invoice)
+	 * Get the invoice's payee public key.
+	 * 
+	 * This uses the explicitly included payee public key, if present, otherwise it recovers the
+	 * payee public key from the signature. Prefer [`Self::get_payee_pub_key`] for clarity.
 	 */
 	public byte[] recover_payee_pub_key() {
 		long ret = bindings.Bolt11Invoice_recover_payee_pub_key(this.ptr);
@@ -225,8 +228,8 @@ public class Bolt11Invoice : CommonBase {
 	}
 
 	/**
-	 * Recover the payee's public key if one was included in the invoice, otherwise return the
-	 * recovered public key from the signature
+	 * Get the invoice's payee public key, preferring an explicitly included payee public key and
+	 * falling back to recovering the key from the signature.
 	 */
 	public byte[] get_payee_pub_key() {
 		long ret = bindings.Bolt11Invoice_get_payee_pub_key(this.ptr);

--- a/c_sharp/src/org/ldk/structs/ChannelManager.cs
+++ b/c_sharp/src/org/ldk/structs/ChannelManager.cs
@@ -723,7 +723,7 @@ namespace org { namespace ldk { namespace structs {
  * [`get_event_or_persistence_needed_future`]: Self::get_event_or_persistence_needed_future
  * [`lightning-block-sync`]: https://docs.rs/lightning_block_sync/latest/lightning_block_sync
  * [`lightning-transaction-sync`]: https://docs.rs/lightning_transaction_sync/latest/lightning_transaction_sync
- * [`lightning-background-processor`]: https://docs.rs/lightning_background_processor/lightning_background_processor
+ * [`lightning-background-processor`]: https://docs.rs/lightning-background-processor/latest/lightning_background_processor
  * [`list_channels`]: Self::list_channels
  * [`list_usable_channels`]: Self::list_usable_channels
  * [`create_channel`]: Self::create_channel
@@ -1014,7 +1014,7 @@ public class ChannelManager : CommonBase {
 	 * 
 	 * The `shutdown_script` provided  will be used as the `scriptPubKey` for the closing transaction.
 	 * Will fail if a shutdown script has already been set for this channel by
-	 * ['ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]. The given shutdown script must
+	 * [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]. The given shutdown script must
 	 * also be compatible with our and the counterparty's features.
 	 * 
 	 * May generate a [`SendShutdown`] message event on success, which should be relayed.
@@ -1026,6 +1026,7 @@ public class ChannelManager : CommonBase {
 	 * 
 	 * [`ChannelConfig::force_close_avoidance_max_fee_satoshis`]: crate::util::config::ChannelConfig::force_close_avoidance_max_fee_satoshis
 	 * [`NonAnchorChannelFee`]: crate::chain::chaininterface::ConfirmationTarget::NonAnchorChannelFee
+	 * [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]: crate::util::config::ChannelHandshakeConfig::commit_upfront_shutdown_pubkey
 	 * [`SendShutdown`]: crate::events::MessageSendEvent::SendShutdown
 	 * 
 	 * Note that shutdown_script (or a relevant inner pointer) may be NULL or all-0s to represent None
@@ -2011,7 +2012,7 @@ public class ChannelManager : CommonBase {
 
 	/**
 	 * Pays for an [`Offer`] looked up using [BIP 353] Human Readable Names resolved by the DNS
-	 * resolver(s) at `dns_resolvers` which resolve names according to bLIP 32.
+	 * resolver(s) at `dns_resolvers` which resolve names according to [bLIP 32].
 	 * 
 	 * If the wallet supports paying on-chain schemes, you should instead use
 	 * [`OMNameResolver::resolve_name`] and [`OMNameResolver::handle_dnssec_proof_for_uri`] (by
@@ -2029,18 +2030,19 @@ public class ChannelManager : CommonBase {
 	 * 
 	 * To revoke the request, use [`ChannelManager::abandon_payment`] prior to receiving the
 	 * invoice. If abandoned, or an invoice isn't received in a reasonable amount of time, the
-	 * payment will fail with an [`Event::InvoiceRequestFailed`].
+	 * payment will fail with an [`PaymentFailureReason::UserAbandoned`] or
+	 * [`PaymentFailureReason::InvoiceRequestExpired`], respectively.
 	 * 
 	 * # Privacy
 	 * 
 	 * For payer privacy, uses a derived payer id and uses [`MessageRouter::create_blinded_paths`]
-	 * to construct a [`BlindedPath`] for the reply path. For further privacy implications, see the
+	 * to construct a [`BlindedMessagePath`] for the reply path. For further privacy implications, see the
 	 * docs of the parameterized [`Router`], which implements [`MessageRouter`].
 	 * 
 	 * # Limitations
 	 * 
 	 * Requires a direct connection to the given [`Destination`] as well as an introduction node in
-	 * [`Offer::paths`] or to [`Offer::signing_pubkey`], if empty. A similar restriction applies to
+	 * [`Offer::paths`] or to [`Offer::issuer_signing_pubkey`], if empty. A similar restriction applies to
 	 * the responding [`Bolt12Invoice::payment_paths`].
 	 * 
 	 * # Errors
@@ -2048,8 +2050,13 @@ public class ChannelManager : CommonBase {
 	 * Errors if:
 	 * - a duplicate `payment_id` is provided given the caveats in the aforementioned link,
 	 * 
+	 * [BIP 353]: https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki
+	 * [bLIP 32]: https://github.com/lightning/blips/blob/master/blip-0032.md
 	 * [`Bolt12Invoice::payment_paths`]: crate::offers::invoice::Bolt12Invoice::payment_paths
 	 * [Avoiding Duplicate Payments]: #avoiding-duplicate-payments
+	 * [`BlindedMessagePath`]: crate::blinded_path::message::BlindedMessagePath
+	 * [`PaymentFailureReason::UserAbandoned`]: crate::events::PaymentFailureReason::UserAbandoned
+	 * [`PaymentFailureReason::InvoiceRequestRejected`]: crate::events::PaymentFailureReason::InvoiceRequestRejected
 	 */
 	public org.ldk.structs.Result_NoneNoneZ pay_for_offer_from_human_readable_name(org.ldk.structs.HumanReadableName name, long amount_msats, byte[] payment_id, org.ldk.structs.Retry retry_strategy, org.ldk.structs.Option_u64Z max_total_routing_fee_msat, Destination[] dns_resolvers) {
 		long ret = bindings.ChannelManager_pay_for_offer_from_human_readable_name(this.ptr, name.ptr, amount_msats, InternalUtils.encodeUint8Array(InternalUtils.check_arr_len(payment_id, 32)), retry_strategy.ptr, max_total_routing_fee_msat.ptr, InternalUtils.encodeUint64Array(InternalUtils.mapArray(dns_resolvers, dns_resolvers_conv_13 => dns_resolvers_conv_13.ptr)));

--- a/c_sharp/src/org/ldk/structs/Event.cs
+++ b/c_sharp/src/org/ldk/structs/Event.cs
@@ -465,7 +465,8 @@ public class Event : CommonBase {
 		 * If the recipient or an intermediate node misbehaves and gives us free money, this may
 		 * overstate the amount paid, though this is unlikely.
 		 * 
-		 * This is only `None` for payments initiated on LDK versions prior to 0.0.103.
+		 * This is only `None` for payments abandoned but ultimately claimed when using LDK versions
+		 * prior to 0.3, 0.2.3, or 0.1.10.
 		 * 
 		 * [`Route::get_total_fees`]: crate::routing::router::Route::get_total_fees
 		 */

--- a/c_sharp/src/org/ldk/structs/PeerManager.cs
+++ b/c_sharp/src/org/ldk/structs/PeerManager.cs
@@ -233,6 +233,8 @@ public class PeerManager : CommonBase {
 	 * [`send_payment`]: crate::ln::channelmanager::ChannelManager::send_payment
 	 * [`ChannelManager::process_pending_htlc_forwards`]: crate::ln::channelmanager::ChannelManager::process_pending_htlc_forwards
 	 * [`send_data`]: SocketDescriptor::send_data
+	 * [`lightning-net-tokio`]: https://docs.rs/lightning-net-tokio/latest/lightning_net_tokio
+	 * [`lightning-background-processor`]: https://docs.rs/lightning-background-processor/latest/lightning_background_processor
 	 */
 	public void process_events() {
 		bindings.PeerManager_process_events(this.ptr);

--- a/c_sharp/src/org/ldk/structs/RapidGossipSync.cs
+++ b/c_sharp/src/org/ldk/structs/RapidGossipSync.cs
@@ -38,6 +38,10 @@ public class RapidGossipSync : CommonBase {
 	 * Sync gossip data from a file.
 	 * Returns the last sync timestamp to be used the next time rapid sync data is queried.
 	 * 
+	 * You should consider the gossip data source as semi-trusted. It is generally the case that it
+	 * can DoS the client either by omitting data which leads to pathfinding failure or by bloating
+	 * the graph such that it leads to eventual OOM on the client.
+	 * 
 	 * `network_graph`: The network graph to apply the updates to
 	 * 
 	 * `sync_path`: Path to the file where the gossip update data is located
@@ -55,6 +59,10 @@ public class RapidGossipSync : CommonBase {
 	 * Update network graph from binary data.
 	 * Returns the last sync timestamp to be used the next time rapid sync data is queried.
 	 * 
+	 * You should consider the gossip data source as semi-trusted. It is generally the case that it
+	 * can DoS the client either by omitting data which leads to pathfinding failure or by bloating
+	 * the graph such that it leads to eventual OOM on the client.
+	 * 
 	 * `update_data`: `&[u8]` binary stream that comprises the update data
 	 */
 	public org.ldk.structs.Result_u32GraphSyncErrorZ update_network_graph(byte[] update_data) {
@@ -69,6 +77,10 @@ public class RapidGossipSync : CommonBase {
 	/**
 	 * Update network graph from binary data.
 	 * Returns the last sync timestamp to be used the next time rapid sync data is queried.
+	 * 
+	 * You should consider the gossip data source as semi-trusted. It is generally the case that it
+	 * can DoS the client either by omitting data which leads to pathfinding failure or by bloating
+	 * the graph such that it leads to eventual OOM on the client.
 	 * 
 	 * `update_data`: `&[u8]` binary stream that comprises the update data
 	 * `current_time_unix`: `Option<u64>` optional current timestamp to verify data age

--- a/c_sharp/src/org/ldk/structs/UtilMethods.cs
+++ b/c_sharp/src/org/ldk/structs/UtilMethods.cs
@@ -30,7 +30,7 @@ public class UtilMethods {
 	}
 
 	/**
-	 * Constructs a new COption_NoneZ containing a
+	 * Constructs a new COption_NoneZ containing a 
 	 */
 	public static COption_NoneZ COption_NoneZ_some() {
 		COption_NoneZ ret = bindings.COption_NoneZ_some();

--- a/src/main/java/org/ldk/structs/Bolt11Invoice.java
+++ b/src/main/java/org/ldk/structs/Bolt11Invoice.java
@@ -213,7 +213,10 @@ public class Bolt11Invoice extends CommonBase {
 	}
 
 	/**
-	 * Recover the payee's public key (only to be used if none was included in the invoice)
+	 * Get the invoice's payee public key.
+	 * 
+	 * This uses the explicitly included payee public key, if present, otherwise it recovers the
+	 * payee public key from the signature. Prefer [`Self::get_payee_pub_key`] for clarity.
 	 */
 	public byte[] recover_payee_pub_key() {
 		byte[] ret = bindings.Bolt11Invoice_recover_payee_pub_key(this.ptr);
@@ -222,8 +225,8 @@ public class Bolt11Invoice extends CommonBase {
 	}
 
 	/**
-	 * Recover the payee's public key if one was included in the invoice, otherwise return the
-	 * recovered public key from the signature
+	 * Get the invoice's payee public key, preferring an explicitly included payee public key and
+	 * falling back to recovering the key from the signature.
 	 */
 	public byte[] get_payee_pub_key() {
 		byte[] ret = bindings.Bolt11Invoice_get_payee_pub_key(this.ptr);

--- a/src/main/java/org/ldk/structs/ChannelManager.java
+++ b/src/main/java/org/ldk/structs/ChannelManager.java
@@ -725,7 +725,7 @@ import javax.annotation.Nullable;
  * [`get_event_or_persistence_needed_future`]: Self::get_event_or_persistence_needed_future
  * [`lightning-block-sync`]: https://docs.rs/lightning_block_sync/latest/lightning_block_sync
  * [`lightning-transaction-sync`]: https://docs.rs/lightning_transaction_sync/latest/lightning_transaction_sync
- * [`lightning-background-processor`]: https://docs.rs/lightning_background_processor/lightning_background_processor
+ * [`lightning-background-processor`]: https://docs.rs/lightning-background-processor/latest/lightning_background_processor
  * [`list_channels`]: Self::list_channels
  * [`list_usable_channels`]: Self::list_usable_channels
  * [`create_channel`]: Self::create_channel
@@ -1011,7 +1011,7 @@ public class ChannelManager extends CommonBase {
 	 * 
 	 * The `shutdown_script` provided  will be used as the `scriptPubKey` for the closing transaction.
 	 * Will fail if a shutdown script has already been set for this channel by
-	 * ['ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]. The given shutdown script must
+	 * [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]. The given shutdown script must
 	 * also be compatible with our and the counterparty's features.
 	 * 
 	 * May generate a [`SendShutdown`] message event on success, which should be relayed.
@@ -1023,6 +1023,7 @@ public class ChannelManager extends CommonBase {
 	 * 
 	 * [`ChannelConfig::force_close_avoidance_max_fee_satoshis`]: crate::util::config::ChannelConfig::force_close_avoidance_max_fee_satoshis
 	 * [`NonAnchorChannelFee`]: crate::chain::chaininterface::ConfirmationTarget::NonAnchorChannelFee
+	 * [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]: crate::util::config::ChannelHandshakeConfig::commit_upfront_shutdown_pubkey
 	 * [`SendShutdown`]: crate::events::MessageSendEvent::SendShutdown
 	 * 
 	 * Note that shutdown_script (or a relevant inner pointer) may be NULL or all-0s to represent None
@@ -2006,7 +2007,7 @@ public class ChannelManager extends CommonBase {
 
 	/**
 	 * Pays for an [`Offer`] looked up using [BIP 353] Human Readable Names resolved by the DNS
-	 * resolver(s) at `dns_resolvers` which resolve names according to bLIP 32.
+	 * resolver(s) at `dns_resolvers` which resolve names according to [bLIP 32].
 	 * 
 	 * If the wallet supports paying on-chain schemes, you should instead use
 	 * [`OMNameResolver::resolve_name`] and [`OMNameResolver::handle_dnssec_proof_for_uri`] (by
@@ -2024,18 +2025,19 @@ public class ChannelManager extends CommonBase {
 	 * 
 	 * To revoke the request, use [`ChannelManager::abandon_payment`] prior to receiving the
 	 * invoice. If abandoned, or an invoice isn't received in a reasonable amount of time, the
-	 * payment will fail with an [`Event::InvoiceRequestFailed`].
+	 * payment will fail with an [`PaymentFailureReason::UserAbandoned`] or
+	 * [`PaymentFailureReason::InvoiceRequestExpired`], respectively.
 	 * 
 	 * # Privacy
 	 * 
 	 * For payer privacy, uses a derived payer id and uses [`MessageRouter::create_blinded_paths`]
-	 * to construct a [`BlindedPath`] for the reply path. For further privacy implications, see the
+	 * to construct a [`BlindedMessagePath`] for the reply path. For further privacy implications, see the
 	 * docs of the parameterized [`Router`], which implements [`MessageRouter`].
 	 * 
 	 * # Limitations
 	 * 
 	 * Requires a direct connection to the given [`Destination`] as well as an introduction node in
-	 * [`Offer::paths`] or to [`Offer::signing_pubkey`], if empty. A similar restriction applies to
+	 * [`Offer::paths`] or to [`Offer::issuer_signing_pubkey`], if empty. A similar restriction applies to
 	 * the responding [`Bolt12Invoice::payment_paths`].
 	 * 
 	 * # Errors
@@ -2043,8 +2045,13 @@ public class ChannelManager extends CommonBase {
 	 * Errors if:
 	 * - a duplicate `payment_id` is provided given the caveats in the aforementioned link,
 	 * 
+	 * [BIP 353]: https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki
+	 * [bLIP 32]: https://github.com/lightning/blips/blob/master/blip-0032.md
 	 * [`Bolt12Invoice::payment_paths`]: crate::offers::invoice::Bolt12Invoice::payment_paths
 	 * [Avoiding Duplicate Payments]: #avoiding-duplicate-payments
+	 * [`BlindedMessagePath`]: crate::blinded_path::message::BlindedMessagePath
+	 * [`PaymentFailureReason::UserAbandoned`]: crate::events::PaymentFailureReason::UserAbandoned
+	 * [`PaymentFailureReason::InvoiceRequestRejected`]: crate::events::PaymentFailureReason::InvoiceRequestRejected
 	 */
 	public Result_NoneNoneZ pay_for_offer_from_human_readable_name(org.ldk.structs.HumanReadableName name, long amount_msats, byte[] payment_id, org.ldk.structs.Retry retry_strategy, org.ldk.structs.Option_u64Z max_total_routing_fee_msat, Destination[] dns_resolvers) {
 		long ret = bindings.ChannelManager_pay_for_offer_from_human_readable_name(this.ptr, name.ptr, amount_msats, InternalUtils.check_arr_len(payment_id, 32), retry_strategy.ptr, max_total_routing_fee_msat.ptr, dns_resolvers != null ? Arrays.stream(dns_resolvers).mapToLong(dns_resolvers_conv_13 -> dns_resolvers_conv_13.ptr).toArray() : null);

--- a/src/main/java/org/ldk/structs/Event.java
+++ b/src/main/java/org/ldk/structs/Event.java
@@ -632,7 +632,8 @@ public class Event extends CommonBase {
 		 * If the recipient or an intermediate node misbehaves and gives us free money, this may
 		 * overstate the amount paid, though this is unlikely.
 		 * 
-		 * This is only `None` for payments initiated on LDK versions prior to 0.0.103.
+		 * This is only `None` for payments abandoned but ultimately claimed when using LDK versions
+		 * prior to 0.3, 0.2.3, or 0.1.10.
 		 * 
 		 * [`Route::get_total_fees`]: crate::routing::router::Route::get_total_fees
 		*/
@@ -1438,7 +1439,7 @@ public class Event extends CommonBase {
 	 * To accept the request (and in the case of a dual-funded channel, not contribute funds),
 	 * call [`ChannelManager::accept_inbound_channel`].
 	 * To reject the request, call [`ChannelManager::force_close_without_broadcasting_txn`].
-	 * Note that a ['ChannelClosed`] event will _not_ be triggered if the channel is rejected.
+	 * Note that a [`ChannelClosed`] event will _not_ be triggered if the channel is rejected.
 	 * 
 	 * The event is only triggered when a new open channel request is received and the
 	 * [`UserConfig::manually_accept_inbound_channels`] config flag is set to true.
@@ -1448,6 +1449,7 @@ public class Event extends CommonBase {
 	 * returning `Err(ReplayEvent ())`) and won't be persisted across restarts.
 	 * 
 	 * [`ChannelManager::accept_inbound_channel`]: crate::ln::channelmanager::ChannelManager::accept_inbound_channel
+	 * [`ChannelClosed`]: Event::ChannelClosed
 	 * [`ChannelManager::force_close_without_broadcasting_txn`]: crate::ln::channelmanager::ChannelManager::force_close_without_broadcasting_txn
 	 * [`UserConfig::manually_accept_inbound_channels`]: crate::util::config::UserConfig::manually_accept_inbound_channels
 	 */

--- a/src/main/java/org/ldk/structs/PeerManager.java
+++ b/src/main/java/org/ldk/structs/PeerManager.java
@@ -237,6 +237,8 @@ public class PeerManager extends CommonBase {
 	 * [`send_payment`]: crate::ln::channelmanager::ChannelManager::send_payment
 	 * [`ChannelManager::process_pending_htlc_forwards`]: crate::ln::channelmanager::ChannelManager::process_pending_htlc_forwards
 	 * [`send_data`]: SocketDescriptor::send_data
+	 * [`lightning-net-tokio`]: https://docs.rs/lightning-net-tokio/latest/lightning_net_tokio
+	 * [`lightning-background-processor`]: https://docs.rs/lightning-background-processor/latest/lightning_background_processor
 	 */
 	public void process_events() {
 		bindings.PeerManager_process_events(this.ptr);

--- a/src/main/java/org/ldk/structs/RapidGossipSync.java
+++ b/src/main/java/org/ldk/structs/RapidGossipSync.java
@@ -43,6 +43,10 @@ public class RapidGossipSync extends CommonBase {
 	 * Sync gossip data from a file.
 	 * Returns the last sync timestamp to be used the next time rapid sync data is queried.
 	 * 
+	 * You should consider the gossip data source as semi-trusted. It is generally the case that it
+	 * can DoS the client either by omitting data which leads to pathfinding failure or by bloating
+	 * the graph such that it leads to eventual OOM on the client.
+	 * 
 	 * `network_graph`: The network graph to apply the updates to
 	 * 
 	 * `sync_path`: Path to the file where the gossip update data is located
@@ -60,6 +64,10 @@ public class RapidGossipSync extends CommonBase {
 	 * Update network graph from binary data.
 	 * Returns the last sync timestamp to be used the next time rapid sync data is queried.
 	 * 
+	 * You should consider the gossip data source as semi-trusted. It is generally the case that it
+	 * can DoS the client either by omitting data which leads to pathfinding failure or by bloating
+	 * the graph such that it leads to eventual OOM on the client.
+	 * 
 	 * `update_data`: `&[u8]` binary stream that comprises the update data
 	 */
 	public Result_u32GraphSyncErrorZ update_network_graph(byte[] update_data) {
@@ -74,6 +82,10 @@ public class RapidGossipSync extends CommonBase {
 	/**
 	 * Update network graph from binary data.
 	 * Returns the last sync timestamp to be used the next time rapid sync data is queried.
+	 * 
+	 * You should consider the gossip data source as semi-trusted. It is generally the case that it
+	 * can DoS the client either by omitting data which leads to pathfinding failure or by bloating
+	 * the graph such that it leads to eventual OOM on the client.
 	 * 
 	 * `update_data`: `&[u8]` binary stream that comprises the update data
 	 * `current_time_unix`: `Option<u64>` optional current timestamp to verify data age

--- a/src/main/jni/bindings.c.body
+++ b/src/main/jni/bindings.c.body
@@ -1354,8 +1354,10 @@ JNIEXPORT void JNICALL Java_org_ldk_enums_Network_init (JNIEnv *env, jclass clz)
 	CHECK(Network_class != NULL);
 	Network_LDKNetwork_Bitcoin = (*env)->GetStaticFieldID(env, Network_class, "LDKNetwork_Bitcoin", "Lorg/ldk/enums/Network;");
 	CHECK(Network_LDKNetwork_Bitcoin != NULL);
-	Network_LDKNetwork_Testnet = (*env)->GetStaticFieldID(env, Network_class, "LDKNetwork_Testnet", "Lorg/ldk/enums/Network;");
-	CHECK(Network_LDKNetwork_Testnet != NULL);
+	Network_LDKNetwork_Testnet3 = (*env)->GetStaticFieldID(env, Network_class, "LDKNetwork_Testnet3", "Lorg/ldk/enums/Network;");
+	CHECK(Network_LDKNetwork_Testnet3 != NULL);
+	Network_LDKNetwork_Testnet4 = (*env)->GetStaticFieldID(env, Network_class, "LDKNetwork_Testnet4", "Lorg/ldk/enums/Network;");
+	CHECK(Network_LDKNetwork_Testnet4 != NULL);
 	Network_LDKNetwork_Regtest = (*env)->GetStaticFieldID(env, Network_class, "LDKNetwork_Regtest", "Lorg/ldk/enums/Network;");
 	CHECK(Network_LDKNetwork_Regtest != NULL);
 	Network_LDKNetwork_Signet = (*env)->GetStaticFieldID(env, Network_class, "LDKNetwork_Signet", "Lorg/ldk/enums/Network;");

--- a/ts/structs/Bolt11Invoice.mts
+++ b/ts/structs/Bolt11Invoice.mts
@@ -965,7 +965,10 @@ export class Bolt11Invoice extends CommonBase {
 	}
 
 	/**
-	 * Recover the payee's public key (only to be used if none was included in the invoice)
+	 * Get the invoice's payee public key.
+	 * 
+	 * This uses the explicitly included payee public key, if present, otherwise it recovers the
+	 * payee public key from the signature. Prefer [`Self::get_payee_pub_key`] for clarity.
 	 */
 	public recover_payee_pub_key(): Uint8Array {
 		const ret: number = bindings.Bolt11Invoice_recover_payee_pub_key(this.ptr);
@@ -974,8 +977,8 @@ export class Bolt11Invoice extends CommonBase {
 	}
 
 	/**
-	 * Recover the payee's public key if one was included in the invoice, otherwise return the
-	 * recovered public key from the signature
+	 * Get the invoice's payee public key, preferring an explicitly included payee public key and
+	 * falling back to recovering the key from the signature.
 	 */
 	public get_payee_pub_key(): Uint8Array {
 		const ret: number = bindings.Bolt11Invoice_get_payee_pub_key(this.ptr);

--- a/ts/structs/ChannelManager.mts
+++ b/ts/structs/ChannelManager.mts
@@ -1516,7 +1516,7 @@ import * as bindings from '../bindings.mjs'
  * [`get_event_or_persistence_needed_future`]: Self::get_event_or_persistence_needed_future
  * [`lightning-block-sync`]: https://docs.rs/lightning_block_sync/latest/lightning_block_sync
  * [`lightning-transaction-sync`]: https://docs.rs/lightning_transaction_sync/latest/lightning_transaction_sync
- * [`lightning-background-processor`]: https://docs.rs/lightning_background_processor/lightning_background_processor
+ * [`lightning-background-processor`]: https://docs.rs/lightning-background-processor/latest/lightning_background_processor
  * [`list_channels`]: Self::list_channels
  * [`list_usable_channels`]: Self::list_usable_channels
  * [`create_channel`]: Self::create_channel
@@ -1771,7 +1771,7 @@ export class ChannelManager extends CommonBase {
 	 * 
 	 * The `shutdown_script` provided  will be used as the `scriptPubKey` for the closing transaction.
 	 * Will fail if a shutdown script has already been set for this channel by
-	 * ['ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]. The given shutdown script must
+	 * [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]. The given shutdown script must
 	 * also be compatible with our and the counterparty's features.
 	 * 
 	 * May generate a [`SendShutdown`] message event on success, which should be relayed.
@@ -1783,6 +1783,7 @@ export class ChannelManager extends CommonBase {
 	 * 
 	 * [`ChannelConfig::force_close_avoidance_max_fee_satoshis`]: crate::util::config::ChannelConfig::force_close_avoidance_max_fee_satoshis
 	 * [`NonAnchorChannelFee`]: crate::chain::chaininterface::ConfirmationTarget::NonAnchorChannelFee
+	 * [`ChannelHandshakeConfig::commit_upfront_shutdown_pubkey`]: crate::util::config::ChannelHandshakeConfig::commit_upfront_shutdown_pubkey
 	 * [`SendShutdown`]: crate::events::MessageSendEvent::SendShutdown
 	 * 
 	 * Note that shutdown_script (or a relevant inner pointer) may be NULL or all-0s to represent None
@@ -2622,7 +2623,7 @@ export class ChannelManager extends CommonBase {
 
 	/**
 	 * Pays for an [`Offer`] looked up using [BIP 353] Human Readable Names resolved by the DNS
-	 * resolver(s) at `dns_resolvers` which resolve names according to bLIP 32.
+	 * resolver(s) at `dns_resolvers` which resolve names according to [bLIP 32].
 	 * 
 	 * If the wallet supports paying on-chain schemes, you should instead use
 	 * [`OMNameResolver::resolve_name`] and [`OMNameResolver::handle_dnssec_proof_for_uri`] (by
@@ -2640,18 +2641,19 @@ export class ChannelManager extends CommonBase {
 	 * 
 	 * To revoke the request, use [`ChannelManager::abandon_payment`] prior to receiving the
 	 * invoice. If abandoned, or an invoice isn't received in a reasonable amount of time, the
-	 * payment will fail with an [`Event::InvoiceRequestFailed`].
+	 * payment will fail with an [`PaymentFailureReason::UserAbandoned`] or
+	 * [`PaymentFailureReason::InvoiceRequestExpired`], respectively.
 	 * 
 	 * # Privacy
 	 * 
 	 * For payer privacy, uses a derived payer id and uses [`MessageRouter::create_blinded_paths`]
-	 * to construct a [`BlindedPath`] for the reply path. For further privacy implications, see the
+	 * to construct a [`BlindedMessagePath`] for the reply path. For further privacy implications, see the
 	 * docs of the parameterized [`Router`], which implements [`MessageRouter`].
 	 * 
 	 * # Limitations
 	 * 
 	 * Requires a direct connection to the given [`Destination`] as well as an introduction node in
-	 * [`Offer::paths`] or to [`Offer::signing_pubkey`], if empty. A similar restriction applies to
+	 * [`Offer::paths`] or to [`Offer::issuer_signing_pubkey`], if empty. A similar restriction applies to
 	 * the responding [`Bolt12Invoice::payment_paths`].
 	 * 
 	 * # Errors
@@ -2659,8 +2661,13 @@ export class ChannelManager extends CommonBase {
 	 * Errors if:
 	 * - a duplicate `payment_id` is provided given the caveats in the aforementioned link,
 	 * 
+	 * [BIP 353]: https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki
+	 * [bLIP 32]: https://github.com/lightning/blips/blob/master/blip-0032.md
 	 * [`Bolt12Invoice::payment_paths`]: crate::offers::invoice::Bolt12Invoice::payment_paths
 	 * [Avoiding Duplicate Payments]: #avoiding-duplicate-payments
+	 * [`BlindedMessagePath`]: crate::blinded_path::message::BlindedMessagePath
+	 * [`PaymentFailureReason::UserAbandoned`]: crate::events::PaymentFailureReason::UserAbandoned
+	 * [`PaymentFailureReason::InvoiceRequestRejected`]: crate::events::PaymentFailureReason::InvoiceRequestRejected
 	 */
 	public pay_for_offer_from_human_readable_name(name: HumanReadableName, amount_msats: bigint, payment_id: Uint8Array, retry_strategy: Retry, max_total_routing_fee_msat: Option_u64Z, dns_resolvers: Destination[]): Result_NoneNoneZ {
 		const ret: bigint = bindings.ChannelManager_pay_for_offer_from_human_readable_name(this.ptr, CommonBase.get_ptr_of(name), amount_msats, bindings.encodeUint8Array(payment_id), CommonBase.get_ptr_of(retry_strategy), CommonBase.get_ptr_of(max_total_routing_fee_msat), bindings.encodeUint64Array(dns_resolvers.map(dns_resolvers_conv_13 => CommonBase.get_ptr_of(dns_resolvers_conv_13))));

--- a/ts/structs/Event.mts
+++ b/ts/structs/Event.mts
@@ -1549,7 +1549,8 @@ export class Event_PaymentSent extends Event {
 	 * If the recipient or an intermediate node misbehaves and gives us free money, this may
 	 * overstate the amount paid, though this is unlikely.
 	 * 
-	 * This is only `None` for payments initiated on LDK versions prior to 0.0.103.
+	 * This is only `None` for payments abandoned but ultimately claimed when using LDK versions
+	 * prior to 0.3, 0.2.3, or 0.1.10.
 	 * 
 	 * [`Route::get_total_fees`]: crate::routing::router::Route::get_total_fees
 	 */

--- a/ts/structs/PeerManager.mts
+++ b/ts/structs/PeerManager.mts
@@ -996,6 +996,8 @@ export class PeerManager extends CommonBase {
 	 * [`send_payment`]: crate::ln::channelmanager::ChannelManager::send_payment
 	 * [`ChannelManager::process_pending_htlc_forwards`]: crate::ln::channelmanager::ChannelManager::process_pending_htlc_forwards
 	 * [`send_data`]: SocketDescriptor::send_data
+	 * [`lightning-net-tokio`]: https://docs.rs/lightning-net-tokio/latest/lightning_net_tokio
+	 * [`lightning-background-processor`]: https://docs.rs/lightning-background-processor/latest/lightning_background_processor
 	 */
 	public process_events(): void {
 		bindings.PeerManager_process_events(this.ptr);

--- a/ts/structs/RapidGossipSync.mts
+++ b/ts/structs/RapidGossipSync.mts
@@ -828,6 +828,10 @@ export class RapidGossipSync extends CommonBase {
 	 * Update network graph from binary data.
 	 * Returns the last sync timestamp to be used the next time rapid sync data is queried.
 	 * 
+	 * You should consider the gossip data source as semi-trusted. It is generally the case that it
+	 * can DoS the client either by omitting data which leads to pathfinding failure or by bloating
+	 * the graph such that it leads to eventual OOM on the client.
+	 * 
 	 * `update_data`: `&[u8]` binary stream that comprises the update data
 	 * `current_time_unix`: `Option<u64>` optional current timestamp to verify data age
 	 */


### PR DESCRIPTION
CI on `main` (and PRs such as #183) is currently red for reasons unrelated to the changes under test. This PR fixes the failures that are fixable from outside the project:

**1. MSRV breakage building `c-bindings-gen` (`java_bindings`, `java_determinism`, `wasm_bindings`, `c_sharp_bindings`, `macos_determinism`)**

`unicode-ident 1.0.23+` requires rustc 1.71, but the jobs intentionally build with Debian Bookworm's rustc 1.63. The existing `proc-macro2`/`quote` pin blocks now also pin `unicode-ident 1.0.22` (MSRV 1.31), and the pin block is added to the jobs that had none (`wasm_bindings`, `c_sharp_bindings`, `macos_determinism`, `android`), which failed on floating `proc-macro2 1.0.107`/`unicode-ident 1.0.24`.

**2. Retired `macos-13` runner image (`osx_java`, `osx_c_sharp`)**

GitHub retired the `macos-13` image; those matrix jobs queue until the run is cancelled. Dropped from both matrices, leaving `macos-14`.

**3. `c_sharp_determinism`: checked-in generated C# sources have drifted**

The tip of the `ldk-c-bindings` `0.1` branch now generates slightly different output (doc-comment updates and enum conversion helpers moving between `bindings.c` and `bindings.c.body`) than what is checked in, failing the "Check latest auto-generated code is in git" step. The second commit is byte-for-byte the diff CI printed when regenerating — no hand-written changes.

**Known remaining failures that only maintainers can fix**

`osx_java`, `osx_c_sharp`, `android`, and the late steps of the determinism jobs fetch deterministic binaries from `git.bitcoin.ninja` for `$(git describe --tag HEAD)` (currently `v0.1.3.0-6-g125b0977`), which 404s because bins for the current HEAD have not been published. Those jobs will stay red on every non-released commit until new bins are uploaded.

Splitting this out of #183 so that PR can be judged on its own diff.